### PR TITLE
Added install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,41 @@ This repository contains snippets files for various programming languages.
 It is community-maintained and many people have contributed snippet files and
 other improvements already.
 
+Installation
+============
+### Pathogen
+
+Install [garbas' fork](https://github.com/garbas/vim-snipmate) of the vim-snipmate plugin
+
+```
+$ cd ~/.vim/bundle
+$ git clone https://github.com/tomtom/tlib_vim.git
+$ git clone https://github.com/MarcWeber/vim-addon-mw-utils.git
+$ git clone https://github.com/garbas/vim-snipmate.git
+```
+
+Install vim-snippets
+
+```
+$ git clone https://github.com/honza/vim-snippets.git
+```
+
+### Vundler
+
+Install [garbas' fork](https://github.com/garbas/vim-snipmate) of the vim-snipmate plugin
+
+```
+Bundle "MarcWeber/vim-addon-mw-utils"
+Bundle "tomtom/tlib_vim"
+Bundle "garbas/vim-snipmate"
+```
+
+Install vim-snippets
+
+```
+Bundle "honza/vim-snippets"
+```
+
 Contents
 ========
 


### PR DESCRIPTION
Just a personal thing but I like it when the install instructions for pathogen and vundler are at the top and easy to follow. I added them for you. I hope this makes it easier for others to install and give vim-snippets a try!

I also had some issues installing this plugin with the legacy snipmate.vim plugin so I used garbas' fork 
