### PR TITLE
Changing #!/usr/bin/perl line

### DIFF
--- a/snippets/perl.snippets
+++ b/snippets/perl.snippets
@@ -1,6 +1,6 @@
 # #!/usr/bin/perl
 snippet #!
-	#!/usr/bin/perl
+	#!/usr/bin/env perl
 
 # Hash Pointer
 snippet .


### PR DESCRIPTION
Changing the #! snippet from `#!/usr/bin/perl` to `#!/usr/bin/env perl`
This allows the use of non-system perls whilst still working with default perl.

This is the same as the python and ruby snippets
