### PR TITLE
Improve compatibility of rst snippets with Python 3

### DIFF
--- a/UltiSnips/rst.snippets
+++ b/UltiSnips/rst.snippets
@@ -87,7 +87,7 @@ def	make_items(times, leading='+'):
 	times = int(times)
 	if leading == 1:
 		msg = ""
-		for x in xrange(1, times+1):
+		for x in range(1, times+1):
 			msg += "%s. Item\n" % x
 		return msg
 	else:


### PR DESCRIPTION
This fixes the `ol` snippet which uses the `xrange()` builtin and the `em` and `st` (strong) snippets, which use the `has_cjk()` function.
