### PR TITLE
README improvements: md style, typos, fix links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Snipmate & UltiSnip Snippets
+snipMate & UltiSnip Snippets
 ============================
 
 This repository contains snippets files for various programming languages.
@@ -9,7 +9,7 @@ other improvements already.
 Contents
 --------
 
-- `snippets/*`: snippets using snipmate format
+- `snippets/*`: snippets using snipMate format
 - `UltiSnips/*`: snippets using UltiSnips format
 
 Snippet engines supporting vim-snippets
@@ -28,8 +28,8 @@ snippets by typing the name of a snippet hitting the expansion mapping.
 - [github.com/drmingdrmer/xptemplate](https://github.com/drmingdrmer/xptemplate):
   Totally different syntax, does not read snippets contained in this file, but
   it is also very powerful. It does not support vim-snippets (just listing it
-  here for completness)
- 
+  here for completeness)
+
 There tries to be a more comprehensive list (which still is incomplete) here:
 http://vim-wiki.mawercer.de/wiki/topic/text-snippets-skeletons-templates.html
 
@@ -45,16 +45,15 @@ If you have VimL only (vim without python support) your best option is using
 [garbas/vim-snipmate](https://github.com/garbas/vim-snipmate) and cope with the
 minor bugs found in the engine.
 
+Q: Should "snipMate be deprecated in favour of UltiSnips"?
 
-Q: Should "snipmate be deprecated in favour of UltiSnips"?
-
-A: No, because snimpate is VimL, and UltiSnips requires Python.
+A: No, because snipMate is VimL, and UltiSnips requires Python.
 Some people want to use snippets without having to install Vim with Python
-support. Yes - this sucks. 
+support. Yes - this sucks.
 
 One solution would be: Use snippets if they are good enough, but allow overriding them
 in UltiSnips. This would avoid most duplication while still serving most users.
-AFAIK there is a nested-placeholder branch for snipmate too. snipmate is still
+AFAIK there is a nested-placeholder branch for snipMate too. snipMate is still
 improved by Adnan Zafar. So maybe time is not ready to make a final decision yet.
 
 [github issue/discussion](https://github.com/honza/vim-snippets/issues/363)
@@ -69,10 +68,10 @@ repetitive information everywhere.
 
 *Recommended way:*
 [vim-addon-manager](https://github.com/MarcWeber/vim-addon-manager) (because Marc Weber wrote it for exactly
-this reason, it supports simple dependency management). Eg you're done by this
-line in your .vimrc:
+this reason, it supports simple dependency management). E.g. you're done by this
+line in your `.vimrc`:
 
-```
+```vim
 " assuming you want to use snipmate snippet engine
 ActivateAddons vim-snippets snipmate
 ```
@@ -80,16 +79,17 @@ ActivateAddons vim-snippets snipmate
 [vim-pi](https://bitbucket.org/vimcommunity/vim-pi/issue/90/we-really-need-a-web-interface)
 Is the place to discuss plugin managers and repository resources.
 
-About how to install snipate see [snipmate@garbas](https://github.com/garbas/vim-snipmate)
+About how to install snipMate see [snipmate@garbas](https://github.com/garbas/vim-snipmate)
 
 (Bundle, Pathogen, git clone - keywords to make people find this link by ctrl-f search)
-I know that I should be reading the docs of the snippet engine, just let me copy paste into my .vimrc:
+I know that I should be reading the docs of the snippet engine, just let me copy paste into my `.vimrc`:
 [See this pull request](https://github.com/honza/vim-snippets/pull/307/files).
 
 TROUBLE
 =======
-If you still have trouble getting this to work create a github ticket, ask on
-irc or the mailinglist.
+
+If you still have trouble getting this to work create a GitHub ticket, ask on
+IRC or the mailing list.
 
 Policies / for contributors
 ---------------------------
@@ -105,7 +105,8 @@ el  : else ..
 wh  : while (cond) ...
 ```
 
-Don't add useless placeholder default texts like
+Don't add useless placeholder default texts like:
+
 ```
 if (${1:condition}){
   ${2:some code here}
@@ -119,7 +120,7 @@ if (${1}){
 }
 ```
 
-Exception: Functions which are used less often, such as Vim's matchall(), matchstr()
+Exception: Functions which are used less often, such as Vim's `matchall()`, `matchstr()`
 functions which case hints may be helpful to remember order. In the VimL case
 get vim-dev plugin which has function completion
 
@@ -140,22 +141,22 @@ on merging should be done (dropping duplicates etc). Also see engines section ab
 
 Related repositories
 --------------------
+
 We also encourage people to maintain sets of snippets for particular use cases
 so that all users can benefit from them.  People can list their snippet repositories here:
 
-     * https://github.com/rbonvall/snipmate-snippets-bib (snippets for BibTeX files)
-     * https://github.com/sudar/vim-arduino-snippets (snippets for Arduino files)
-     * https://github.com/zedr/zope-snipmate-bundle.git (snippets for Python, TAL and ZCML)
-     * https://github.com/bonsaiben/bootstrap-snippets (snippets for Twitter Bootstrap markup, in HTML and Haml)
+* https://github.com/rbonvall/snipmate-snippets-bib (snippets for BibTeX files)
+* https://github.com/sudar/vim-arduino-snippets (snippets for Arduino files)
+* https://github.com/zedr/zope-snipmate-bundle.git (snippets for Python, TAL and ZCML)
+* https://github.com/bonsaiben/bootstrap-snippets (snippets for Twitter Bootstrap markup, in HTML and Haml)
 
-Installation using VAM: "github:rbonvall/snipmate-snippets-bib"
+Installation using VAM: https://github.com/MarcWeber/vim-addon-manager
 
 Future - ideas - examples
 -------------------------
 
 [overview snippet engines](http://vim-wiki.mawercer.de/wiki/topic/text-snippets-skeletons-templates.html)
 If you have ideas you can add them to that list of "snippet engine features by example".
-
 
 Historical notes
 ----------------
@@ -166,15 +167,15 @@ unfortunately abandoned the project. [Rok Garbas][3] is now maintaining a
 
 Versions / dialects / ..
 ========================
+
 There are some issues, such as newer language versions may require other
 snippets than older. If this exists we currently recommend doing this:
 
-add snippets/ruby.snippets (common snippets)
-add snippets/ruby-1.8.snippets (1.8 only)
-add snippets/ruby-1.9.snippets (1.9 only)
+* add snippets/ruby.snippets (common snippets)
+* add snippets/ruby-1.8.snippets (1.8 only)
+* add snippets/ruby-1.9.snippets (1.9 only)
 
-then configure github.com/garbas/vim-snipmate this way:
-
+then configure https://github.com/garbas/vim-snipmate this way:
 
 ```vim
 let g:snipMate = {}
@@ -183,16 +184,17 @@ let g:snipMate.scope_aliases['ruby'] = 'ruby,ruby-rails,ruby-1.9'
 ```
 
 If it happens that you work on a project requiring ruby-1.8 snippets instead,
-consider using vim-addon-local-vimrc and override the filetypes.
+consider using `vim-addon-local-vimrc` and override the filetypes.
 
 Well - of course it may not make sense to create a new file for each
 ruby-library-version triplet. Sometimes postfixing a name such as
 
-    migrate_lib_20_down
-    migrate_lib_20_up
+```
+migrate_lib_20_down
+migrate_lib_20_up
+```
 
 will do it then if syntax has changed.
-
 
 Language maintainers
 --------------------
@@ -218,7 +220,6 @@ License
 
 Just as the original snipMate plugin, all the snippets are licensed under the
 terms of the MIT license.
-
 
 [1]: http://github.com/garbas/vim-snipmate
 [2]: http://github.com/msanders


### PR DESCRIPTION
- consistent blank lines
- spelling, in particular capitalization of proper nouns
- surround filenames and inline code with backticks

Standardization points taken from http://www.cirosantilli.com/markdown-styleguide/  and adapted to the current style.
