### PR TITLE
Erlang snippets

### DIFF
--- a/snippets/erlang.snippets
+++ b/snippets/erlang.snippets
@@ -82,6 +82,29 @@ snippet application
 
 	stop(_State) ->
 	    ok.	
+# OTP supervisor
+snippet supervisor
+	-module(${1:`Filename('', 'my')`}).
+
+	-behaviour(supervisor).
+
+	%% API
+	-export([start_link/0]).
+
+	%% Supervisor callbacks
+	-export([init/1]).
+
+	-define(SERVER, ?MODULE).
+
+	start_link() ->
+	    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+	init([]) ->
+	    Server = {${2:my_server}, {$2, start_link, []},
+	      permanent, 2000, worker, [$2]},
+	    Children = [Server],
+	    RestartStrategy = {one_for_one, 0, 1},
+	    {ok, {RestartStrategy, Children}}.
 # OTP gen_server
 snippet gen_server
 	-module(${1:`Filename('', 'my')`}).


### PR DESCRIPTION
Commits contain OTP-templates for _gen_server_, _application_, and _supervisor_ following the normal conventions. OTP apps require a fair amount of boiler plate code, and having this available as snippets is very handy. 

In addition I included a simple snippet for _anonymous functions_ and one for _try..catch_.

I'm a lover of programming languages, and if this request is accepted I'll be happy to contribute more to this project.
