### PR TITLE
Add and improve golang snippets

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -138,6 +138,13 @@ snippet fum
 	func (self ${1:type}) ${2:funcName}(${3}) ${4:error} {
 		${5:/* code */}
 	}
+	${6}
+# log printf
+snippet lf
+	log.Printf("%${1:s}", ${2:var})${3}
+# log printf
+snippet lp
+	log.Println("${1}")${2}
 # make
 snippet mk
 	make(${1:[]string}, ${2:0})
@@ -158,7 +165,7 @@ snippet pn
 	panic("${1:msg}")
 # print
 snippet pr
-	fmt.Printf("${1:%s}\n", ${2:var})${3}
+	fmt.Printf("%${1:s}\n", ${2:var})${3}
 # range 
 snippet rn
 	range ${1}
@@ -198,7 +205,7 @@ snippet sw
 		${6:/* code */}
 	}
 snippet sp
-	fmt.Sprintf("${1:%s}", ${2:var})${3}
+	fmt.Sprintf("%${1:s}", ${2:var})${3}
 # true 
 snippet t
 	true


### PR DESCRIPTION
- Basically none of the functions are ending at the functions closing brackets. I've add to all statements and endpoint.
- The snippet for struct had a wrong number.
- The printf and sprintf should rename after % not directly %s. Otherwise everytime the user has to type % again and again, which kinda doesn't make sense for these functions.
- Add log.Printf and log.Println for adding quickly log prints, which imho is very useful for debugging with print statements.
