### PR TITLE
Add vim modeline snippets

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -120,4 +120,14 @@ vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
 no sea takimata sanctus est Lorem ipsum dolor sit amet.
 endsnippet
 
+##########################
+# VIM MODELINE GENERATOR #
+##########################
+# See advice on `:help 'tabstop'` for why these values are set. Uses second
+# modeline form ('set') to work in languages with comment terminators
+# (/* like C */).
+snippet modeline "Vim modeline"
+vim`!v ':set '. (&expandtab ? printf('et sw=%i ts=%i', &sw, &ts) : printf('noet sts=%i sw=%i ts=%i', &sts, &sw, &ts)) . (&tw ? ' tw='. &tw : '') . ':'`
+endsnippet
+
 # vim:ft=snippets:

--- a/UltiSnips/help.snippets
+++ b/UltiSnips/help.snippets
@@ -29,4 +29,9 @@ ${1:SubSubsection}:`!p snip.rv = sec_title(snip, t)`
 $0
 endsnippet
 
+# For vim help, follow the same settings as the official docs.
+snippet modeline "Vim help modeline"
+ `!v 'vim'`:tw=78:ts=8:ft=help:norl:
+endsnippet
+
 # vim:ft=snippets:


### PR DESCRIPTION
Add an 'all' and a 'help' snippet for vim modelines.

The 'all' snippet implements the advice in tabstop's docs about setting
softtabstop when using noexpandtab what other variables (expandtab,
shiftwidth, and tabstop) to set. It sets these variables to their
current values.

Vim supports two forms of modelines, but only the second (that includes
the 'set') works in languages with comment terminators (/\* like C */).

The 'help' snippet uses exactly what vim help files use (including the
leading space -- I expect users will insert the modeline at the start of
a line).

Does some unnecessary interpolation ('set' and 'vim') to prevent vim
from interpreting the snippet definition as a modeline for the snippets
file.
