### PR TITLE
Rename node p to pipe.

### DIFF
--- a/snippets/javascript/javascript.node.snippets
+++ b/snippets/javascript/javascript.node.snippets
@@ -29,7 +29,7 @@ snippet net
 		});
 	}).listen(${4:8124});
 # Stream snippets
-snippet p
+snippet pipe
 	pipe(${1:stream})${2}
 # Express snippets
 snippet eget


### PR DESCRIPTION
Otherwise, conflicts with p for paragraph in html with default settings, as Js snippets are also loaded in HTML by default.

If anyone knows how to prevent any of the node maps from being loaded in HTML by default, that would be an even better solution.
