### PR TITLE
remove border attribute for table tag

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -749,15 +749,15 @@ snippet summary
 snippet sup
 	<sup>${0}</sup>
 snippet table
-	<table border="${1:0}">
+	<table>
 		${0}
 	</table>
 snippet table.
-	<table class="${1}" border="${2:0}">
+	<table class="${1}">
 		${0}
 	</table>
 snippet table#
-	<table id="${1}" border="${2:0}">
+	<table id="${1}">
 		${0}
 	</table>
 snippet tbody


### PR DESCRIPTION
Hi,

The "border" attribute for table tag is deprecated in HTML 5 (and not recommanded in HTML 4).
