### PR TITLE
Fix java setter method param case, remove return.

### DIFF
--- a/UltiSnips/java.snippets
+++ b/UltiSnips/java.snippets
@@ -25,9 +25,11 @@ def getArgs(group):
 	return [i.split(" ") for i in word.findall(group) ]
 
 def camel(word):
+	if not word: return ''
 	return word[0].upper() + word[1:]
 
 def mixedCase(word):
+	if not word: return ''
 	return word[0].lower() + word[1:]
 
 endglobal


### PR DESCRIPTION
The paramater was keeping the case of the setter name.  It should
have been lowercased.  The other uses of the paramter were already
lowercased correctly.

There should also not be a return statement in a void method.
