### PR TITLE
change python `snippet .` to `snippet s.` to prevent unexpected shadowing, etc

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -75,7 +75,7 @@ snippet cascii
 # Lambda
 snippet ld
 	${1:var} = lambda ${2:vars} : ${3:action}
-snippet .
+snippet s.
 	self.
 snippet try Try/Except
 	try:


### PR DESCRIPTION
in line with [issue 97](https://github.com/honza/snipmate-snippets/issues/97), change `snippet .` to `snippet s.` to prevent shadowing of other completion functions/unexpected behavior
