### PR TITLE
fix underline length

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -23,11 +23,11 @@ snippet ![:*
 	![${1:id}]: ${2:`@*`} "${3:title}"
 
 snippet ===
-	`repeat('=', strlen(getline(line(".") - 1)))`
+	`repeat('=', strlen(getline(line(".") - 1)) - strlen(getline('.')))`
 
 	${1}
 snippet ---
-	`repeat('-', strlen(getline(line(".") - 1)))`
+	`repeat('-', strlen(getline(line(".") - 1)) - strlen(getline('.')))`
 
 	${1}
 


### PR DESCRIPTION
if you're hasty and type more than three '='s/'-'s, the underline will be longer than the title above. To fix this we need to subtract the (remaining) length of the current line from the length of the title.
