### PR TITLE
Add erlang common_test testsuite snippet

### DIFF
--- a/snippets/erlang.snippets
+++ b/snippets/erlang.snippets
@@ -157,4 +157,194 @@ snippet gen_server
 	%%%===================================================================
 	%%% Internal functions
 	%%%===================================================================
+# common_test test_SUITE
+snippet testsuite
+	-module(${1:`vim_snippets#Filename('', 'my')`}).
+
+	-include_lib("common_test/include/ct.hrl").
+	
+	%% Test server callbacks
+	-export([suite/0, all/0, groups/0,
+		 init_per_suite/1, end_per_suite/1,
+		 init_per_group/2, end_per_group/2,
+		 init_per_testcase/2, end_per_testcase/2]).
+	
+	%% Test cases
+	-export([
+		]).
+	
+	%%--------------------------------------------------------------------
+	%% COMMON TEST CALLBACK FUNCTIONS
+	%%--------------------------------------------------------------------
+	
+	%%--------------------------------------------------------------------
+	%% Function: suite() -> Info
+	%%
+	%% Info = [tuple()]
+	%%   List of key/value pairs.
+	%%
+	%% Description: Returns list of tuples to set default properties
+	%%              for the suite.
+	%%
+	%% Note: The suite/0 function is only meant to be used to return
+	%% default data values, not perform any other operations.
+	%%--------------------------------------------------------------------
+	suite() ->
+	    [{timetrap,{minutes,10}}].
+	
+	%%--------------------------------------------------------------------
+	%% Function: init_per_suite(Config0) ->
+	%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+	%%
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding the test case configuration.
+	%% Reason = term()
+	%%   The reason for skipping the suite.
+	%%
+	%% Description: Initialization before the suite.
+	%%
+	%% Note: This function is free to add any key/value pairs to the Config
+	%% variable, but should NOT alter/remove any existing entries.
+	%%--------------------------------------------------------------------
+	init_per_suite(Config) ->
+	    Config.
+	
+	%%--------------------------------------------------------------------
+	%% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
+	%%
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding the test case configuration.
+	%%
+	%% Description: Cleanup after the suite.
+	%%--------------------------------------------------------------------
+	end_per_suite(_Config) ->
+	    ok.
+	
+	%%--------------------------------------------------------------------
+	%% Function: init_per_group(GroupName, Config0) ->
+	%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+	%%
+	%% GroupName = atom()
+	%%   Name of the test case group that is about to run.
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding configuration data for the group.
+	%% Reason = term()
+	%%   The reason for skipping all test cases and subgroups in the group.
+	%%
+	%% Description: Initialization before each test case group.
+	%%--------------------------------------------------------------------
+	init_per_group(_GroupName, Config) ->
+	    Config.
+	
+	%%--------------------------------------------------------------------
+	%% Function: end_per_group(GroupName, Config0) ->
+	%%               void() | {save_config,Config1}
+	%%
+	%% GroupName = atom()
+	%%   Name of the test case group that is finished.
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding configuration data for the group.
+	%%
+	%% Description: Cleanup after each test case group.
+	%%--------------------------------------------------------------------
+	end_per_group(_GroupName, _Config) ->
+	    ok.
+	
+	%%--------------------------------------------------------------------
+	%% Function: init_per_testcase(TestCase, Config0) ->
+	%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+	%%
+	%% TestCase = atom()
+	%%   Name of the test case that is about to run.
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding the test case configuration.
+	%% Reason = term()
+	%%   The reason for skipping the test case.
+	%%
+	%% Description: Initialization before each test case.
+	%%
+	%% Note: This function is free to add any key/value pairs to the Config
+	%% variable, but should NOT alter/remove any existing entries.
+	%%--------------------------------------------------------------------
+	init_per_testcase(_TestCase, Config) ->
+	    Config.
+	
+	%%--------------------------------------------------------------------
+	%% Function: end_per_testcase(TestCase, Config0) ->
+	%%               void() | {save_config,Config1} | {fail,Reason}
+	%%
+	%% TestCase = atom()
+	%%   Name of the test case that is finished.
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding the test case configuration.
+	%% Reason = term()
+	%%   The reason for failing the test case.
+	%%
+	%% Description: Cleanup after each test case.
+	%%--------------------------------------------------------------------
+	end_per_testcase(_TestCase, _Config) ->
+	    ok.
+	
+	%%--------------------------------------------------------------------
+	%% Function: groups() -> [Group]
+	%%
+	%% Group = {GroupName,Properties,GroupsAndTestCases}
+	%% GroupName = atom()
+	%%   The name of the group.
+	%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+	%%   Group properties that may be combined.
+	%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+	%% TestCase = atom()
+	%%   The name of a test case.
+	%% Shuffle = shuffle | {shuffle,Seed}
+	%%   To get cases executed in random order.
+	%% Seed = {integer(),integer(),integer()}
+	%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+	%%              repeat_until_any_ok | repeat_until_any_fail
+	%%   To get execution of cases repeated.
+	%% N = integer() | forever
+	%%
+	%% Description: Returns a list of test case group definitions.
+	%%--------------------------------------------------------------------
+	groups() ->
+	    [].
+	
+	%%--------------------------------------------------------------------
+	%% Function: all() -> GroupsAndTestCases | {skip,Reason}
+	%%
+	%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+	%% GroupName = atom()
+	%%   Name of a test case group.
+	%% TestCase = atom()
+	%%   Name of a test case.
+	%% Reason = term()
+	%%   The reason for skipping all groups and test cases.
+	%%
+	%% Description: Returns the list of groups and test cases that
+	%%              are to be executed.
+	%%--------------------------------------------------------------------
+	all() -> 
+	    [].
+	
+	
+	%%--------------------------------------------------------------------
+	%% TEST CASES
+	%%--------------------------------------------------------------------
+	
+	%%--------------------------------------------------------------------
+	%% Function: TestCase(Config0) ->
+	%%               ok | exit() | {skip,Reason} | {comment,Comment} |
+	%%               {save_config,Config1} | {skip_and_save,Reason,Config1}
+	%%
+	%% Config0 = Config1 = [tuple()]
+	%%   A list of key/value pairs, holding the test case configuration.
+	%% Reason = term()
+	%%   The reason for skipping the test case.
+	%% Comment = term()
+	%%   A comment about the test case that will be printed in the html log.
+	%%
+	%% Description: Test case function. (The name of it must be specified in
+	%%              the all/0 list or in a test case group for the test case
+	%%              to be executed).
+	%%--------------------------------------------------------------------
 


### PR DESCRIPTION
Adds snippet for a template of common_test test_SUITE file.

One of two standard ways to write tests in Erlang.

I was unsure if I should remove all the comments in the template, but I feel they are really helpful.
