### PR TITLE
Change variable name in Ruby alias_method_chain

### DIFF
--- a/snippets/rails.snippets
+++ b/snippets/rails.snippets
@@ -109,6 +109,8 @@ snippet dele delegate .. to
 	delegate :${1:methods}, to: :${0:object}
 snippet dele delegate .. to .. prefix .. allow_nil
 	delegate :${1:methods}, to: :${2:object}, prefix: :${3:prefix}, allow_nil: ${0:allow_nil}
+snippet amc
+	alias_method_chain :${1:method_name}, :${0:feature}
 snippet flash
 	flash[:${1:notice}] = '${0}'
 snippet habtm

--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -209,8 +209,6 @@ snippet defds
 	def_delegators :${1:@del_obj}, :${0:del_methods}
 snippet am
 	alias_method :${1:new_name}, :${0:old_name}
-snippet amc
-	alias_method_chain :${1:method_name}, :${0:feature}
 snippet app
 	if __FILE__ == $PROGRAM_NAME
 		${0}


### PR DESCRIPTION
`method_name` is more clear than `name`, and follows the style of the other snippets.

Also moving the snippet to the Rails snippets, because it's technically part of Rails ActiveSupport, not base Ruby.
