### PR TITLE
Add message and field snippets for proto filetype

### DIFF
--- a/UltiSnips/proto.snippets
+++ b/UltiSnips/proto.snippets
@@ -1,7 +1,6 @@
 priority -50
 
 global !p
-
 from vimsnippets import complete
 
 FIELD_TYPES = [
@@ -20,7 +19,6 @@ FIELD_TYPES = [
 	'bool',
 	'string',
 	'bytes']
-
 endglobal
 
 snippet mess "Proto message" b


### PR DESCRIPTION
Adds some basic snippets for Google protocol buffers.

See https://developers.google.com/protocol-buffers/docs/proto for details on protocol buffer syntax.
