### PR TITLE
Correct the indentation of the javascript-requirejs.snippets

### DIFF
--- a/snippets/javascript/javascript-requirejs.snippets
+++ b/snippets/javascript/javascript-requirejs.snippets
@@ -1,14 +1,14 @@
 snippet def
-  define(["${1:#dependencies1}"], function (${2:#dependencies2}) {
-    return ${0:TARGET};
-  });
+	define(["${1:#dependencies1}"], function (${2:#dependencies2}) {
+		return ${0:TARGET};
+	});
 
 snippet defn
-  define("${1:#name}", ["${2:#dependencies1}"], function (${3:#dependencies2}) {
-    return ${0:TARGET};
-  });
+	define("${1:#name}", ["${2:#dependencies1}"], function (${3:#dependencies2}) {
+		return ${0:TARGET};
+	});
 
 snippet reqjs
-  require(["${1:#dependencies1}"], function (${2:#dependencies2}) {
-    return ${0:TARGET};
-  });
+	require(["${1:#dependencies1}"], function (${2:#dependencies2}) {
+		return ${0:TARGET};
+	});


### PR DESCRIPTION
Will have following error without tabs.

An error occured. This is either a bug in UltiSnips or a bug in a
snippet definition. If you think this is a bug, please report it to
https://github.com/SirVer/ultisnips/issues/new.

Following is the full stack trace:
Traceback (most recent call last):
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 54, in wrapper
    return func(self, _args, *_kwds)
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 130, in expand_or_jump
    rv = self._try_expand()
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 546, in _try_expand
    snippets = self._snips(before, False)
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 461, in _snips
    source.ensure(filetypes)
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/source/file/_base.py", line 37, in ensure
    self._load_snippets_for(ft)
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/source/file/_base.py", line 67, in _load_snippets_for
    self._parse_snippets(ft, fn)
  File "/home/vincent.hsu/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/source/file/_base.py", line 83, in _parse_snippets
    raise SnippetSyntaxError(filename, line_index, msg)
SnippetSyntaxError: Invalid line '  define(["${1:#dependencies1}"], function (${2:#dependencies2}) {' in ~/.dotfiles/link/.vim/bundle/vim-snippets/snippets/javascript/javascript-requirejs.snippets:2
