### PR TITLE
Fixing numbering in html snippets.

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -556,7 +556,7 @@ snippet link
 snippet link:atom
 	<link rel="alternate" href="${1:atom.xml}" title="Atom" type="application/atom+xml" />${2}
 snippet link:css
-	<link rel="stylesheet" href="${2:style.css}" type="text/css" media="${3:all}" />${4}
+	<link rel="stylesheet" href="${1:style.css}" type="text/css" media="${2:all}" />${3}
 snippet link:favicon
 	<link rel="shortcut icon" href="${1:favicon.ico}" type="image/x-icon" />${2}
 snippet link:rss


### PR DESCRIPTION
The numbering in the snippet for including stylesheets started at 2, which caused snipmate to insert the defaults and jump to the end of the line when trying to use it.
