### PR TITLE
fix haml render snippets

### DIFF
--- a/snippets/haml.snippets
+++ b/snippets/haml.snippets
@@ -11,10 +11,12 @@ snippet ul
 		%li
 			${1:item}
 		%li
-snippet =rp
-	= render :partial => '${1:partial}'
-snippet =rpl
-	= render :partial => '${1:partial}', :locals => {}
-snippet =rpc
-	= render :partial => '${1:partial}', :collection => @$1
+snippet rp
+	= render :partial => "${1:item}"
+snippet rpc
+	= render :partial => "${1:item}", :collection => ${2:@$1s}
+snippet rpl
+	= render :partial => "${1:item}", :locals => { :${2:$1} => ${3:@$1}
+snippet rpo
+	= render :partial => "${1:item}", :object => ${2:@$1}
 


### PR DESCRIPTION
1) fix render partial snippets names to standart(eruby.snippet, ruby.snippet like)
rp instead of =rp - this is the point of constantly confuse)))

2) make snippets ruby.snippets like
3) added missed snippets

make snippets more standardized!)
