### PR TITLE
js define prop: Use single quotes to match style

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -191,7 +191,7 @@ snippet props
 snippet prop
 	Object.defineProperty(
 		${1:object},
-		"${2:property}",
+		'${2:property}',
 		{
 			get : function $1_$2_getter() {
 				// getter code


### PR DESCRIPTION
Hiya

In the other vanila snippets we are using single quotes. I've changed the define property snippet to conform to this style.

Cheers,
Louis
