### PR TITLE
Fixed duplicate 'title' snippet in html.

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -128,7 +128,7 @@ snippet scope
 	scope="${1:row}"${2}
 snippet src
 	src="${1}"${2}
-snippet title
+snippet title=
 	title="${1}"${2}
 snippet type
 	type="${1}"${2}


### PR DESCRIPTION
Renamed the first one to 'title=' since it was the title attribute.
The other snippet was for the <title> tag.
