### PR TITLE
Symlink mkd to markdown for plasticboy/vim-markdown

### DIFF
--- a/snippets/mkd.snippets
+++ b/snippets/mkd.snippets
@@ -1,0 +1,1 @@
+markdown.snippets


### PR DESCRIPTION
https://github.com/plasticboy/vim-markdown

They use `mkd` there, and changing that would be backwards incompatible, so I'd rather avoid it.

Ah just noticed that there is the `alias` options on snipmate itself, but I'm not sure which is best. Proposed that one as well: https://github.com/garbas/vim-snipmate/pull/175
