### PR TITLE
Added phpunit comment with group option

### DIFF
--- a/UltiSnips/php_phpunit.snippets
+++ b/UltiSnips/php_phpunit.snippets
@@ -30,3 +30,9 @@ expects($this->${1:once}())
 	->with($this->equalTo(${3})${4})
 	->will($this->returnValue(${5}));
 endsnippet
+
+snippet testcmt "phpunit comment with group" b
+/**
+* @group ${1}
+*/
+endsnippet


### PR DESCRIPTION
This snippet is very useful for me to add comments with group option.

I have all my tests classified by groups to only launch the tests that i'm working with.
