### PR TITLE
Fixed typo in python utf-8 encoding snippet

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -68,7 +68,7 @@ snippet for
 	for ${1:item} in ${2:items}
 		${3:code...}
 # Encodes
-snippet cuft8
+snippet cutf8
 	# -*- coding: utf-8 -*-
 snippet clatin1
 	# -*- coding: latin-1 -*-


### PR DESCRIPTION
There was a typo in the uft-8 encoding snippet for python.
I fixed it.
