### PR TITLE
Fix the "fun" snippet definition

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -93,9 +93,9 @@ snippet fn
 	fn(${1:args}) -> ${0} end
 
 snippet fun
-        function do
-        	${0}
-        end
+	function do
+		${0}
+	end
 
 snippet mdoc
 	@moduledoc """


### PR DESCRIPTION
At line 96, the definition for the snippet "fun" was using spaces instead of tabs
