### PR TITLE
key word argument get (kwg)

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -206,3 +206,5 @@ snippet dol
 	    super(${0:ClassName}, self).$1(*args, **kwargs)
 snippet kwg
 	self.${1:var_name} = kwargs.get('$1', ${2:None})
+snippet lkwg
+	${1:var_name} = kwargs.get('$1', ${2:None})


### PR DESCRIPTION
a common usage -especially when overloading class- is to use `*args` array and `**kwargs` dictionary to handle method's arguments

this snippet is usefull to quickly get the argument value from the keyword arguments dictionary -kwargs- or setting a default value
