### PR TITLE
Remove backslash that falsely escapes dollar (placeholder)

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -1,7 +1,7 @@
 #PREAMBLE
 #newcommand
 snippet nc \newcommand
-	\newcommand{\${1:cmd}}[${2:opt}]{${3:realcmd}} ${0}
+	\newcommand{\\${1:cmd}}[${2:opt}]{${3:realcmd}} ${0}
 #usepackage
 snippet up \usepackage
 	\usepackage[${1:options}]{${2:package}} ${0}


### PR DESCRIPTION
The backslash would escape a dollar that should be used by the snippet engine
for placeholders.  I was not able to come up with a better solution to keep
the backslash in the expanded snippet.  At least not with snipmate.  With
ultisnips one could use a backslash to escape the backslash but the snippet
for "nc" in Ultisnips/tex.snippets does not seem to override the one in
"snippets/tex.snippets".

What do you think should be done?
1. open an isse for snipmate about backslash before dollar
2. open an issue for Ultisnips about overrideing snippets from snipmate
3. something else?
