### PR TITLE
Fix stupid typo.

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -51,7 +51,7 @@ snippet case
 	end
 
 snippet df
-	def ${1:name}, do: {2}
+	def ${1:name}, do: ${2}
 
 snippet def
 	def ${1:name} do


### PR DESCRIPTION
I just discovered that I forget the $ sign when I added the snippet for `def`. Here's a fix.
