### PR TITLE
Fixed a missed tag close

### DIFF
--- a/snippets/xslt.snippets
+++ b/snippets/xslt.snippets
@@ -16,7 +16,7 @@ snippet attribute blank
 
 snippet attribute value-of
 	<xsl:attribute name="${1:name}">
-		<xsl:value-of select="${2:*}">
+		<xsl:value-of select="${2:*}" />
 	</xsl:attribute>${3}
 
 snippet call-template


### PR DESCRIPTION
The value-of tag in the attribute value-of snippet needed to be self-closed and wasn't. Fixed now!
