### PR TITLE
Inline code and code block snippets - Create pandoc.snippets

### DIFF
--- a/UltiSnips/markdown.snippets
+++ b/UltiSnips/markdown.snippets
@@ -39,7 +39,7 @@ snippet img "Image"
 ![${1:pic alt}](${2:path}${3/.+/ "/}${3:opt title}${3/.+/"/})$0
 endsnippet
 
-snippet ilc "Inline Code"
+snippet ilc "Inline Code" i
 \`$1\`$0
 endsnippet
 

--- a/UltiSnips/pandoc.snippets
+++ b/UltiSnips/pandoc.snippets
@@ -1,1 +1,3 @@
+priority -49
+
 extends markdown


### PR DESCRIPTION
Hi there!

I added to new snippets to the `markdown.snippets` to be able to write faster inline or block code:
-     `snippet ilc "Inline Code"`
-     `snippet cbl "Codeblock" b`

I also created a `pandoc.snippets` files for those who are using the Pandoc Flavor of Markdown. Basically it is just a copy of the `markdown.snippets` file.

Hope this can help! :)
