### PR TITLE
complete and improve HTML doctype snippets

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -15,32 +15,50 @@ endglobal
 ############
 # Doctypes #
 ############
-snippet doctype "DocType XHTML 1.0 Strict" b
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+snippet doctype "HTML 5" b
+<!DOCTYPE html>
 
 endsnippet
 
-snippet doctype "DocType XHTML 1.0 Transitional" b
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+snippet doctype "HTML 4.01 Strict" b
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+	"http://www.w3.org/TR/html4/strict.dtd">
 
 endsnippet
 
-snippet doctype "DocType XHTML 1.1" b
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-	"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-
-endsnippet
-
-snippet doctype "HTML - 4.0 Transitional (doctype)" b
+snippet doctype "HTML 4.01 Transitional" b
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 	"http://www.w3.org/TR/html4/loose.dtd">
 
 endsnippet
 
-snippet doctype "HTML - 5.0 (doctype)" b
-<!DOCTYPE html>
+snippet doctype "HTML 4.01 Frameset" b
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+	"http://www.w3.org/TR/html4/frameset.dtd">
+
+endsnippet
+
+snippet doctype "XHTML 1.0 Strict" b
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+endsnippet
+
+snippet doctype "XHTML 1.0 Transitional" b
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+endsnippet
+
+snippet doctype "XHTML 1.0 Frameset" b
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
+
+endsnippet
+
+snippet doctype "XHTML 1.1" b
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+	"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 
 endsnippet
 


### PR DESCRIPTION
Complete and improve html snippets:
there are 8 frenquetly-used doctype snippets, but UltiSnips has only 5 of them.

The 8 frequently-used doctype snippets are as follows,
1. HTML 5
2. HTML 4.01 Strict
3. HTML 4.01 Transitional
4. HTML 4.01 Frameset
5. XHTML 1.0 Strict
6. XHTML 1.0 Transitional
7. XHTML 1.0 Frameset
8. XHTML 1.1

Reference:[http://www.w3schools.com/tags/tag_DOCTYPE.asp](http://www.w3schools.com/tags/tag_DOCTYPE.asp)