### PR TITLE
repeared shebang

### DIFF
--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -1,6 +1,6 @@
 # Shebang. Executing bash via /usr/bin/env makes scripts more portable.
 snippet bash
-	#!/usr/bin/bash
+	#!/bin/bash
 
 snippet if
 	if [[ ${1:condition} ]]; then

--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -1,6 +1,6 @@
 # Shebang. Executing bash via /usr/bin/env makes scripts more portable.
-snippet #!
-	#!/usr/bin/env bash
+snippet bash
+	#!/usr/bin/bash
 
 snippet if
 	if [[ ${1:condition} ]]; then
@@ -80,11 +80,8 @@ snippet getopt
 	shift $(($OPTIND-1))
 snippet root
 	if [ \$(id -u) -ne 0 ]; then exec sudo \$0; fi
+
 snippet fun
-	${1:function_name}() {
-		${0:#function_body}
-	}
-snippet ffun
 	function ${1:function_name}() {
 		${0:#function_body}
 	}


### PR DESCRIPTION
changed shebang snippet, did not work (becous of the leading # in the snippet?)
also changed the function snippet becous it was verry confusing, sh version could be placed back, but snippet for bash was confusing without looking at the plugin-file.