### PR TITLE
Refactor go Snipmate snippet "if", so you can tab into if block body

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -79,7 +79,7 @@ snippet inf
 snippet if
 	if ${1:/* condition */} {
 		${2}
-	}${2}
+	}${3}
 # else snippet
 snippet el
 	else {


### PR DESCRIPTION
With this change, a user can `tab` from `/* condition */` to `/* code */` and out of the `if` block.

``` go
if /* condition */ {
  /* code */
}
```
