### PR TITLE
Added descriptions for duplicated snippet names.

### DIFF
--- a/snippets/actionscript.snippets
+++ b/snippets/actionscript.snippets
@@ -107,7 +107,7 @@ snippet try
 		${3}
 	}
 # For Loop (same as c.snippet)
-snippet for
+snippet for for (..) {..}
 	for (${2:i} = 0; $2 < ${1:count}; $2${3:++}) {
 		${4:/* code */}
 	}

--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -26,7 +26,7 @@ snippet beg
 	rescue ${1:Exception} => ${2:e}
 	end
 
-snippet req
+snippet req require
 	require "${1}"${2}
 snippet #
 	# =>
@@ -575,7 +575,7 @@ snippet asre
 	assert_response :${1:success}, @response.body${2}
 snippet asrj
 	assert_rjs :${1:replace}, "${2:dom id}"
-snippet ass
+snippet ass assert_select(..)
 	assert_select '${1:path}', :${2:text} => '${3:inner_html' ${4:do}
 snippet bf
 	before_filter :${1:method}

--- a/snippets/xslt.snippets
+++ b/snippets/xslt.snippets
@@ -8,7 +8,7 @@ snippet apply-templates sort-by
 		<xsl:sort select="${2:node}" order="${3:ascending}" data-type="${4:text}">${5}
 	</xsl:apply-templates>${6}
 
-snippet apply-templates 
+snippet apply-templates plain
 	<xsl:apply-templates select="${1:*}" />${2}
 
 snippet attribute blank


### PR DESCRIPTION
This is to make the snippets a little more compatible with
neosnippets.

I'm also working from the other direction too... See [pull request 64](https://github.com/Shougo/neosnippet/pull/64).

Ciao!
