### PR TITLE
Fix box and bbox snippets outside the first column

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -78,10 +78,12 @@ endglobal
 snippet box "A nice box with the current comment symbol" b
 `!p
 box = make_box(len(t[1]))
-snip.rv = box[0] + '\n' + box[1]
+snip.rv = box[0]
+snip += box[1]
 `${1:content}`!p
 box = make_box(len(t[1]))
-snip.rv = box[2] + '\n' + box[3]`
+snip.rv = box[2]
+snip += box[3]`
 $0
 endsnippet
 
@@ -89,10 +91,12 @@ snippet bbox "A nice box over the full width" b
 `!p
 width = int(vim.eval("&textwidth")) or 71
 box = make_box(len(t[1]), width)
-snip.rv = box[0] + '\n' + box[1]
+snip.rv = box[0]
+snip += box[1]
 `${1:content}`!p
 box = make_box(len(t[1]), width)
-snip.rv = box[2] + '\n' + box[3]`
+snip.rv = box[2]
+snip += box[3]`
 $0
 endsnippet
 


### PR DESCRIPTION
Current behavior of `box` and `bbox` is fine on the first colum:

```
box + <tab>
#############
#  content  #
#############

bbox + <tab>
##############################################################################
#                                  content                                   #
##############################################################################
```

But it fails if it is triggered after a few spaces:

```
   box + <tab>
   #############
#  content  #
#############

   bbox + <tab>
   ##############################################################################
#                                  content                                   #
##############################################################################
```
