### PR TITLE
Move the RSpec snippets from rails.snippets to ruby.snippets.

### DIFF
--- a/snippets/rails.snippets
+++ b/snippets/rails.snippets
@@ -411,56 +411,6 @@ snippet tctss
 ##########################
 #     Rspec snippets     #
 ##########################
-snippet desc
-	describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
-		${0}
-	end
-snippet descm
-	describe '${1:#method}' do
-		${0:pending 'Not implemented'}
-	end
-snippet cont
-	context '${1:message}' do
-		${0}
-	end
-snippet bef
-	before :${1:each} do
-		${0}
-	end
-snippet aft
-	after :${1:each} do
-		${0}
-	end
-snippet let
-	let(:${1:object}) { ${0} }
-snippet let!
-	let!(:${1:object}) { ${0} }
-snippet subj
-	subject { ${0} }
-snippet s.
-	subject.${0:method}
-snippet spec
-	specify { subject.${0} }
-snippet exp
-	expect(${1:object}).to ${0}
-snippet expb
-	expect { ${1:object} }.to ${0}
-snippet experr
-	expect { ${1:object} }.to raise_error ${2:StandardError}, /${0:message_regex}/
-snippet shared
-	shared_examples ${0:'shared examples name'}
-snippet ibl
-	it_behaves_like ${0:'shared examples name'}
-snippet it
-	it '${1:spec_name}' do
-		${0}
-	end
-snippet its
-	its(:${1:method}) { should ${0} }
-snippet is
-	it { should ${0} }
-snippet isn
-	it { should_not ${0} }
 #ShouldaMatchers#ActionController
 snippet isfp
 	it { should filter_param :${0:key} }

--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -656,3 +656,56 @@ snippet msend
 	must_send [ ${1:what}, :${2:method}, ${3:args} ]
 snippet mthrow
 	-> { throw :${1:error} }.must_throw :${2:error}
+##########################
+#     Rspec snippets     #
+##########################
+snippet desc
+	describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
+		${0}
+	end
+snippet descm
+	describe '${1:#method}' do
+		${0:pending 'Not implemented'}
+	end
+snippet cont
+	context '${1:message}' do
+		${0}
+	end
+snippet bef
+	before :${1:each} do
+		${0}
+	end
+snippet aft
+	after :${1:each} do
+		${0}
+	end
+snippet let
+	let(:${1:object}) { ${0} }
+snippet let!
+	let!(:${1:object}) { ${0} }
+snippet subj
+	subject { ${0} }
+snippet s.
+	subject.${0:method}
+snippet spec
+	specify { subject.${0} }
+snippet exp
+	expect(${1:object}).to ${0}
+snippet expb
+	expect { ${1:object} }.to ${0}
+snippet experr
+	expect { ${1:object} }.to raise_error ${2:StandardError}, /${0:message_regex}/
+snippet shared
+	shared_examples ${0:'shared examples name'}
+snippet ibl
+	it_behaves_like ${0:'shared examples name'}
+snippet it
+	it '${1:spec_name}' do
+		${0}
+	end
+snippet its
+	its(:${1:method}) { should ${0} }
+snippet is
+	it { should ${0} }
+snippet isn
+	it { should_not ${0} }


### PR DESCRIPTION
Since many of the RSpec snippets are extremely useful in non-Rails projects as well, I think it would be a good idea to move them to the `ruby.snippets` file instead. The RSpec snippets that are Rails-specific are still kept in the `rails.snippets` file.
