### PR TITLE
Fix bbox outside the first column (consider &tw)

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -89,7 +89,8 @@ endsnippet
 
 snippet bbox "A nice box over the full width" b
 `!p
-width = int(vim.eval("&textwidth")) or 71
+if not snip.c:
+	width = int(vim.eval("&textwidth - (virtcol('.') == 1 ? 0 : virtcol('.'))")) or 71
 box = make_box(len(t[1]), width)
 snip.rv = box[0]
 snip += box[1]


### PR DESCRIPTION
This is a complement to fix #497. 

Current behavior:

    bbox
    ##############################################################################
    #                                  content                                   #
    ##############################################################################
    
    <tab> + <tab> + <tab> + bbox
             ##############################################################################
             #                                  content                                   #
             ##############################################################################
             
With this fix:    
    
    bbox
    ##############################################################################
    #                                  content                                   #
    ##############################################################################
    
    <tab> + <tab> + <tab> + bbox
             ######################################################################
             #                              content                               #
             ######################################################################
             
For a few tabs the current behavior is missed, but when the level of indentation increases the box starts to wrap.
Editing the box to fit `&tw` is more complex than deleting some characters on the beginning as the text won't be centralized any more; on the other side, the current behavior can still be achieved by creating the box on the first column and them `vip>`.