### PR TITLE
Fix html5 snippet indentation and meta tag.

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -281,16 +281,16 @@ snippet html5 "HTML5 Template"
 <!DOCTYPE html>
 <html>
 <head>
-    <title>${1}</title>
-    <meta charset="utf-8" />
+	<title>${1}</title>
+	<meta charset="utf-8">
 </head>
 <body>
-    <header>
-        ${2}
-    </header>
-    <footer>
-        ${4}
-    </footer>
+	<header>
+		${2}
+	</header>
+	<footer>
+		${4}
+	</footer>
 </body>
 </html>
 endsnippet


### PR DESCRIPTION
Replace spaces with tabs in the html5 snippet and fix the meta tag.
