### PR TITLE
Added missing semicolon to JS return statement

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -103,7 +103,7 @@ snippet cd
 	console.debug(${0});
 # return
 snippet ret
-	return ${0:result}
+	return ${0:result};
 # for (property in object ) { ... }
 snippet fori
 	for (var ${1:prop} in ${2:Things}) {


### PR DESCRIPTION
Hey!

As in the title.

Cheers,
Louis
