### PR TITLE
Licenses snippets

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -9,3 +9,190 @@ snippet ddate
 	`strftime("%B %d, %Y")`
 snippet lorem
 	Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+snippet GPL2
+	# ${1:One line to give the program's name and a brief description.}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	# 
+	# This program is free software; you can redistribute it and/or modify
+	# it under the terms of the GNU General Public License as published by
+	# the Free Software Foundation; either version 2 of the License, or
+	# (at your option) any later version.
+	#
+	# This program is distributed in the hope that it will be useful,
+	# but WITHOUT ANY WARRANTY; without even the implied warranty of
+	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	# GNU General Public License for more details.
+	#
+	# You should have received a copy of the GNU General Public License
+	# along with this program; if not, write to the Free Software Foundation,
+	# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+	${3:#code}
+snippet LGPL2
+	# ${1:One line to give the program's name and a brief description.}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	#
+	# This library is free software; you can redistribute it and/or modify
+	# it under the terms of the GNU Lesser General Public License as published
+	# by the Free Software Foundation; either version 2.1 of the License, or
+	# (at your option) any later version.
+	#
+	# This library is distributed in the hope that it will be useful,
+	# but WITHOUT ANY WARRANTY; without even the implied warranty of
+	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+	# GNU Lesser General Public License for more details.
+	#
+	# You should have received a copy of the GNU Lesser General Public License
+	# along with this library; if not, write to the Free Software Foundation,
+	# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+	${3:#code}
+snippet GPL3
+	# ${1:one line to give the program's name and a brief description.}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	#
+	# This program is free software: you can redistribute it and/or modify
+	# it under the terms of the GNU General Public License as published by
+	# the Free Software Foundation, either version 3 of the License, or
+	# (at your option) any later version.
+	#
+	# This program is distributed in the hope that it will be useful,
+	# but WITHOUT ANY WARRANTY; without even the implied warranty of
+	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	# GNU General Public License for more details.
+	#
+	# You should have received a copy of the GNU General Public License
+	# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	
+	${3:#code}
+snippet LGPL3
+	# ${1:One line to give the program's name and a brief description.}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	#
+	# This library is free software; you can redistribute it and/or modify
+	# it under the terms of the GNU Lesser General Public License as published
+	# by the Free Software Foundation; either version 3 of the License, or
+	# (at your option) any later version.
+	#
+	# This library is distributed in the hope that it will be useful,
+	# but WITHOUT ANY WARRANTY; without even the implied warranty of
+	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+	# GNU Lesser General Public License for more details.
+	#
+	# You should have received a copy of the GNU Lesser General Public License
+	# along with this library; if not, write to the Free Software Foundation,
+	# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+	${3:#code}
+snippet BSD2
+	# ${1:one line to give the program's name and a brief description}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	# All rights reserved.
+	#
+	# Redistribution and use in source and binary forms, with or without
+	# modification, are permitted provided that the following conditions are met:
+	# 1. Redistributions of source code must retain the above copyright
+	#    notice, this list of conditions and the following disclaimer.
+	# 2. Redistributions in binary form must reproduce the above copyright
+	#    notice, this list of conditions and the following disclaimer in the
+	#    documentation and/or other materials provided with the distribution.
+	#
+	# THIS SOFTWARE IS PROVIDED BY $2 ''AS IS'' AND ANY
+	# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	# DISCLAIMED. IN NO EVENT SHALL $2 BE LIABLE FOR ANY
+	# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+	# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	#
+	# 
+	# The views and conclusions contained in the software and documentation 
+	# are those of the authors and should not be interpreted as representing
+	# official policies, either expressedor implied, of $2.
+
+	${4:#code}
+snippet BSD3
+	# ${1:one line to give the program's name and a brief description}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	# All rights reserved.
+	#
+	# Redistribution and use in source and binary forms, with or without
+	# modification, are permitted provided that the following conditions are met:
+	# 1. Redistributions of source code must retain the above copyright
+	#    notice, this list of conditions and the following disclaimer.
+	# 2. Redistributions in binary form must reproduce the above copyright
+	#    notice, this list of conditions and the following disclaimer in the
+	#    documentation and/or other materials provided with the distribution.
+	# 3. Neither the name of the ${3:organization} nor the
+	#    names of its contributors may be used to endorse or promote products
+	#    derived from this software without specific prior written permission.
+	#
+	# THIS SOFTWARE IS PROVIDED BY $2 ''AS IS'' AND ANY
+	# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	# DISCLAIMED. IN NO EVENT SHALL $2 BE LIABLE FOR ANY
+	# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+	# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	${4:#code}
+snippet BSD4
+	# ${1:one line to give the program's name and a brief description}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	# All rights reserved.
+	#
+	# Redistribution and use in source and binary forms, with or without
+	# modification, are permitted provided that the following conditions are met:
+	# 1. Redistributions of source code must retain the above copyright
+	#    notice, this list of conditions and the following disclaimer.
+	# 2. Redistributions in binary form must reproduce the above copyright
+	#    notice, this list of conditions and the following disclaimer in the
+	#    documentation and/or other materials provided with the distribution.
+	# 3. All advertising materials mentioning features or use of this software
+	#    must display the following acknowledgement:
+	#    This product includes software developed by the ${3:organization}.
+	# 4. Neither the name of the $3 nor the
+	#    names of its contributors may be used to endorse or promote products
+	#    derived from this software without specific prior written permission.
+	#
+	# THIS SOFTWARE IS PROVIDED BY $2 ''AS IS'' AND ANY
+	# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	# DISCLAIMED. IN NO EVENT SHALL $2 BE LIABLE FOR ANY
+	# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+	# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	${4:#code}
+snippet MIT
+	# ${1:one line to give the program's name and a brief description}
+	# Copyright (C) `strftime("%Y")` ${2:copyright holder}
+	#
+	# Permission is hereby granted, free of charge, to any person obtaining
+	# a copy of this software and associated documentation files (the "Software"),
+	# to deal in the Software without restriction, including without limitation
+	# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+	# and/or sell copies of the Software, and to permit persons to whom the 
+	# Software is furnished to do so, subject to the following conditions:
+	#
+	# The above copyright notice and this permission notice shall be included
+	# in all copies or substantial portions of the Software.
+	#
+	# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+	# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+	# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+	# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+	# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+	# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+	# OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+	
+	${3:#code}

--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -121,25 +121,6 @@ snippet ipdb
 # ipython debugger (pdbbb)
 snippet pdbbb
 	import pdbpp; pdbpp.set_trace()
-# GPL
-snippet gpl
-	# ${1:Name}
-	# Copyright (C) `strftime("%Y")` ${2:Author}
-	#
-	# This program is free software: you can redistribute it and/or modify
-	# it under the terms of the GNU General Public License as published by
-	# the Free Software Foundation, either version 3 of the License, or
-	# (at your option) any later version.
-	#
-	# This program is distributed in the hope that it will be useful,
-	# but WITHOUT ANY WARRANTY; without even the implied warranty of
-	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	# GNU General Public License for more details.
-	#
-	# You should have received a copy of the GNU General Public License
-	# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-	
-	${3:#code}
 snippet "
 	"""
 	${1:doc}


### PR DESCRIPTION
Removed the "gpl" snippet from the python file and added alla the common open source licenses to the global snippet file.

Relevant issue : https://github.com/honza/snipmate-snippets/issues/48
