### PR TITLE
adding pry-snippet to ruby-snippets

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -570,3 +570,6 @@ snippet aft
 #debugging
 snippet debug
 	require 'ruby-debug'; debugger; true;
+snippet pry
+	require 'pry'; binding.pry
+


### PR DESCRIPTION
recently, I use pry as alternative ruby debugger more and more.

This commit moves my local snippet into this repo, hoping to adhere to the principle of least surprise with the naming
