### PR TITLE
LaTeX snippets

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -1,4 +1,20 @@
 # recomendation: change the fold marker from {{{,}}} to (fold),(end) ; tex uses "{" and "}" a lot
+
+#PREAMBLE
+#newcommand
+snippet nc
+	\newcommand{\${1:cmd}}[${2:opt}]{${3:realcmd}}${4}
+#usepackage
+snippet up
+	\usepackage[${1:[options}]{${2:package}}
+#newunicodechar
+snippet nuc
+	\newunicodechar{${1}}{${2:\ensuremath}${3:tex-substitute}}}
+#DeclareMathOperator
+snippet dmo
+	\DeclareMathOperator{${1}}{${2}}
+
+#DOCUMENT
 # \begin{}...\end{}
 snippet begin
 	\begin{${1:env}}
@@ -7,6 +23,10 @@ snippet begin
 # Tabular
 snippet tab
 	\begin{${1:tabular}}{${2:c}}
+	${3}
+	\end{$1}
+snippet thm
+	\begin[${1:author}]{${2:thm}}
 	${3}
 	\end{$1}
 snippet center
@@ -44,7 +64,7 @@ snippet enum
 		\item ${1}
 	\end{enumerate}
 # Itemize
-snippet item
+snippet itemize
 	\begin{itemize}
 		\item ${1}
 	\end{itemize}
@@ -124,6 +144,11 @@ snippet section
 	${1:Section}~\ref{${2:sec:}}${3}
 snippet page
 	${1:page}~\pageref{${2}}${3}
+snippet index
+	\index{${1:index}}${2}
+#cite
+snippet cite
+	\cite{${1}}${2}
 #Formating text: italic, bold, underline, small capital, emphase ..
 snippet it
 	\textit{${1:text}}
@@ -148,16 +173,25 @@ snippet ft
 snippet fig
 	\begin{figure}
 	\begin{center}
-	\includegraphics[scale=${1}]{Figures/${2}}
+	    \includegraphics[scale=${1}]{Figures/${2}}
+	\end{center}
+	\caption{${3}}
+	\label{fig:${4}}
+	\end{figure}
+snippet tikz
+	\begin{figure}
+	\begin{center}
+	\begin{tikzpicture}[scale=${1:1}]
+		${2}
+	\end{tikzpicture}
 	\end{center}
 	\caption{${3}}
 	\label{fig:${4}}
 	\end{figure}
 #math
+snippet stackrel
+	\stackrel{${1:above}}{${2:below}} ${3}
 snippet frac
-	\frac{${1}}{${2}}
+	\frac{${1:num}}{${2:denom}}
 snippet sum
 	\sum^{${1:n}}_{${2:i=1}}{${3}}
-#cite
-snippet cite
-	\cite{${1}}


### PR DESCRIPTION
Dear Maintainers of snipmate/snipmate-snippets,
I am a daily user of your snippets and now follow your "call for snippets".
here are the changes i suggest
- added snippets for preamble
- a theorem snippet
- tikzpicture
- index
- stackrel snippet
- moved cite-snippet to the references section
- modified the frac snippet
- renamed the item -> itemize (because its not much more to type and it's misleading)

yours epsilonhalbe

PS.: this is my first fork/pull request, please inform me if accidentally did something wrong.
