### PR TITLE
Modify js prototype and add node snippets

### DIFF
--- a/snippets/javascript/javascript.node.snippets
+++ b/snippets/javascript/javascript.node.snippets
@@ -1,0 +1,50 @@
+# module exports
+snippet ex
+	module.exports = ${1};
+# require
+snippet re
+	var ${1} = require("${2:module_name}");
+# EventEmitter
+snippet on
+	on('${1:event_name}', function(${2:stream}) {
+	  ${3}
+	});
+snippet emit
+	emit('${1:event_name}', ${2:args});
+snippet once
+	once('${1:event_name}', function(${2:stream}) {
+	  ${3}
+	});
+# http. User js function snippet as handler
+snippet http
+	http.createServer(${1:handler}).listen(${2:port_number});
+# net 
+snippet net
+	net.createServer(function(${1:socket}){
+		${1}.on('data', function('data'){
+		  ${2}
+		]});
+		${1}.on('end', function(){
+		  ${3}
+		});
+	}).listen(${4:8124});
+# Stream snippets
+snippet p
+	pipe(${1:stream})${2}
+# Express snippets
+snippet eget
+	${1:app}.get('${2:route}', ${3:handler});
+snippet epost
+	${1:app}.post('${2:route}', ${3:handler});
+snippet eput
+	${1:app}.put('${2:route}', ${3:handler});
+snippet edel
+	${1:app}.delete('${2:route}', ${3:handler});
+# process snippets
+snippet stdin
+	process.stdin
+snippet stdout
+	process.stdout
+snippet stderr
+	process.stderr
+

--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -1,7 +1,6 @@
-# Prototype
+# prototype
 snippet proto
-	${1:class_name}.prototype.${2:method_name} =
-	function(${3:first_argument}) {
+	${1:class_name}.prototype.${2:method_name} = function(${3:first_argument}) {
 		${0:// body...}
 	};
 # Function
@@ -11,12 +10,12 @@ snippet fun
 	}
 # Anonymous Function
 snippet f
-	function (${1}) {
+	function(${1}) {
 		${0}
 	}
 # Immediate function
 snippet (f
-	(function (${1}) {
+	(function(${1}) {
 		${0}
 	}(${2}));
 # if


### PR DESCRIPTION
I rarely see any js code where the function being added to the prototype is on a new line so I moved it to the same one.

I've also added node snippets that cover very common actions such as requiring modules or exporting from a module. I decided to leave out most callbacks from the snippets because they can be created by tabbing through until the `handler` and using the `f` snippet to create a new anonymous function. 

It's nitpicking but I've also removed the spaces before the braces in anonymous functions as this seems to be a convention adopted by the js community. See [here](https://github.com/airbnb/javascript#functions) and [here](http://contribute.jquery.org/style-guide/js/).
