### PR TITLE
Make the jquery snippet support the Shougo's neosnippet

### DIFF
--- a/snippets/javascript_jquery.snippets
+++ b/snippets/javascript_jquery.snippets
@@ -1,0 +1,1 @@
+javascript-jquery.snippets


### PR DESCRIPTION
Shougo's neosnippet support the "vim__.snip_" style.

So I create a file javascript_jquery.snippet and symbol link to the javascript-jquery.snippet.
