### PR TITLE
Correct js vf ${1} snippet syntax error

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -15,7 +15,7 @@ snippet f
 	}
 # Function assigned to variable
 snippet vf
-	var ${1} = function ${1}(${2}) {
+	var ${1:function_name} = function $1(${2}) {
 		${0}
 	};
 # Immediate function


### PR DESCRIPTION
Use of ${1} twice rather than ${1} followed by $1 caused vim-snipmate to skip this field.
