### PR TITLE
Add a "me" snippet

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -7,5 +7,7 @@ snippet date
 	`strftime("%Y-%m-%d")`
 snippet ddate
 	`strftime("%B %d, %Y")`
+snippet me
+	`g:snips_author`
 snippet lorem
 	Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
Just a simple snippet that expands directly to g:snips_author. Useful for quickly filling author fields or signing documents when there isn't a more comprehensive snippet to use.
