### PR TITLE
Change jsdoc author info to match jsdoc documentation format at http://usejsdoc.org/tags-author.html

### DIFF
--- a/UltiSnips/javascript_jsdoc.snippets
+++ b/UltiSnips/javascript_jsdoc.snippets
@@ -9,7 +9,7 @@ snippet /* "A JSDoc comment" b
 endsnippet
 
 snippet @au "@author email (First Last)"
-@author ${1:`!v g:snips_author_email`} (${2:`!v g:snips_author`})
+@author ${1:`!v g:snips_author`} [${2:`!v g:snips_author_email`}]
 endsnippet
 
 snippet @li "@license Description"


### PR DESCRIPTION
Change jsdoc author info to match jsdoc documentation format at http://usejsdoc.org/tags-author.html
