### PR TITLE
each_with_object snippet for Ruby

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -286,7 +286,7 @@ snippet eavd
 snippet eawi
 	each_with_index { |${1:e}, ${2:i}| ${3} }
 snippet eawid
-	each_with_index do |${1:e},${2:i}|
+	each_with_index do |${1:e}, ${2:i}|
 		${3}
 	end
 snippet eawo


### PR DESCRIPTION
I added a Ruby snippet for Enumerable#each_with_object.

I also added a space to the "each_with_index" snippet, because it was inconsistent with the block style of similar snippets.
