### PR TITLE
Add HTML `ac` Anchor from Clipboard.

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -147,6 +147,8 @@ snippet a:ext
 	<a href="http://${1:example.com}">${0:$1}</a>
 snippet a:mail
 	<a href="mailto:${1:joe@example.com}?subject=${2:feedback}">${0:email me}</a>
+snippet ac
+	<a href="`@+`">${0:`@+`}</a>
 snippet abbr
 	<abbr title="${1}">${0}</abbr>
 snippet address


### PR DESCRIPTION
The most common source of anchors is the clipboard after copying from the browser.
