### PR TITLE
Remove self-closing meta tags on HTML5 templates

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -462,8 +462,8 @@ snippet html5
 	<!DOCTYPE html>
 	<html>
 		<head>
-			<meta charset="utf-8" />
-			<meta name="viewport" content="width=device-width" />
+			<meta charset="utf-8">
+			<meta name="viewport" content="width=device-width">
 			<title>${1:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
 			${2:link}
 		</head>
@@ -475,8 +475,8 @@ snippet html5l
 	<!DOCTYPE html>
 	<html lang="${1:es}">
 		<head>
-			<meta charset="utf-8" />
-			<meta name="viewport" content="width=device-width" />
+			<meta charset="utf-8">
+			<meta name="viewport" content="width=device-width">
 			<title>${2:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
 			${3:link}
 		</head>


### PR DESCRIPTION
In HTML5, it's not necessary, or common, to have self-closing tags. This
commit removes the self-closing meta tags for the html5 and html5l
Snipmate snippets.
