### PR TITLE
log snippet for ruby updated

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -673,6 +673,8 @@ snippet i18
 snippet ist
 	<%= image_submit_tag("${1:agree.png}", :id => "${2:id}"${3} %>
 snippet log
+	Rails.logger.${1:debug} ${2}
+snippet log2
 	RAILS_DEFAULT_LOGGER.${1:debug} ${2}
 snippet logd
 	logger.debug { "${1:message}" }${2}


### PR DESCRIPTION
Current Rails version (3) doesn't have RAILS_DEFAULT_LOGGER anymore.
I updated "log" snippet for Rails 3.x, added "log2" snippet for Rails 2.x
