### PR TITLE
Improve tex citation snippets

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -149,6 +149,8 @@ snippet index
 #Citations
 snippet cite
 	\cite[${1}]{${2}}${3}
+snippet fcite
+	\footcite[${1}]{${2}}${3}
 #Formating text: italic, bold, underline, small capital, emphase ..
 snippet it
 	\textit{${1:text}}


### PR DESCRIPTION
Add the optional `\cite` argument to the `cite` snippet which is usually used to cite specific pages (as in `\cite[Page 14]{my_bib_key}`.

Add a snippet for citations in foot notes with the `biblatex` packages.  This citation style is often used in juristic work in Germany.
