### PR TITLE
Improve ruby `desc` snippet

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -957,7 +957,7 @@ snippet tctss
 #     Rspec snippets     #
 ##########################
 snippet desc
-	describe ${1:class_name} do
+	describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
 		${0}
 	end
 snippet descm


### PR DESCRIPTION
Instead of dummy text, first argument for `describe` becomes a class name derived from a spec file name. Example:
file: `some_class_spec.rb`
describe argument: `SomeClass`

This works pretty much the same as getting the class name for ruby `cla` snippets.
The only difference is that the idiomatic '_spec' is removed from spec file name, before converting to class name.

Let me know if more explanation or examples are needed!
