### PR TITLE
Fix indentation in coffee snippet

### DIFF
--- a/snippets/coffee/requirejs_coffee.snippets
+++ b/snippets/coffee/requirejs_coffee.snippets
@@ -1,11 +1,11 @@
 snippet def
-  define ["${1:#dependencies1}"], (${2:#dependencies2}) ->
-    ${0:TARGET}
+	define ["${1:#dependencies1}"], (${2:#dependencies2}) ->
+		${0:TARGET}
 
 snippet defn
-  define "${1:#name}", ["${2:#dependencies1}"], (${3:#dependencies2}) ->
-    ${0:TARGET}
+	define "${1:#name}", ["${2:#dependencies1}"], (${3:#dependencies2}) ->
+		${0:TARGET}
 
 snippet reqjs
-  require ["${1:#dependencies1}"], (${2:#dependencies2}) ->
-    ${0:TARGET}
+	require ["${1:#dependencies1}"], (${2:#dependencies2}) ->
+		${0:TARGET}


### PR DESCRIPTION
Apparently UltiSnips is breaking with snippets that don't use tabs for indentation. This fixes a problem I was encountering in CoffeeScript files.
