### PR TITLE
Give a chance to set the assert_difference value

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -596,8 +596,8 @@ snippet artp
 snippet artpp
 	assert_redirected_to ${1:model}s_path
 snippet asd
-	assert_difference "${1:Model}.${2:count}", $1 do
-		${3}
+	assert_difference "${1:Model}.${2:count}", ${3:1} do
+		${4}
 	end
 snippet asnd
 	assert_no_difference "${1:Model}.${2:count}" do


### PR DESCRIPTION
Althought 1 is a quite frequent value to use `assert_difference`, -1 is also a frequent value for that. So i think give it a chance to edit the value is resonable.
