### PR TITLE
Added head5 to html.snippets

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -414,6 +414,11 @@ snippet head
 
 		<title>${1:`substitute(Filename('', 'Page Title'), '^.', '\u&', '')`}</title>${2}
 	</head>
+snippet head5
+	<head>
+		<meta charset=${1:"utf-8"} />
+		<title>${2:`substitute(Filename('', 'Page Title'), '^.', '\u&', '')`}</title>${3}
+	</head>
 snippet header
 	<header>
 		${1}


### PR DESCRIPTION
head5 is the HTML5 equivalent of the existing head snippet. The only
difference is it uses the shorter <meta> tag, using utf-8 as the default
text:

```
<meta charset="utf-8" />
```
