### PR TITLE
Add define snippet with no block.

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -50,6 +50,9 @@ snippet case
 		${0}
 	end
 
+snippet df
+	def ${1:name}, do: {2}
+
 snippet def
 	def ${1:name} do
 		${0}


### PR DESCRIPTION
Basically, I just wanted a `def` snippet without a block since that is often quite useful when you for instance do pattern matching. 
