### PR TITLE
Add support for rnoweb filetype

### DIFF
--- a/UltiSnips/rnoweb.snippets
+++ b/UltiSnips/rnoweb.snippets
@@ -1,0 +1,3 @@
+priority -50
+
+extends tex


### PR DESCRIPTION
Rnoweb is a filetype that combines LaTeX and R. It's used by systems like Sweave and Knitr.
