### PR TITLE
Shoulda matchers

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -1005,3 +1005,62 @@ snippet shared
 	shared_examples "${1:shared examples name}" ${2}
 snippet itb
 	it_behaves_like "${1:shared examples name}"${2}
+#ShouldaMatchers#ActionController
+snippet sfp
+	it { should filter_param :${1:key} }
+snippet srt
+	it { should redirect_to ${1:url} }
+snippet srtp
+	it { should render_template ${1} }
+snippet srwl
+	it { should render_with_layout ${1} }
+snippet srf
+	it { should rescue_from ${1:exception} }
+snippet srw
+	it { should respond_with ${1:status} }
+snippet sr
+	it { should route(:${1:method}, '${2:path}') }
+snippet sss
+	it { should set_session :${1:key} }
+snippet ssf
+	it { should set_the_flash('${1}') }
+#ShouldaMatchers#ActiveModel
+snippet sama
+	it { should allow_mass_assignment_of :${1} }
+snippet sav
+	it { should allow_value(${1}) }
+snippet see
+	it { should ensure_exclusion_of :${1} }
+snippet sei
+	it { should ensure_inclusion_of :${1} }
+snippet sel
+	it { should ensure_length_of :${1} }
+snippet sva
+	it { should validate_acceptance_of :${1} }
+snippet svc
+	it { should validate_confirmation_of :${1} }
+snippet svn
+	it { should validate_numericality_of :${1} }
+snippet svp
+	it { should validate_presence_of :${1} }
+snippet svu
+	it { should validate_uniqueness_of :${1} }
+#ShouldaMatchers#ActiveRecord
+snippet sana
+	it { should accept_nested_attributes_for :${1} }
+snippet sb
+	it { should belong_to :${1} }
+snippet shbtm
+	it { should have_and_belong_to_many :${1} }
+snippet shc
+	it { should have_db_column :${1} }
+snippet shi
+	it { should have_db_index :${1} }
+snippet shm
+	it { should have_many :${1} }
+snippet sho
+	it { should have_one :${1} }
+snippet shroa
+	it { should have_readonly_attribute :${1} }
+snippet ss
+	it { should serialize :${1} }


### PR DESCRIPTION
- move accepts_nested_attributes_for to attributes section
- make rspec section definition comment more readable
- add rspec shoulda matchers snippets

I think it's make sense to extract rspec snippets to the separate file. What do you think about it?
