### PR TITLE
Duplicated snippet in ruby.snippets

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -1032,7 +1032,7 @@ snippet see
 	it { should ensure_exclusion_of :${1} }
 snippet sei
 	it { should ensure_inclusion_of :${1} }
-snippet sel
+snippet itsel
 	it { should ensure_length_of :${1} }
 snippet sva
 	it { should validate_acceptance_of :${1} }


### PR DESCRIPTION
after this commit of @babybeasimple : https://github.com/babybeasimple/vim-snippets/commit/e3e7ab1b45dc264c7aa5348a677371f3d83e80ab#L0R1036

``` bash
408| snippet sel
409|     select { |${1:e}| ${2} }
```

and

``` bash
1037| snippet sel
1038|     it { should ensure_length_of :${1} }
```

Renamed the latter to `itsel`. In fact, I would rename all specs snippets to
`it%xxx%`, so they don't block other names.
