### PR TITLE
Add a missing closing double quote in HTML

### DIFF
--- a/UltiSnips/html_minimal.snippets
+++ b/UltiSnips/html_minimal.snippets
@@ -17,7 +17,7 @@ snippet label_and_input
 endsnippet
 
 snippet input
-<input type="${1:text}" value="${2}" name="${3}"${4: id="${5:$3}}/>${7}
+<input type="${1:text}" value="${2}" name="${3}"${4: id="${5:$3}"}/>${7}
 endsnippet
 
 snippet submit


### PR DESCRIPTION
Hi, I just found a missing closing double-quote in this HTML snippet for an input.