### PR TITLE
Add pprint snippet to Python

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -121,6 +121,8 @@ snippet ipdb
 # ipython debugger (pdbbb)
 snippet pdbbb
 	import pdbpp; pdbpp.set_trace()
+snippet pprint
+	import pprint; pprint.pprint(${1})${2}
 snippet "
 	"""
 	${1:doc}


### PR DESCRIPTION
This just adds a simple `pprint` snippet. It's a tiny modification, I know, but it seems somewhat useful.
