### PR TITLE
Allow java else/elif to be expanded mid line.

### DIFF
--- a/UltiSnips/java.snippets
+++ b/UltiSnips/java.snippets
@@ -173,13 +173,13 @@ default:
 	$0
 endsnippet
 
-snippet elif "else if" b
+snippet elif "else if"
 else if ($1)`!p nl(snip)`{
 	$0
 }
 endsnippet
 
-snippet /el(se)?/ "else" br
+snippet /el(se)?/ "else" r
 else`!p nl(snip)`{
 	$0
 }


### PR DESCRIPTION
A common style of writing else and else if in java is like:

``` java
if (...) {
  ...
} else if (...) {
  ...
} else {
  ...
}
```
