### PR TITLE
Extend html in eruby for UltiSnips

### DIFF
--- a/UltiSnips/eruby.snippets
+++ b/UltiSnips/eruby.snippets
@@ -1,3 +1,5 @@
+extends html
+
 priority -50
 
 # TextMate added these variables to cope with changes in ERB handling


### PR DESCRIPTION
The UltiSnips version of the eruby (erb) templates did not extend html. This small patch `extends html` at the top of the file so that all of the html snippets work inside of erb templates.
