### PR TITLE
Fix snippet for Django context tag inserting a blank line below itself

### DIFF
--- a/snippets/htmldjango.snippets
+++ b/snippets/htmldjango.snippets
@@ -8,7 +8,6 @@ snippet %%
 	{% end$1 %}
 snippet {
 	{{ ${1} }}${2}
-
 # Template Tags
 
 snippet autoescape


### PR DESCRIPTION
Fix for #54. Removing the whitespace underneath the snippet seems to resolve the problem. 
