### PR TITLE
add def overloading method (dol)

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -201,3 +201,6 @@ snippet epydoc
 
 	@raise e: ${0: Description}
 	"""
+snippet dol
+	def ${1:__init__}(self, *args, **kwargs):
+	    super(${0:ClassName}, self).$1(*args, **kwargs)


### PR DESCRIPTION
I add it because I use it many times a day -not only for the `__init__` method-

this snippet is very useful to me, no need to call super and handle all args and kwargs, and less typo errors
