### PR TITLE
erlang: remove spaces before parens in UltiSnips

### DIFF
--- a/UltiSnips/erlang.snippets
+++ b/UltiSnips/erlang.snippets
@@ -5,12 +5,12 @@
 priority -50
 
 snippet pat "Case:Receive:Try Clause"
-${1:pattern}${2: when ${3:guard}} ->;
+${1:pattern}${2: when ${3:guard}} ->
 	${4:body}
 endsnippet
 
-snippet beh "Behaviour Directive"
--behaviour (${1:behaviour}).
+snippet beh "Behaviour Directive" b
+-behaviour(${1:behaviour}).
 endsnippet
 
 snippet case "Case Expression"
@@ -20,12 +20,12 @@ case ${1:expression} of
 end
 endsnippet
 
-snippet def "Define Directive"
--define (${1:macro}${2: (${3:param})}, ${4:body}).
+snippet def "Define Directive" b
+-define(${1:macro}${2: (${3:param})}, ${4:body}).
 endsnippet
 
-snippet exp "Export Directive"
--export ([${1:function}/${2:arity}]).
+snippet exp "Export Directive" b
+-export([${1:function}/${2:arity}]).
 endsnippet
 
 snippet fun "Fun Expression"
@@ -36,7 +36,7 @@ end
 endsnippet
 
 snippet fu "Function"
-${1:function} (${2:param})${3: when ${4:guard}} ->
+${1:function}(${2:param})${3: when ${4:guard}} ->
 	${5:body}
 endsnippet
 
@@ -47,24 +47,24 @@ if
 end
 endsnippet
 
-snippet ifdef "Ifdef Directive"
--ifdef (${1:macro}).
+snippet ifdef "Ifdef Directive" b
+-ifdef(${1:macro}).
 endsnippet
 
-snippet ifndef "Ifndef Directive"
--ifndef (${1:macro}).
+snippet ifndef "Ifndef Directive" b
+-ifndef(${1:macro}).
 endsnippet
 
-snippet imp "Import Directive"
--import (${1:module}, [${2:function}/${3:arity}]).
+snippet imp "Import Directive" b
+-import(${1:module}, [${2:function}/${3:arity}]).
 endsnippet
 
-snippet inc "Include Directive"
--include ("${1:file}").
+snippet inc "Include Directive" b
+-include("${1:file}").
 endsnippet
 
-snippet mod "Module Directive"
--module (${1:`!p snip.rv = snip.basename or "module"`}).
+snippet mod "Module Directive" b
+-module(${1:`!p snip.rv = snip.basename or "module"`}).
 endsnippet
 
 snippet rcv "Receive Expression"
@@ -77,8 +77,8 @@ ${6:after
 end
 endsnippet
 
-snippet rec "Record Directive"
--record (${1:record}, {${2:field}${3: = ${4:value}}}).
+snippet rec "Record Directive" b
+-record(${1:record}, {${2:field}${3: = ${4:value}}}).
 endsnippet
 
 snippet try "Try Expression"
@@ -93,8 +93,16 @@ ${13:after
 end
 endsnippet
 
-snippet undef "Undef Directive"
--undef (${1:macro}).
+snippet undef "Undef Directive" b
+-undef(${1:macro}).
+endsnippet
+
+snippet || "List Comprehension"
+[${1:X} || ${2:X} <- ${3:List}${4:, gen}]
+endsnippet
+
+snippet gen "Generator Expression"
+${1:X} <- ${2:List}${3:, gen}
 endsnippet
 
 # vim:ft=snippets:


### PR DESCRIPTION
So this is ultimately a matter of style without a strict standard, but I have pretty much never seen anyone write Erlang in the style previously used by the UltiSnips snippets (a space preceding the opening parenthesis of directives, and even the parameters of function definitions)—the official Erlang documentation doesn't use this style, code skeletons in [the Emacs mode shipped in the Erlang/OTP distribution][1] (also borrowed by vimerl) don't, and if it's a clincher, the Snipmate snippets in this repository don't either.

I've had local overrides for awhile, and finally decided everyone else shouldn't have to do the same.

Also adds a list comprehension snippet, as a bonus :smile: 

**An aside question** for @SirVer while I'm here, if I may: see the `fu` Erlang snippet here as an example—the third placeholder (with nested fourth) is meant to be an optional guard clause that you might backspace over if it is unneeded. However, if I backspace over the *second* placeholder in order to define a function with no arguments, moving to the third placeholder shifts the text selection to the wrong place. I see this behavior regularly with other UltiSnips snippets. Perhaps it's something with my Vim config that I should try a minimal configuration to reproduce, but is this a familiar issue, and is there any Vim config or snippet definition practice that avoids it? Thanks!

[1]: http://www.erlang.org/doc/apps/tools/erlang_mode_chapter.html