### PR TITLE
Add angular snippets.

### DIFF
--- a/UltiSnips/javascript_angular.snippets
+++ b/UltiSnips/javascript_angular.snippets
@@ -12,8 +12,14 @@ beforeEach(inject(function($1) {
 }));
 endsnippet
 
-snippet acon "angular config" i
+snippet aconf "angular config" i
 config(function($1) {
+	$0
+});
+endsnippet
+
+snippet acont "angular controller" i
+controller('${1:name}', function($2) {
 	$0
 });
 endsnippet


### PR DESCRIPTION
Add two jasmine snippets for use with angular that prepopulate the
"it" and "before" functions with "inject".  Add an angular config
snippet.

I wasn't really sure how to name these.  My thinking for the jasmine snippets was to use the normal name for the snippet, appending an "i" to stand for "inject".

If there would be a better way to name any of these I would be happy to change them.
