### PR TITLE
Update Rust snippets

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -91,4 +91,10 @@ snippet fd "Struct field definition" w
 ${1:name}: ${2:Type},
 endsnippet
 
+snippet impl "Struct/Trait implementation" b
+impl ${1:Type/Trait}${2: for ${3:Type}} {
+	${0}
+}
+endsnippet
+
 # vim:ft=snippets:

--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -4,9 +4,31 @@
 
 priority -50
 
-snippet fn "A function, optionally with arguments and return type." b
+snippet let "let variable declaration" b
+let ${1:name}${2:: ${3:type}} = ${4};
+endsnippet
+
+snippet letm "let mut variable declaration" b
+let mut ${1:name}${2:: ${3:type}} = ${4};
+endsnippet
+
+snippet fn "A function, optionally with arguments and return type."
 fn ${1:function_name}(${2})${3/..*/ -> /}${3} {
 	${VISUAL}${0}
+}
+endsnippet
+
+snippet arg "Function Arguments" i
+${1:a}: ${2:T}${3:, arg}
+endsnippet
+
+snippet || "Closure, anonymous function (inline)" i
+${1:move }|${2}| { $3 }
+endsnippet
+
+snippet |} "Closure, anonymous function (block)" i
+${1:move }|${2}| {
+	$3
 }
 endsnippet
 
@@ -30,7 +52,7 @@ macro_rules! ${1:name} (
 )
 endsnippet
 
-snippet mod	 "A module" b
+snippet mod "A module" b
 mod ${1:`!p snip.rv = snip.basename.lower() or "name"`} {
 	${VISUAL}${0}
 }
@@ -52,18 +74,21 @@ struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
 }
 endsnippet
 
+# TODO: fancy dynamic field mirroring like Python slotclass
 snippet stn "Struct with new constructor." b
 pub struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
-	${3}
+	fd${0}
 }
 
 impl $1 {
 	pub fn new(${2}) -> $1 {
-		${4}return $1 {
-			${5}
-		};
+		$1 { ${3} };
 	}
 }
+endsnippet
+
+snippet fd "Struct field definition" w
+${1:name}: ${2:Type},
 endsnippet
 
 # vim:ft=snippets:

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -3,11 +3,11 @@
 #################
 
 # Functions
-snippet fn
+snippet fn "Function definition"
 	fn ${1:function_name}(${2})${3} {
 		${0}
 	}
-snippet test
+snippet test "Unit test function"
 	#[test]
 	fn ${1:test_function_name}() {
 		${0}
@@ -19,32 +19,53 @@ snippet bench "Bench function" b
 			${0}
 		})
 	}
-snippet new
+snippet new "Constructor function"
 	pub fn new(${2}) -> ${1:Name} {
-		${0}return $1 { ${3} };
+		$1 { ${3} };
 	}
-snippet main
+snippet main "Main function"
 	pub fn main() {
 		${0}
 	}
-snippet let
-	let ${1:name: type} = ${2};
-snippet let
-	let mut ${1:name: type} = ${2};
-snippet pln
+snippet let "let variable declaration"
+	let ${1:name}${2:: ${3:type}} = ${4};
+snippet letm "let mut variable declaration"
+	let mut ${1:name}${2:: ${3:type}} = ${4};
+snippet pln "println!"
 	println!("${1}");
-snippet pln,
+snippet pln, "println! with format param"
 	println!("${1}", ${2});
-snippet ec
+
+# Modules
+snippet ec "extern crate"
 	extern crate ${1:sync};
-snippet ecl
-	#![feature(phase)]
-	#[phase(plugin, link)] extern crate log;
+snippet ecl "extern crate log"
+	#[macro_use]
+	extern crate log;
 snippet mod
 	mod ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
 		${0}
 	} /* $1 */
-snippet crate
+snippet testmod "Test module" b
+	#[cfg(test)]
+	mod tests {
+		use super::${1:*};
+
+		test${0}
+	}
+
+# Attributes
+snippet allow "allow lint attribute" b
+	#[allow(${1:unused_variable})]
+snippet cfg "cfg attribute" b
+	#[cfg(${1:target_os = "linux"})]
+snippet feat "feature attribute" b
+	#![feature(${1:plugin})]
+snippet der "#[derive(..)]" b
+	#[derive(${1:Debug})]
+snippet attr "#[..]" b
+	#[${1:inline}]
+snippet crate "Define create meta attributes"
 	// Crate name
 	#![crate_name = "${1:crate_name}"]
 	// Additional metadata attributes
@@ -53,39 +74,33 @@ snippet crate
 	#![comment = "${4:Comment.}"]
 	// Specify the output type
 	#![crate_type = "${5:lib}"]
-snippet allow
-	#[allow(${1:unused_variable})]
-snippet feat
-	#![feature(${1:macro_rules})]
-snippet der "#[deriving(..)]" b
-	#[deriving(${1:Show})]
-snippet attr "#[..]" b
-	#[${1:inline}]
 
 # Common types
-snippet opt
-	Option<${1:int}>
-snippet res
+snippet opt "Option<T>"
+	Option<${1:i32}>
+snippet res "Result<T, E>"
 	Result<${1:~str}, ${2:()}>
+
+# Control structures
 snippet if
 	if ${1} {
 		${0}
 	}
-snippet ife
+snippet ife "if / else"
 	if ${1} {
 		${2}
 	} else {
 		${0}
 	}
-snippet el
+snippet el "else"
 	else {
 		${0}
 	}
-snippet eli
+snippet eli "else if"
 	else if ${1} {
 		${0}
 	}
-snippet mat
+snippet mat "match pattern"
 	match ${1} {
 		${2} => ${3},
 	}
@@ -93,70 +108,72 @@ snippet loop "loop {}" b
 	loop {
 		${0}
 	}
-snippet while
+snippet while "while loop"
 	while ${1:condition} {
 		${0}
 	}
-snippet for
+snippet for "for ... in ... loop"
 	for ${1:i} in ${2:0u..10} {
 		${0}
 	}
-snippet spawn
-	spawn(proc() {
-		${0}
-	});
-snippet chan
-	let (${1:tx}, ${2:rx}): (Sender<${3:int}>, Receiver<${4:int}>) = channel();
-snippet duplex
-	let (${1:from_child}, ${2:to_child}) = sync::duplex();
 # TODO commenting
-snippet todo
+snippet todo "TODO comment"
 	// [TODO]: ${0:Description}
 snippet fixme "FIXME comment"
 	// FIXME: $0
 
 # Struct
-snippet st
+snippet st "Struct definition"
 	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
 		${0}
 	}
-snippet stn
-	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
+snippet impl "Struct/Trait implementation"
+	impl ${1:Type/Trait}${2: ${3:for Type}} {
+		${0}
+	}
+snippet stn "Struct with new constructor"
+	pub struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
 		${0}
 	}
 
 	impl $1 {
 		pub fn new(${2}) -> $1 {
-			${4}return $1 {
-				${5}
-			};
+			$1 { ${3} };
 		}
 	}
-snippet typ
-	type ${1:NewName} = $0;
-# Enum
-snippet enum
+snippet type "Type alias"
+	type ${1:NewName} = $2;
+snippet enum "enum definition"
 	enum ${1:Name} {
-		${0},
+		${2},
 	}
-# Impl
-snippet imp
-	impl ${1:Name} {
+# Traits
+snippet trait "Trait definition"
+	trait ${1:Name} {
 		${0}
 	}
-snippet drop
+snippet drop "Drop trait implementation (destructor)"
 	impl Drop for ${1:Name} {
 		fn drop(&mut self) {
 			${0}
 		}
 	}
-# Traits
-snippet trait
-	trait ${1:Name} {
-		${0}
-	}
 # Statics
-snippet ss
+snippet ss "static string declaration"
 	static ${1}: &'static str = "${0}";
-snippet stat
+snippet stat "static item declaration"
 	static ${1}: ${2:usize} = ${0};
+
+# Concurrency
+snippet spawn "spawn a task or thread"
+	spawn(proc() {
+		${0}
+	});
+snippet chan "Declare (Sender, Receiver) pair of asynchronous channel()"
+	let (${1:tx}, ${2:rx}): (Sender<${3:i32}>, Receiver<${4:i32}>) = channel();
+
+# Testing
+snippet as "assert!"
+	assert!(${1:predicate})
+snippet ase "assert_eq!"
+	assert_eq!(${1:expected}, ${2:actual})

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -102,8 +102,10 @@ snippet eli "else if"
 	}
 snippet mat "match pattern"
 	match ${1} {
-		${2} => ${3},
+		${2} => ${3}
 	}
+snippet case "Case clause of pattern match"
+	${1:_} => ${2:expression}
 snippet loop "loop {}" b
 	loop {
 		${0}

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -161,8 +161,12 @@ snippet ss "static string declaration"
 snippet stat "static item declaration"
 	static ${1}: ${2:usize} = ${0};
 # Concurrency
-snippet spawn "spawn a task or thread"
-	spawn(proc() {
+snippet scoped "spawn a scoped thread"
+	thread::scoped(${1:move }|| {
+		${0}
+	});
+snippet spawn "spawn a thread"
+	thread::spawn(${1:move }|| {
 		${0}
 	});
 snippet chan "Declare (Sender, Receiver) pair of asynchronous channel()"

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -35,7 +35,6 @@ snippet pln "println!"
 	println!("${1}");
 snippet pln, "println! with format param"
 	println!("${1}", ${2});
-
 # Modules
 snippet ec "extern crate"
 	extern crate ${1:sync};
@@ -53,7 +52,6 @@ snippet testmod "Test module" b
 
 		test${0}
 	}
-
 # Attributes
 snippet allow "allow lint attribute" b
 	#[allow(${1:unused_variable})]
@@ -74,13 +72,11 @@ snippet crate "Define create meta attributes"
 	#![comment = "${4:Comment.}"]
 	// Specify the output type
 	#![crate_type = "${5:lib}"]
-
 # Common types
 snippet opt "Option<T>"
 	Option<${1:i32}>
 snippet res "Result<T, E>"
 	Result<${1:~str}, ${2:()}>
-
 # Control structures
 snippet if
 	if ${1} {
@@ -123,7 +119,6 @@ snippet todo "TODO comment"
 	// [TODO]: ${0:Description}
 snippet fixme "FIXME comment"
 	// FIXME: $0
-
 # Struct
 snippet st "Struct definition"
 	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
@@ -165,7 +160,6 @@ snippet ss "static string declaration"
 	static ${1}: &'static str = "${0}";
 snippet stat "static item declaration"
 	static ${1}: ${2:usize} = ${0};
-
 # Concurrency
 snippet spawn "spawn a task or thread"
 	spawn(proc() {
@@ -173,7 +167,6 @@ snippet spawn "spawn a task or thread"
 	});
 snippet chan "Declare (Sender, Receiver) pair of asynchronous channel()"
 	let (${1:tx}, ${2:rx}): (Sender<${3:i32}>, Receiver<${4:i32}>) = channel();
-
 # Testing
 snippet as "assert!"
 	assert!(${1:predicate})

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -128,7 +128,7 @@ snippet st "Struct definition"
 		${0}
 	}
 snippet impl "Struct/Trait implementation"
-	impl ${1:Type/Trait}${2: ${3:for Type}} {
+	impl ${1:Type/Trait}${2: for ${3:Type}} {
 		${0}
 	}
 snippet stn "Struct with new constructor"


### PR DESCRIPTION
Several things here:

1. Snippet descriptions. Especially with snippet hints these days in YouCompleteMe/neocomplete/UltiSnip's `<C-Tab>` listing, the large set of (usually Snipmate) snippets without descriptions drives me crazy. Particularly in cases like the `let` trigger before these changes, where there were two snippets with the same trigger (for `let` and `let mut`), with no hint about which one I was going to get from a menu selection. :weary: 
2. Changing the `typ` trigger works around an issue in SirVer/UltiSnips#450. The failure should probably be addressed in UltiSnips eventually, but for now this avoids an out-of-the-box breakage for any Rust user on current UltiSnips and vim-snippets. Plus I'm pretty unlikely to remember `typ` as the trigger anyway, personally, and it only saved one whopping keystroke.
3. Rust has been changing quickly, but should be settling down now that it's in 1.0-alpha stage. These changes update a few things that have changed, been deprecated, etc. I'll make notes inline to explain these.
4. Adds a few new snippets while we're at it.

**For Snipmate**

General questions for Snipmate experts since I switched to UltiSnips years ago: does anything here need a `version 1` parser requirement added to this file? Descriptions, nested tabstops on the updated `let` snippets? A few existing snippets had UltiSnips-style options after the description (`snippet der "#[deriving(..)]" b`)—I don't think Snipmate supports these, but they are probably just ignored or considered part of description by the parser. I copied them onto a few related snippets but will remove them if I should. It'd be great if the Snipmate vimdoc page had a section with clear bullet points of what is or isn't supported by the different parser versions.

Some newer Snipmate features like nested tabstops don't seem to be supported by the UltiSnips compatibility mode. Thus if I define snippets in a Snipmate file using these features, they won't work in UltiSnips and I need to duplicate them in the UltiSnips file.

It's a troublesome thing about a common repository for Snipmate and UltiSnips: as an UltiSnips user I would like to define Snipmate-compatible snippets in only one place and have them available to all users, but I'm unlikely to actually go to the trouble of testing with Snipmate... (Sorry).

cc @SirVer 