### PR TITLE
Remove useless placeholder text from JS functions

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -1,11 +1,11 @@
 # prototype
 snippet proto
-	${1}.prototype.${2} = function(${3}) {
+	${1:class_name}.prototype.${2:method_name} = function(${3}) {
 		${0}
 	};
 # Function
 snippet fun
-	function ${1}(${2}) {
+	function ${1:function_name}(${2}) {
 		${0}
 	}
 # Anonymous Function


### PR DESCRIPTION
The README states...

> Don't add useless placeholder default texts like:

So I've removed the useless placeholder default text from the JS function snippets.

My main motivation for doing this was that removing the `argument` placeholder text with the delete key would break tabbing to the next field. Now that it been removed this is no longer an issue.

Cheers,
Louis

P.S. I've removed the `class_name` placeholder text from the `prototype` snippet. I'm not entirely sure this was the correct thing to do. What are your thoughts?
