### PR TITLE
Current time snippet

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -7,6 +7,8 @@ snippet date
 	`strftime("%Y-%m-%d")`
 snippet ddate
 	`strftime("%B %d, %Y")`
+snippet time
+	`strftime("%H:%M")`
 snippet lorem
 	Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 snippet GPL2


### PR DESCRIPTION
Expand `time` to the current time. I often use this in conjunction to the already existing snippet `date`.
