### PR TITLE
Avoid collision with print_r snippet

### DIFF
--- a/UltiSnips/php.snippets
+++ b/UltiSnips/php.snippets
@@ -240,8 +240,8 @@ public function __construct(${1:$dependencies})
 $0
 endsnippet
 
-snippet prv "Dumb debug helper in HTML"
-echo '<pre>' . var_export($1, 1) . '</pre>';$0
+snippet ve "Dumb debug helper in HTML"
+    echo '<pre>' . var_export($1, 1) . '</pre>';$0
 endsnippet
 
 snippet pc "Dumb debug helper in cli"


### PR DESCRIPTION
I realize that there is a collision between names. 

I think the naming is better in this way. What do you think?
