### PR TITLE
Go Variables

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -1,3 +1,8 @@
+# variables
+snippet v
+	${1} := ${2}
+snippet vr
+	var ${1} ${2} = ${3}
 # append
 snippet ap
 	append(${1:slice}, ${2:value})


### PR DESCRIPTION
Add snippets for declaring and initializing a single variable, both longhand and shorthand.

_v_
`f := "short"`

_vr_
`var a string = "initial"`

/cc @akrennmair @fatih @afolmert @gmile
