### PR TITLE
Add test assertThat style (for junit 4) support

### DIFF
--- a/snippets/java.snippets
+++ b/snippets/java.snippets
@@ -79,6 +79,8 @@ snippet cos
 	static public final String ${1:var} = "${2}";${3}
 snippet as
 	assert ${1:test} : "${2:Failure message}";${3}
+snippet assert
+	assertThat(${1}, is(${2}));
 snippet try
 	try {
 		${3}


### PR DESCRIPTION
Since there is many people using junit 4 and its feature its nice to have support for assertThat style.

```
@Test
public void testWithMatchers() {
    assertThat("this string", is("this string"));
}
```
