### PR TITLE
ol. and ol# are missing a double quote

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -674,11 +674,11 @@ snippet ol
 		${0}
 	</ol>
 snippet ol.
-	<ol class="${1}>
+	<ol class="${1}">
 		${0}
 	</ol>
 snippet ol#
-	<ol id="${1}>
+	<ol id="${1}">
 		${0}
 	</ol>
 snippet ol+


### PR DESCRIPTION
ol. and ol# snippets are missing a double quote.
