### PR TITLE
Add snippets for requirejs module definitions for coffee- and javascript

### DIFF
--- a/snippets/coffee/requirejs_coffee.snippets
+++ b/snippets/coffee/requirejs_coffee.snippets
@@ -1,0 +1,11 @@
+snippet def
+  define ["${1:#dependencies1}"], (${2:#dependencies2}) ->
+    ${0:TARGET}
+
+snippet defn
+  define "${1:#name}", ["${2:#dependencies1}"], (${3:#dependencies2}) ->
+    ${0:TARGET}
+
+snippet reqjs
+  require ["${1:#dependencies1}"], (${2:#dependencies2}) ->
+    ${0:TARGET}

--- a/snippets/javascript/javascript-requirejs.snippets
+++ b/snippets/javascript/javascript-requirejs.snippets
@@ -1,0 +1,14 @@
+snippet def
+  define(["${1:#dependencies1}"], function (${2:#dependencies2}) {
+    return ${0:TARGET};
+  });
+
+snippet defn
+  define("${1:#name}", ["${2:#dependencies1}"], function (${3:#dependencies2}) {
+    return ${0:TARGET};
+  });
+
+snippet reqjs
+  require(["${1:#dependencies1}"], function (${2:#dependencies2}) {
+    return ${0:TARGET};
+  });


### PR DESCRIPTION
The snippet that generates a require block is called `reqjs` in order to
have no collision with the existing `req` snippet.
