### PR TITLE
BEERWARE error

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -216,12 +216,12 @@ snippet APACHE
 
 	${3}
 snippet BEERWARE 
-	${1:one line to give the program's name and a brief description}
-	Copyright `strftime("%Y")` ${2:copyright holder}
+	${2:one line to give the program's name and a brief description}
+	Copyright `strftime("%Y")` ${3:copyright holder}
 	
 	Licensed under the "THE BEER-WARE LICENSE" (Revision 42):
 	${1:`g:snips_author`} wrote this file. As long as you retain this notice you
 	can do whatever you want with this stuff. If we meet some day, and you think
 	this stuff is worth it, you can buy me a beer or coffee in return 
 
-	${3}
+	${4}


### PR DESCRIPTION
The BEERWARE snippet had two sections numbered as 1, causing strange behavior. Renumbered so that each number has only one section.
