### PR TITLE
Add iem python snippet for embedded ipython

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -129,6 +129,9 @@ snippet pdb
 # ipython debugger (ipdb)
 snippet ipdb
 	import ipdb; ipdb.set_trace()
+# embed ipython itself
+snippet iem
+	import IPython; IPython.embed()
 # ipython debugger (pdbbb)
 snippet pdbbb
 	import pdbpp; pdbpp.set_trace()


### PR DESCRIPTION
I use this quite often to embed ipython interpreter almost like a break point.