### PR TITLE
Fixed #335 - django snippet fix model save method

### DIFF
--- a/snippets/django.snippets
+++ b/snippets/django.snippets
@@ -84,7 +84,7 @@ snippet model
 		def __unicode__(self):
 			${5}
 
-		def save(self, force_insert=False, force_update=False):
+		def save(self, *args, **kwargs):
 			${6}
 
 		@models.permalink


### PR DESCRIPTION
According django documentation
https://docs.djangoproject.com/en/dev/topics/db/models/#overriding-predefined-model-methods
