### PR TITLE
fixed indentation in html snippets (for UltiSnips)

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -355,12 +355,12 @@ snippet figure
 	<figure>${0}</figure>
 snippet figure#
 	<figure id="${1}">
-        ${0}
-    </figure>
+		${0}
+	</figure>
 snippet figure.
 	<figure class="${1}">
-        ${0}
-    </figure>
+		${0}
+	</figure>
 snippet footer
 	<footer>
 		${0}
@@ -627,7 +627,7 @@ snippet meta
 snippet meta:s
 	<meta ${0} />
 snippet meta:d
-    <meta name="description" content="${0}" />
+	<meta name="description" content="${0}" />
 snippet meta:compat
 	<meta http-equiv="X-UA-Compatible" content="IE=${1:7,8,edge}" />
 snippet meta:refresh


### PR DESCRIPTION
Hi,

UltiSnips crashed with e.g. `SnippetSyntaxError: Invalid line '    <meta name="description" content="${0}" />' in html.snippets:630` due to some non-tabed indentations.

Please merge.

Regards,
Thomas 
