### PR TITLE
Fix ruby `super_call` snippet

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -1075,4 +1075,4 @@ snippet isres
 snippet isresw
 	it { should respond_to(:${1}).with(${2}).arguments }
 snippet super_call
-      ${1:super_class}.instance_method(:${2:method}).bind(self).call
+	${1:super_class}.instance_method(:${2:method}).bind(self).call


### PR DESCRIPTION
There was no tab in the beginning of the line and snippet wasn't
working.

Edit: update to explain the problem in more details.
I'm on vim 7.4, using snippets with [vim-snipmate](https://github.com/garbas/vim-snipmate).
When I'm in a ruby file, all ruby snippets work fine. However, `super_call` does not work. I investigated a bit and it turns out `super_call` snippet had only spaces before the template (instead of a tab). This pull request fixes that.
