### PR TITLE
Remove remaining of old block of code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,6 @@ let g:snipMate.scope_aliases = {}
 let g:snipMate.scope_aliases['ruby'] = 'ruby,ruby-rails,ruby-1.9'
 ```
 
-            \ 'ruby'    : {'filetypes': ["ruby", "ruby-rails", "ruby-1.9"] },
-```
-
 If it happens that you work on a project requiring ruby-1.8 snippets instead,
 consider using vim-addon-local-vimrc and override the filetypes.
 


### PR DESCRIPTION
After @MarcWeber last commit, we have this. I'm not sure if the last part can be removed. If not, please close this.

``` vim
let g:snipMate = {}
let g:snipMate.scope_aliases = {}
let g:snipMate.scope_aliases['ruby'] = 'ruby,ruby-rails,ruby-1.9'
```

```
        \ 'ruby'    : {'filetypes': ["ruby", "ruby-rails", "ruby-1.9"] },
```

```

As you can see it's interpreting this comment as block of code
```
