### PR TITLE
Fix PHP getter and setter UltiSnips snippet

### DIFF
--- a/UltiSnips/php.snippets
+++ b/UltiSnips/php.snippets
@@ -120,19 +120,19 @@ endsnippet
 
 snippet gs "PHP Class Getter Setter" b
 /*
- * Getter for ${1/(\w+)\s*;/$1/}
+ * Getter for $1
  */
-public function get${1/(\w+)\s*;/\u$1/}()
+public function get${1/\w+\s*/\u$0/}()
 {
-	return $this->${1/(\w+)\s*;/$1/};$2
+	return $this->$1;$2
 }
 
 /*
- * Setter for ${1/(\w+)\s*;/$1/}
+ * Setter for $1
  */
-public function set${1/(\w+)\s*;/\u$1/}($${1/(\w+)\s*;/$1/})
+public function set${1/\w+\s*/\u$0/}($$1)
 {
-	$this->${1/(\w+)\s*;/$1/} = $${1/(\w+)\s*;/$1/};$3
+	$this->$1 = $$1;$3
 	${4:return $this;}
 }
 $0


### PR DESCRIPTION
Using latest UltiSnips on vim 7.4. When trying to expand the PHP getter and setter snippet (gs), UltiSnips throws the following error:

```
An error occured. This is either a bug in UltiSnips or a bug in a
snippet definition. If you think this is a bug, please report it to
https://github.com/SirVer/ultisnips/issues/new.

Following is the full stack trace:
Traceback (most recent call last):
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 53, in wrapper
    return func(self, *args, **kwds)
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 117, in expand
    if not self._try_expand():
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 520, in _try_expand
    self._do_snippet(snippet, before)
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 490, in _do_snippet
    self._cs.find_parent_for_new_to(start), start, end)
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/definition/_base.py", line 220, in launch
    self.instantiate(snippet_instance, initial_text, indent)
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/definition/ultisnips.py", line 13, in instantiate
    return parse_and_instantiate(snippet_instance, initial_text, indent)
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/parsing/ultisnips.py", line 53, in parse_and_instantiate
    _create_transformations(all_tokens, seen_ts)
  File "/home/jorge/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/parsing/ultisnips.py", line 42, in _create_transformations
    % token.number)
RuntimeError: Tabstop 1 is not known but is used by a Transformation
```

This snippet applied some complex transformations on $1, which the individual getter and setter snippets don't use, so I have copied both snippets onto this one to make it work as expected.
