### PR TITLE
Add receiver to fum snippet

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -148,8 +148,8 @@ snippet fun
 	${0}
 # function on receiver
 snippet fum
-	func (self ${1:type}) ${2:funcName}(${3}) ${4:error} {
-		${5}
+	func (${1:receiver} ${2:type}) ${3:funcName}(${4}) ${5:error} {
+		${6}
 	}
 	${0}
 # log printf


### PR DESCRIPTION
According to https://code.google.com/p/go-wiki/wiki/CodeReviewComments#Receiver_Names, receiver name should be a reflection of its identity.
Plus, using self on receiver names raises warnings on lint.
