### PR TITLE
update vim snippet for plugin definition with Vundle.vim

### DIFF
--- a/snippets/vim.snippets
+++ b/snippets/vim.snippets
@@ -46,5 +46,7 @@ snippet au
 		" this one is which you're most likely to use?
 		autocmd ${2:BufRead,BufNewFile} ${3:*.ext,*.ext3|<buffer[=N]>} ${0}
 	augroup end
-snippet bun
-	Bundle '${0}'
+snippet bun Vundle.vim Plugin definition
+	Plugin '${0}'
+snippet plug Vundle.vim Plugin definition
+	Plugin '${0}'


### PR DESCRIPTION
Vundle has changed it's public API.  The Bundle command is deprecated.  See
https://github.com/gmarik/Vundle.vim/blob/v0.10/doc/vundle.txt#L372
