### PR TITLE
Use the extends keyword

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -1,3 +1,6 @@
+# Include C snippets
+extends c
+
 ## STL Collections
 # std::array
 snippet array

--- a/snippets/eruby.snippets
+++ b/snippets/eruby.snippets
@@ -1,5 +1,8 @@
 # .erb and .rhmtl files
 
+# Include erubi-rails and HTML snippets
+extends eruby-rails,html
+
 # Includes html.snippets
 
 # Rails *****************************

--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -1,3 +1,6 @@
+# Include HTML snippets
+extends javascript
+
 # Some useful Unicode entities
 # Non-Breaking Space
 snippet nbs

--- a/snippets/mxml.snippets
+++ b/snippets/mxml.snippets
@@ -1,0 +1,2 @@
+# Include ActionScript snippets
+extends actionscript

--- a/snippets/objc.snippets
+++ b/snippets/objc.snippets
@@ -1,3 +1,6 @@
+# Include C snippets
+extends c
+
 # #import <...>
 snippet Imp
 	#import <${1:Cocoa/Cocoa.h}>${2}

--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -1,3 +1,6 @@
+# Include HTML and JavaScript snippets
+extends html,javascript
+
 snippet <?
 	<?php
 

--- a/snippets/ur.snippets
+++ b/snippets/ur.snippets
@@ -1,0 +1,2 @@
+# Include HTML and JavaScript snippets
+extends html,javascript

--- a/snippets/xhtml.snippets
+++ b/snippets/xhtml.snippets
@@ -1,0 +1,2 @@
+# Include HTML snippets
+extends html


### PR DESCRIPTION
I've just added support for an UltiSnips style extends keyword in .snippets files. It deprecates the scope aliases previously used, and will also increase compatibility with UltiSnips. This particular pull request simply translates the default scope aliases into the extends format. I make no claim either way whether or not these belong in the vim-snippets repository, but I thought I'd send it over anyway. :)
