### PR TITLE
HTML form : change get to post, remove accept-charset

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -361,15 +361,15 @@ snippet footer#
 		${0}
 	</footer>
 snippet form
-	<form action="${1}" method="${2:post}" accept-charset="utf-8">
+	<form action="${1}" method="${2:post}">
 		${0}
 	</form>
 snippet form.
-	<form class="${1}" action="${2}" method="${3:post}" accept-charset="utf-8">
+	<form class="${1}" action="${2}" method="${3:post}">
 		${0}
 	</form>
 snippet form#
-	<form id="${1}" action="${2}" method="${3:post}" accept-charset="utf-8">
+	<form id="${1}" action="${2}" method="${3:post}">
 		${0}
 	</form>
 snippet h1


### PR DESCRIPTION
Two small changes in HTML :
- form : change the default method to post instead of get.
- form : remove the accept-charset attribut, which must be unused is most cases.
