### PR TITLE
Added suggestion to use the plugin "EnterIndent"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ to maintain snippets for a language, please get in touch.
 * Markdown - [honza](http://github.com/honza)
 * Ruby - [taq](http://github.com/taq)
 
+Suggestion plugin
+-----------------
+
+* [Enter Indent](https://github.com/acustodioo/vim-enter-indent) - Reposition the cursor when "enter" is pressed between two tags
+
 Contributing notes
 ------------------
 

--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -1,8 +1,4 @@
 snippet php
-	<?php
-	${1}
-	?>
-snippet phpil
 	<?php ${1} ?>
 snippet ec
 	echo "${1:string}"${2};


### PR DESCRIPTION
With the plugin "Enter Indent" (http://github.com/acustodioo/vim-enter-indent) is unnecessary two snippet as "php" and "phpil", between other.
