### PR TITLE
added switch, switch with no default, and case snippets to c snippets

### DIFF
--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -68,6 +68,27 @@ snippet elif
 # ternary
 snippet t
 	${1:/* condition */} ? ${2:a} : ${3:b}
+# switch
+snippet switch
+	switch (${1:/* variable */}) {
+		case ${2:/* variable case */}:
+			${3}
+			${4:break;}${5}
+		default:
+			${6}
+	}${7}
+# switch without default
+snippet switchndef
+	switch (${1:/* variable */}) {
+		case ${2:/* variable case */}:
+			${3}
+			${4:break;}${5}
+	}${6}
+# case
+snippet case
+	case ${1:/* variable case */}:
+		${2}
+		${3:break;}${4}
 ##
 ## Loops
 # for


### PR DESCRIPTION
I added support for switch to the c.snippets file. Three snippets were created: 
1. switch: creates a switch structure with one case terminated by a break and a default case
2. switchndef: creates switch structure with one case, no default case
3. case: creates a new case. Useful for adding cases to an existing switch

In all cases, "break;" is one of the tab locations, allowing you to easily delete it if you want a fall-through switch statement.
