### PR TITLE
Ruby strf snippet

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -585,6 +585,8 @@ snippet debug
 	require 'ruby-debug'; debugger; true;
 snippet pry
 	require 'pry'; binding.pry
+snippet strf
+	strftime("${1:%Y-%m-%d %H:%M:%S %z}")${0}
 #############################################
 # Rails snippets - for pure Ruby, see above #
 #############################################


### PR DESCRIPTION
Ruby `strf` snippet adds a `Time` class formatting - the same as `Time.now` default output.
