### PR TITLE
Added a semicolon to the sdf (self-defining function) javascript snippet

### DIFF
--- a/snippets/javascript.snippets
+++ b/snippets/javascript.snippets
@@ -156,7 +156,7 @@ snippet sing
 	}
 # Crockford's object function 
 snippet obj
-	object(o) {
+	function object(o) {
 		function F() {}
 		F.prototype = o;
 		return new F();


### PR DESCRIPTION
It was the only snippet that was missing a semicolon :)
