### PR TITLE
Fix markdown fenced code blocks.

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -46,15 +46,16 @@ snippet blockquote-link
 	${0:quote}
 	{% endblockquote %}
 
-snippet bt-codeblock-short
-	```
-	${0:code_snippet}
-	```
+snippet ```
+	\`\`\`
+	${1:code}
+	\`\`\`
 
-snippet bt-codeblock-full
-	``` ${1:language} ${2:title} ${3:URL} ${4:link_text}
-	${0:code_snippet}
-	```
+# Language.
+snippet ```l
+	\`\`\`${1:language}
+	${2:code}
+	\`\`\`
 
 snippet codeblock-short
 	{% codeblock %}


### PR DESCRIPTION
Broken because backticks were interpreted as vim code execution.

Also simplified the trigger which was too long and unintuitive.
