### PR TITLE
Remove needless semicolon from Javascript for-loops

### DIFF
--- a/snippets/javascript.snippets
+++ b/snippets/javascript.snippets
@@ -54,12 +54,12 @@ snippet case
 snippet for
 	for (var ${2:i} = 0; $2 < ${1:Things}.length; $2${3: += 1}) {
 		${4:$1[$2]}
-	};
+	}
 # for (...) {...} (Improved Native For-Loop)
 snippet forr
 	for (var ${2:i} = ${1:Things}.length - 1; $2 >= 0; $2${3: -= 1}) {
 		${4:$1[$2]}
-	};
+	}
 # while (...) {...}
 snippet wh
 	while (${1:/* condition */}) {
@@ -101,7 +101,7 @@ snippet ret
 snippet fori
 	for (var ${1:prop} in ${2:Things}) {
 		${3:$2[$1]}
-	};
+	}
 # hasOwnProperty
 snippet has
 	hasOwnProperty(${1})


### PR DESCRIPTION
Since all other block-type JS snippets omit the needless semicolon after the final `}` (e.g. `if`, `switch`, etc.), we should remove them from all the for-loop snippets.
