### PR TITLE
Make markdown links consistent on cursor exits

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -6,41 +6,41 @@ snippet [
 	[${1:text}](http://${2:address})
 snippet [*
 	[${1:link}](${2:`@*`})
-
 snippet ["
-	[${1:text}](http://${2:address} "${0:title}")
+	[${1:text}](http://${2:address} "${3:title}")
 snippet ["*
 	[${1:link}](${2:`@*`} "${3:title}")
-
 snippet [:
 	[${1:id}]: http://${2:url}
+
 snippet [:*
 	[${1:id}]: ${2:`@*`}
 
 snippet [:"
-	[${1:id}]: http://${2:url} "${0:title}"
+	[${1:id}]: http://${2:url} "${3:title}"
+
 snippet [:"*
-	[${1:id}]: ${2:`@*`} "${0:title}"
+	[${1:id}]: ${2:`@*`} "${3:title}"
 
 snippet ![
 	![${1:alttext}](${2:/images/image.jpg})
 snippet ![*
 	![${1:alt}](${2:`@*`})
-
 snippet !["
-	![${1:alttext}](${2:/images/image.jpg} "${0:title}")
+	![${1:alttext}](${2:/images/image.jpg} "${3:title}")
 snippet !["*
 	![${1:alt}](${2:`@*`} "${3:title}")
-
 snippet ![:
 	![${1:id}]: ${2:url}
+
 snippet ![:*
 	![${1:id}]: ${2:`@*`}
 
 snippet ![:"
-	![${1:id}]: ${2:url} "${0:title}"
+	![${1:id}]: ${2:url} "${3:title}"
+
 snippet ![:"*
-	![${1:id}]: ${2:`@*`} "${0:title}"
+	![${1:id}]: ${2:`@*`} "${3:title}"
 
 snippet <
 	<http://${1:url}>


### PR DESCRIPTION
Make the versions of link with and without \* behave alike:
-   don't set the 0 location so that the cursor exits.
  Having a 0 in the title is bad because titles are short.
-   either open a new line at end for both, or for neither
  
  The only case where the newline is certain is for link definitions.
