### PR TITLE
package declaration and pod snippets

### DIFF
--- a/snippets/perl.snippets
+++ b/snippets/perl.snippets
@@ -232,7 +232,7 @@ snippet psubi
 snippet subpod
 	=head2 $1
 
-	Summarry of $1
+	Summary of $1
 
 	=cut
 


### PR DESCRIPTION
Added a newer perl5.14 style package declaration, snippet for inline subroutine pod and try to use the file name when creating the package name.
