### PR TITLE
Some clipboard yanking markdown snippets, some [id]: snippets, and setext header underlining

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -2,6 +2,29 @@
 
 snippet [
 	[${1:text}](http://${2:address} "${3:title}")
+snippet [*
+	[${1:link}](${2:`@*`} "${3:title}")${4}
+
+snippet [:
+	[${1:id}]: http://${2:url} "${3:title}"
+snippet [:*
+	[${1:id}]: ${2:`@*`} "${3:title}"
+
 snippet ![
 	![${1:alttext}](${2:/images/image.jpg} "${3:title}")
+snippet ![*
+	![${1:alt}](${2:`@*`} "${3:title}")${4}
 
+snippet ![:
+	![${1:id}]: ${2:url} "${3:title}"
+snippet ![:*
+	![${1:id}]: ${2:`@*`} "${3:title}"
+
+snippet ===
+	`repeat('=', strlen(getline(line(".") - 1)))`
+	
+	${1}
+snippet ---
+	`repeat('-', strlen(getline(line(".") - 1)))`
+	
+	${1}


### PR DESCRIPTION
For your consideration, a few additional markdown snippets, of three kinds:
1. Snippets for completing reference style links, both for urls and images, e.g.,

```
snippet [:
   [${1:id}]: http://${2:url} "${3:title}"
```
1. Snippets that yank the url from the `"*` register, which should contain the contents of the system clipboard, e.g.,

```
snippet [*
   [${1:link}](${2:`@*`} "${3:title}")${4}
```
1. Snippets to that underline a line with the proper number of `=`s or `-`s, e.g.,

```
snippet ===
   `repeat('=', strlen(getline(line(".") - 1)))`

   ${1}
```
