### PR TITLE
Replace spaces with tabs to avoid Python syntax error

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -89,18 +89,18 @@ snippet AGPL3
 	${1:one line to give the program's name and a brief description.}
 	Copyright (C) `strftime("%Y")` ${2:copyright holder}
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as
+	published by the Free Software Foundation, either version 3 of the
+	License, or (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 	${0}
 snippet BSD2


### PR DESCRIPTION
Fix a Python syntax bug introduced by the recent commit below:

https://github.com/honza/vim-snippets/commit/1eeef032d35b3ebb9c61f984320fa5999f08a110

Without fix, the first attempt to auto-complete will throw a Python syntax error and show an error window.
