### PR TITLE
Fix and improve rst_char_len

### DIFF
--- a/UltiSnips/rst.snippets
+++ b/UltiSnips/rst.snippets
@@ -77,7 +77,7 @@ def check_file_exist(rst_path, relative_path):
 try:
 	rst_char_len = vim.strwidth  # Requires Vim 7.3+
 except AttributeError:
-	from unicodedata import east_asian_width  # Requires Python 2.4+
+	from unicodedata import east_asian_width
 	def rst_char_len(s):
 		"""Return the required over-/underline length for s."""
 		result = 0


### PR DESCRIPTION
The previously used regex was plainly wrong (see #394). This solution should be more solid.

Tests with Python 3.4.1 (both manually defined `rst_char_len` and `vim.strwidth` yield the same output; only results shown):

``` rst
****
jkfö
****

*************
란 무엇입니까
*************

**
我
**

Section name
============
```
