### PR TITLE
Some improvements to the snippets of CoffeeScript

### DIFF
--- a/UltiSnips/coffee.snippets
+++ b/UltiSnips/coffee.snippets
@@ -7,7 +7,7 @@ ${1:name} = `!p snip.rv = "(" if t[2] else ""`${2:args}`!p snip.rv = ") " if t[2
 endsnippet
 
 snippet bfun "Function (bound)" i
-`!p snip.rv = "(" if t[1] else ""`${1:args}`!p snip.rv = ") " if t[1] else ""`=>`!p snip.rv = " " if t[2] else ""`${2:expr}
+`!p snip.rv = "(" if t[1] else ""`${1:args}`!p snip.rv = ") " if t[1] else ""`=>`!p snip.rv = " " if t[2] and not t[2].startswith("\n") else ""`${2:expr}
 endsnippet
 
 snippet if "If"
@@ -66,7 +66,7 @@ endsnippet
 snippet swit "Switch when .. then"
 switch ${1:object}
 	when ${2:condition}`!p snip.rv = " then " if t[3] else ""`${3:value}
-	else`!p snip.rv = " " if t[4] else ""`${4:value}
+	else`!p snip.rv = " " if t[4] and not t[4].startswith("\n") else ""`${4:value}
 endsnippet
 
 snippet cla "Class" b


### PR DESCRIPTION
I made the following improvements to `UltiSnips/coffee.snippets` in this pull request:
- For several snippets(e.g. `bfun`, `if`, `for*`, etc.), I removed the limit(`b`) of only being expanded when triggered at the beginning of the line. Since most statements in CoffeeScript are also assignable expressions(especially the `bfun`, which is almost always used anonymously within an expression), it's better to make those snippets available in the middle of a line.
- I modified the `fun` snippet to make the brackets a part of selections. This is useful when defining function without arguments. Besides, this is consistent with the behavior of `bfun`.

```
snippet fun "Function" b
${1:name} = ${2:(${3:args}) }->
  ${0:# body...}
endsnippet
```
- Interpolation is often used to suffix a token, so I made it an in-word snippet(adding `i`).
- It's better to have an 'else' clause in the `swi` snippet. This won't hurt since the coffee compiler automatically drops empty else.

```
snippet swi "Switch"
switch ${1:object}
  when ${2:value}
    ${3:# body...}
  else
    $0
endsnippet
```
- Added a new `swit` snippet, which expands to the 'switch-when-then' statement.

```
snippet swit "Switch when .. then"
switch ${1:object}
  when ${2:${3:condition} then ${4:value}}
  else ${0:value}
endsnippet
```
