### PR TITLE
Correct img tag

### DIFF
--- a/UltiSnips/html_minimal.snippets
+++ b/UltiSnips/html_minimal.snippets
@@ -29,5 +29,5 @@ snippet textarea
 endsnippet
 
 snippet img
-	<img src="$1"${2: alt="$3"}/>
+<img src="$1"${2: alt="$3"}/>
 endsnippet


### PR DESCRIPTION
I delete the blank before the "img" tag, because it's redundant when Vim could indent automatically.