### PR TITLE
Ruby `pry` snippet inserts only one line

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -585,7 +585,6 @@ snippet debug
 	require 'ruby-debug'; debugger; true;
 snippet pry
 	require 'pry'; binding.pry
-
 #############################################
 # Rails snippets - for pure Ruby, see above #
 #############################################


### PR DESCRIPTION
Problem description: (vim 7.4, snipmate) ruby `pry` snippet inserts 2 lines instead of one. The purpose of other line is to be used as a document header margin (for source code readability).
I often use `pry`, and when you're frantically debugging, the last thing you want to have is unnecessary stuff in code.

In case we still need a one line header margin in source code for readability - we can put a comment char in the front of the line. That way there is space, and snipmate also inserts only one line. Please let me know if this needs to be updated..
