### PR TITLE
Adds brackets to RSpec's let()

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -1030,9 +1030,9 @@ snippet aft
 		${0}
 	end
 snippet let
-	let(:${1:object}) ${0}
+	let(:${1:object}) { ${0} }
 snippet let!
-	let!(:${1:object}) ${0}
+	let!(:${1:object}) { ${0} }
 snippet subj
 	subject { ${0} }
 snippet s.


### PR DESCRIPTION
Guys, after using the `let` snippet, I have to add `{ }` all the time. Do you think it makes sense to add it by default here?
