### PR TITLE
Html snippets

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -138,76 +138,76 @@ snippet width
 	width="${1}"${2}
 # Elements
 snippet a
-	<a href="${1:#}">${2:$1}</a>${3}
+	<a href="${1:#}">${2:$1}</a>
 snippet a.
-	<a class="${1}" href="${2:#}">${3:$1}</a>${4}
+	<a class="${1}" href="${2:#}">${3:$1}</a>
 snippet a#
-	<a id="${1}" href="${2:#}">${3:$1}</a>${4}
+	<a id="${1}" href="${2:#}">${3:$1}</a>
 snippet a:ext
-	<a href="http://${1:example.com}">${2:$1}</a>${3}
+	<a href="http://${1:example.com}">${2:$1}</a>
 snippet a:mail
-	<a href="mailto:${1:joe@example.com}?subject=${2:feedback}">${3:email me}</a>${4}
+	<a href="mailto:${1:joe@example.com}?subject=${2:feedback}">${3:email me}</a>
 snippet abbr
-	<abbr title="${1}">${2}</abbr>${3}
+	<abbr title="${1}">${2}</abbr>
 snippet address
 	<address>
 		${1}
-	</address>${2}
+	</address>
 snippet area
-	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${4}" />${5}
+	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${4}" />
 snippet area+
 	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${4}" />
 	area+${5}
 snippet area:c
-	<area shape="circle" coords="${1}" href="${2}" alt="${3}" />${4}
+	<area shape="circle" coords="${1}" href="${2}" alt="${3}" />
 snippet area:d
-	<area shape="default" coords="${1}" href="${2}" alt="${3}" />${4}
+	<area shape="default" coords="${1}" href="${2}" alt="${3}" />
 snippet area:p
-	<area shape="poly" coords="${1}" href="${2}" alt="${3}" />${4}
+	<area shape="poly" coords="${1}" href="${2}" alt="${3}" />
 snippet area:r
-	<area shape="rect" coords="${1}" href="${2}" alt="${3}" />${4}
+	<area shape="rect" coords="${1}" href="${2}" alt="${3}" />
 snippet article
 	<article>
 		${1}
-	</article>${2}
+	</article>
 snippet article.
 	<article class="${1}">
 		${2}
-	</article>${3}
+	</article>
 snippet article#
 	<article id="${1}">
 		${2}
-	</article>${3}
+	</article>
 snippet aside
 	<aside>
 		${1}
-	</aside>${2}
+	</aside>
 snippet aside.
 	<aside class="${1}">
 		${2}
-	</aside>${3}
+	</aside>
 snippet aside#
 	<aside id="${1}">
 		${2}
-	</aside>${3}
+	</aside>
 snippet audio
-	<audio src="${1}>${2}</audio>${3}
+	<audio src="${1}>${2}</audio>
 snippet b
-	<b>${1}</b>${2}
+	<b>${1}</b>
 snippet base
-	<base href="${1}" target="${2}" />${3}
+	<base href="${1}" target="${2}" />
 snippet bdi
-	<bdi>${1}</bdo>${2}
+	<bdi>${1}</bdo>
 snippet bdo
-	<bdo dir="${1}">${2}</bdo>${3}
+	<bdo dir="${1}">${2}</bdo>
 snippet bdo:l
-	<bdo dir="ltr">${1}</bdo>${3}
+	<bdo dir="ltr">${1}</bdo>
 snippet bdo:r
-	<bdo dir="rtl">${1}</bdo>${3}
+	<bdo dir="rtl">${1}</bdo>
 snippet blockquote
 	<blockquote>
 		${1}
-	</blockquote>${2}
+	</blockquote>
 snippet body
 	<body>
 		${1}
@@ -215,25 +215,25 @@ snippet body
 snippet br
 	<br />${1}
 snippet button
-	<button type="${1:submit}">${2}</button>${3}
+	<button type="${1:submit}">${2}</button>
 snippet button.
-	<button class="${1:button}" type="${2:submit}">${3}</button>${4}
+	<button class="${1:button}" type="${2:submit}">${3}</button>
 snippet button#
-	<button id="${1}" type="${2:submit}">${3}</button>${4}
+	<button id="${1}" type="${2:submit}">${3}</button>
 snippet button:s
-	<button type="submit">${1}</button>${2}
+	<button type="submit">${1}</button>
 snippet button:r
-	<button type="reset">${1}</button>${2}
+	<button type="reset">${1}</button>
 snippet canvas
 	<canvas>
 		${1}
-	</canvas>${2}
+	</canvas>
 snippet caption
-	<caption>${1}</caption>${2}
+	<caption>${1}</caption>
 snippet cite
-	<cite>${1}</cite>${2}
+	<cite>${1}</cite>
 snippet code
-	<code>${1}</code>${2}
+	<code>${1}</code>
 snippet col
 	<col />${1}
 snippet col+
@@ -242,58 +242,58 @@ snippet col+
 snippet colgroup
 	<colgroup>
 		${1}
-	</colgroup>${2}
+	</colgroup>
 snippet colgroup+
 	<colgroup>
 		<col />
 		col+${1}
 	</colgroup>
 snippet command
-	<command type="command" label="${1}" icon="${2}" />${3}
+	<command type="command" label="${1}" icon="${2}" />
 snippet command:c
-	<command type="checkbox" label="${1}" icon="${2}" />${3}
+	<command type="checkbox" label="${1}" icon="${2}" />
 snippet command:r
-	<command type="radio" radiogroup="${1}" label="${2}" icon="${3}" />${4}
+	<command type="radio" radiogroup="${1}" label="${2}" icon="${3}" />
 snippet datagrid
 	<datagrid>
 		${1}
-	</datagrid>${2}
+	</datagrid>
 snippet datalist
 	<datalist>
 		${1}
-	</datalist>${2}
+	</datalist>
 snippet datatemplate
 	<datatemplate>
 		${1}
-	</datatemplate>${2}
+	</datatemplate>
 snippet dd
-	<dd>${1}</dd>${2}
+	<dd>${1}</dd>
 snippet dd.
-	<dd class="${1}">${2}</dd>${3}
+	<dd class="${1}">${2}</dd>
 snippet dd#
-	<dd id="${1}">${2}</dd>${3}
+	<dd id="${1}">${2}</dd>
 snippet del
-	<del>${1}</del>${2}
+	<del>${1}</del>
 snippet details
 	<details>${1}</details>
 snippet dfn
-	<dfn>${1}</dfn>${2}
+	<dfn>${1}</dfn>
 snippet dialog
 	<dialog>
 		${1}
-	</dialog>${2}
+	</dialog>
 snippet div
 	<div>
 		${1}
-	</div>${2}
+	</div>
 snippet div.
 	<div class="${1}">
 		${2}
-	</div>${3}
+	</div>
 snippet div#
 	<div id="${1}">
 		${2}
-	</div>${3}
+	</div>
 snippet dl
 	<dl>
 		${1}
@@ -315,29 +315,29 @@ snippet dl+
 snippet dt
 	<dt>${1}</dt>
 snippet dt.
-	<dt class="${1}">${2}</dt>${3}
+	<dt class="${1}">${2}</dt>
 snippet dt#
-	<dt id="${1}">${2}</dt>${3}
+	<dt id="${1}">${2}</dt>
 snippet dt+
 	<dt>${1}</dt>
 	<dd>${2}</dd>
 	dt+${3}
 snippet em
-	<em>${1}</em>${2}
+	<em>${1}</em>
 snippet embed
-	<embed src=${1} type="${2} />${3}
+	<embed src=${1} type="${2} />
 snippet fieldset
 	<fieldset>
 		${1}
-	</fieldset>${2}
+	</fieldset>
 snippet fieldset.
 	<fieldset class="${1}">
 		${2}
-	</fieldset>${3}
+	</fieldset>
 snippet fieldset#
 	<fieldset id="${1}">
 		${2}
-	</fieldset>${3}
+	</fieldset>
 snippet fieldset+
 	<fieldset>
 		<legend><span>${1}</span></legend>
@@ -345,95 +345,96 @@ snippet fieldset+
 	</fieldset>
 	fieldset+${3}
 snippet figcaption
-	<figcaption>${1}</figcaption>${2}
+	<figcaption>${1}</figcaption>
 snippet figure
-	<figure>${1}</figure>${2}
+	<figure>${1}</figure>
 snippet footer
 	<footer>
 		${1}
-	</footer>${2}
+	</footer>
 snippet footer.
 	<footer class="${1}>
 		${2}
-	</footer>${3}
+	</footer>
 snippet footer#
 	<footer id="${1}>
 		${2}
-	</footer>${3}
+	</footer>
 snippet form
 	<form action="${1}" method="${2:get}" accept-charset="utf-8">
 		${3}
-	</form>${4}
+	</form>
 snippet form.
 	<form class="${1}" action="${2}" method="${3:get}" accept-charset="utf-8">
 		${4}
-	</form>${5}
+	</form>
 snippet form#
 	<form id="${1}" action="${2}" method="${3:get}" accept-charset="utf-8">
 		${4}
-	</form>${5}
+	</form>
 snippet h1
-	<h1>${1}</h1>${2}
+	<h1>${1}</h1>
 snippet h1.
-	<h1 class="${1}">${2}</h1>${3}
+	<h1 class="${1}">${2}</h1>
 snippet h1#
-	<h1 id="${1}">${2}</h1>${3}
+	<h1 id="${1}">${2}</h1>
 snippet h2
-	<h2>${1}</h2>${2}
+	<h2>${1}</h2>
 snippet h2.
-	<h2 class="${1}">${2}</h2>${3}
+	<h2 class="${1}">${2}</h2>
 snippet h2#
-	<h2 id="${1}">${2}</h2>${3}
+	<h2 id="${1}">${2}</h2>
 snippet h3
-	<h3>${1}</h3>${2}
+	<h3>${1}</h3>
 snippet h3.
-	<h3 class="${1}">${2}</h2>${3}
+	<h3 class="${1}">${2}</h2>
 snippet h3#
-	<h3 id="${1}">${2}</h2>${3}
+	<h3 id="${1}">${2}</h2>
 snippet h4
-	<h4>${1}</h4>${2}
+	<h4>${1}</h4>
 snippet h4.
-	<h4 class="${1}">${2}</h4>${3}
+	<h4 class="${1}">${2}</h4>
 snippet h4#
-	<h4 id="${1}">${2}</h4>${3}
+	<h4 id="${1}">${2}</h4>
 snippet h5
-	<h5>${1}</h5>${2}
+	<h5>${1}</h5>
 snippet h5.
-	<h5 class="${1}">${2}</h5>${3}
+	<h5 class="${1}">${2}</h5>
 snippet h5#
-	<h5 id="${1}">${2}</h5>${3}
+	<h5 id="${1}">${2}</h5>
 snippet h6
-	<h6>${1}</h6>${2}
+	<h6>${1}</h6>
 snippet h6.
-	<h6 class="${1}">${2}</h6>${3}
+	<h6 class="${1}">${2}</h6>
 snippet h6#
-	<h6 id="${1}">${2}</h6>${3}
+	<h6 id="${1}">${2}</h6>
 snippet head
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 
-		<title>${1:`substitute(Filename('', 'Page Title'), '^.', '\u&', '')`}</title>${2}
+		<title>${1:`substitute(Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
+		${2}
 	</head>
 snippet header
 	<header>
 		${1}
-	</header>${2}
+	</header>
 snippet header.
 	<header class="${1}">
 		${2}
-	</header>${3}
+	</header>
 snippet header#
 	<header id="${1}">
 		${2}
-	</header>${3}
+	</header>
 snippet hgroup
 	<hgroup>
 		${1}
-	</hgroup>${2}
+	</hgroup>
 snippet hgroup.
 	<hgroup class="${1}>
 		${2}
-	</hgroup>${3}
+	</hgroup>
 snippet hr
 	<hr />${1}
 snippet html
@@ -445,7 +446,7 @@ snippet xhtml
 	${1}
 	</html>
 snippet i
-	<i>${1}</i>${2}
+	<i>${1}</i>
 snippet iframe
 	<iframe src="${1}" frameborder="0"></iframe>${2}
 snippet iframe.
@@ -507,13 +508,13 @@ snippet input:url
 snippet input:week
 	<input type="week" name="${1}" id="${2:$1}" value="${3}" />${4}
 snippet ins
-	<ins>${1}</ins>${2}
+	<ins>${1}</ins>
 snippet kbd
-	<kbd>${1}</kbd>${2}
+	<kbd>${1}</kbd>
 snippet keygen
-	<keygen>${1}</keygen>${2}
+	<keygen>${1}</keygen>
 snippet label
-	<label for="${2:$1}">${1}</label>${3}
+	<label for="${2:$1}">${1}</label>
 snippet label:i
 	<label for="${2:$1}">${1}</label>
 	<input type="${3:text/submit/hidden/button}" name="${4:$2}" id="${5:$2}" value="${6}" />${7}
@@ -523,18 +524,18 @@ snippet label:s
 		<option value="${5}">${6:$5}</option>
 	</select>
 snippet legend
-	<legend>${1}</legend>${2}
+	<legend>${1}</legend>
 snippet legend+
-	<legend><span>${1}</span></legend>${2}
+	<legend><span>${1}</span></legend>
 snippet li
-	<li>${1}</li>${2}
+	<li>${1}</li>
 snippet li.
-	<li class="${1}">${2}</li>${3}
+	<li class="${1}">${2}</li>
 snippet li+
 	<li>${1}</li>
 	li+${2}
 snippet lia
-	<li><a href="${2:#}">${1}</a></li>${3}
+	<li><a href="${2:#}">${1}</a></li>
 snippet lia+
 	<li><a href="${2:#}">${1}</a></li>
 	lia+${3}
@@ -553,33 +554,33 @@ snippet link:touch
 snippet map
 	<map name="${1}">
 		${2}
-	</map>${3}
+	</map>
 snippet map.
 	<map class="${1}" name="${2}">
 		${3}
-	</map>${4}
+	</map>
 snippet map#
 	<map name="${1}" id="${2:$1}>
 		${3}
-	</map>${4}
+	</map>
 snippet map+
 	<map name="${1}">
 		<area shape="${2}" coords="${3}" href="${4} alt="${5}" />${6}
 	</map>${7}
 snippet mark
-	<mark>${1}</mark>${2}
+	<mark>${1}</mark>
 snippet menu
 	<menu>
 		${1}
-	</menu>${2}
+	</menu>
 snippet menu:c
 	<menu type="context">
 		${1}
-	</menu>${2}
+	</menu>
 snippet menu:t
 	<menu type="toolbar">
 		${1}
-	</menu>${2}
+	</menu>
 snippet meta
 	<meta http-equiv="${1}" content="${2}" />${3}
 snippet meta:compat
@@ -593,19 +594,19 @@ snippet meter
 snippet nav
 	<nav>
 		${1}
-	</nav>${2}
+	</nav>
 snippet nav.
 	<nav class="${1}">
 		${2}
-	</nav>${3}
+	</nav>
 snippet nav#
 	<nav id="${1}">
 		${2}
-	</nav>${3}
+	</nav>
 snippet noscript
 	<noscript>
 		${1}
-	</noscript>${2}
+	</noscript>
 snippet object
 	<object data="${1}" type="${2}">
 		${3}
@@ -641,31 +642,31 @@ snippet ol+
 		li+${2}
 	</ol>
 snippet opt
-	<option value="${1}">${2:$1}</option>${3}
+	<option value="${1}">${2:$1}</option>
 snippet opt+
 	<option value="${1}">${2:$1}</option>
 	opt+${3}
 snippet optt
-	<option>${1}</option>${2}
+	<option>${1}</option>
 snippet optgroup
 	<optgroup>
 		<option value="${1}">${2:$1}</option>
 		opt+${3}
 	</optgroup>
 snippet output
-	<output>${1}</output>${2}
+	<output>${1}</output>
 snippet p
-	<p>${1}</p>${2}
+	<p>${1}</p>
 snippet param
 	<param name="${1}" value="${2}" />${3}
 snippet pre
 	<pre>
 		${1}
-	</pre>${2}
+	</pre>
 snippet progress
-	<progress>${1}</progress>${2}
+	<progress>${1}</progress>
 snippet q
-	<q>${1}</q>${2}
+	<q>${1}</q>
 snippet rp
 	<rp>${1}</rp>
 snippet rt
@@ -673,31 +674,31 @@ snippet rt
 snippet ruby
 	<ruby>
 		<rp><rt>${1}</rt></rp>
-	</ruby>${2}
+	</ruby>
 snippet s
-	<s>${1}</s>${2}
+	<s>${1}</s>
 snippet samp
 	<samp>
 		${1}
-	</samp>${2}
+	</samp>
 snippet script
 	<script type="text/javascript" charset="utf-8">
 		${1}
-	</script>${2}
+	</script>
 snippet scriptsrc
 	<script src="${1}.js" type="text/javascript" charset="utf-8"></script>
 snippet section
 	<section>
 		${1}
-	</section>${2}
+	</section>
 snippet section.
 	<section class="${1}">
 		${2}
-	</section>${3}
+	</section>
 snippet section#
 	<section id="${1}">
 		${2}
-	</section>${3}
+	</section>
 snippet select
 	<select name="${1}" id="${2:$1}">
 		${3}
@@ -712,25 +713,25 @@ snippet select+
 		opt+${5}
 	</select>
 snippet small
-	<small>${1}</small>${2}
+	<small>${1}</small>
 snippet source
-	<source src="${1}" type="${2}" media="${3}" />${4}
+	<source src="${1}" type="${2}" media="${3}" />
 snippet span
-	<span>${1}</span>${2}
+	<span>${1}</span>
 snippet strong
-	<strong>${1}</strong>${2}
+	<strong>${1}</strong>
 snippet style
 	<style type="text/css" media="${1:all}">
 		${2}
 	</style>
 snippet sub
-	<sub>${1}</sub>${2}
+	<sub>${1}</sub>
 snippet summary
 	<summary>
 		${1}
-	</summary>${2}
+	</summary>
 snippet sup
-	<sup>${1}</sup>${2}
+	<sup>${1}</sup>
 snippet table
 	<table border="${1:0}">
 		${2}
@@ -746,11 +747,13 @@ snippet table#
 snippet tbody
 	<tbody>
 		${1}
-	</tbody>${2}
+	</tbody>
 snippet td
-	<td>${1}</td>${2}
+	<td>${1}</td>
 snippet td.
-	<td class="${1}">${2}</td>${3}
+	<td class="${1}">${2}</td>
+snippet td#
+	<td id="${1}">${2}</td>
 snippet td+
 	<td>${1}</td>
 	td+${2}
@@ -759,18 +762,20 @@ snippet textarea
 snippet tfoot
 	<tfoot>
 		${1}
-	</tfoot>${2}
+	</tfoot>
 snippet th
-	<th>${1}</th>${2}
+	<th>${1}</th>
 snippet th.
-	<th class="${1}">${2}</th>${3}
+	<th class="${1}">${2}</th>
+snippet th#
+	<th id="${1}">${2}</th>
 snippet th+
 	<th>${1}</th>
 	th+${2}
 snippet thead
 	<thead>
 		${1}
-	</thead>${2}
+	</thead>
 snippet time
 	<time datetime="${1}" pubdate="${2:$1}>${3:$1}</time>
 snippet title
@@ -778,7 +783,7 @@ snippet title
 snippet tr
 	<tr>
 		${1}
-	</tr>${2}
+	</tr>
 snippet tr+
 	<tr>
 		<td>${1}</td>
@@ -804,7 +809,7 @@ snippet ul+
 		li+${2}
 	</ul>
 snippet var
-	<var>${1}</var>${2}
+	<var>${1}</var>
 snippet video
 	<video src="${1} height="${2}" width="${3}" preload="${5:none}" autoplay="${6:autoplay}>${7}</video>${8}
 snippet wbr


### PR DESCRIPTION
I stripped out many of the ending tabstops in the HTML snippets file (many of which I myself introduced). The reason for this is that they aren't needed for the common use case, and could cause an extra step for developers who don't enter things exactly in the order the snippets demand.

For instance, if I add a new `div` element by typing `div<tab>`, the first tab stop places my cursor inside the opening `<div>` and closing `</div>`, but it is highly likely that I'm going to want to add more elements at this point rather than tab out of it.

Here are cases where an ending tabstop can still be useful (I have left these in):
- a self-closing tag, such as `<br />` or `<input ... />`
- a snippet with a `+` variant, such as `li+`, which allows a user to quickly add new tags as needed
