### PR TITLE
Add main element

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -592,6 +592,10 @@ snippet link:rss
 	<link rel="alternate" href="${1:rss.xml}" title="RSS" type="application/atom+xml" />
 snippet link:touch
 	<link rel="apple-touch-icon" href="${1:favicon.png}" />
+snippet main
+	<main role="main">
+		${0}
+	</main>
 snippet map
 	<map name="${1}">
 		${0}


### PR DESCRIPTION
From the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main):

> The HTML `<main>` element represents the main content of  the `<body>` of a document or application.
> ...
> The `<main>` element is widely supported (except for Internet Explorer). It is suggested that until `<main>` element is supported in Internet Explorer, the "main" ARIA role be added to the `<main>` element.
 