### PR TITLE
js node require: Use single quotes to match style

### DIFF
--- a/snippets/javascript/javascript.node.snippets
+++ b/snippets/javascript/javascript.node.snippets
@@ -3,7 +3,7 @@ snippet ex
 	module.exports = ${1};
 # require
 snippet re
-	var ${1} = require("${2:module_name}");
+	var ${1} = require('${2:module_name}');
 # EventEmitter
 snippet on
 	on('${1:event_name}', function(${2:stream}) {


### PR DESCRIPTION
Hiya

In the other node snippets we are using single quotes. I've changed the node require snippet to conform to this style.

Cheers,
Louis
