### PR TITLE
Update rust snippets

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -73,7 +73,7 @@ endsnippet
 
 snippet ecl "...extern crate log;" b
 #![feature(phase)]
-#[phase(syntax, link)] extern crate log;
+#[phase(plugin, link)] extern crate log;
 endsnippet
 
 snippet mod	 "A module" b
@@ -83,16 +83,16 @@ mod ${1:`!p snip.rv = snip.basename.lower() or "name"`} {
 endsnippet
 
 snippet crate "Create header information" b
-// Crate ID
-#![crate_id = "${1:crate_name}#${2:0.0.1}"]
+// Crate name
+#![crate_name = "${1:crate_name}"]
 
 // Additional metadata attributes
-#![desc = "${3:Descrption.}"]
-#![license = "${4:BSD}"]
-#![comment = "${5:Comment.}"]
+#![desc = "${2:Descrption.}"]
+#![license = "${3:BSD}"]
+#![comment = "${4:Comment.}"]
 
 // Specify the output type
-#![crate_type = "${6:lib}"]
+#![crate_type = "${5:lib}"]
 endsnippet
 
 snippet allow "#[allow(..)]" b

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -34,20 +34,20 @@ snippet ec
 	extern crate ${1:sync};
 snippet ecl
 	#![feature(phase)]
-	#[phase(syntax, link)] extern crate log;
+	#[phase(plugin, link)] extern crate log;
 snippet mod
 	mod ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
 		${0}
 	} /* $1 */
 snippet crate
-	// Crate ID
-	#![crate_id = "${1:crate_name}#${2:0.0.1}"]
+	// Crate name
+	#![crate_name = "${1:crate_name}"]
 	// Additional metadata attributes
-	#![desc = "${3:Descrption.}"]
-	#![license = "${4:BSD}"]
-	#![comment = "${5:Comment.}"]
+	#![desc = "${2:Descrption.}"]
+	#![license = "${3:BSD}"]
+	#![comment = "${4:Comment.}"]
 	// Specify the output type
-	#![crate_type = "${6:lib}"]
+	#![crate_type = "${5:lib}"]
 snippet allow
 	#[allow(${1:unused_variable})]
 snippet feat


### PR DESCRIPTION
phase(syntax) is now called phase(plugin).
crate_id was renamed to crate_name and no longer allows the #<version> syntax.
