### PR TITLE
Update prompt_toolkit to ptpython, fix argument defaults.

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -138,10 +138,10 @@ snippet pdbbb
 # remote python debugger (rpdb)
 snippet rpdb
 	import rpdb; rpdb.set_trace()
-# python_prompt_toolkit
-snippet ppt
-	from prompt_toolkit.contrib.repl import embed
-	embed(globals(), locals(), vi_mode=${1:default=False}, history_filename=${2:default=None})
+# ptpython
+snippet ptpython
+	from ptpython.repl import embed
+	embed(globals(), locals(), vi_mode=${1:False}, history_filename=${2:None})
 # python console debugger (pudb)
 snippet pudb
 	import pudb; pudb.set_trace()


### PR DESCRIPTION
The repl debugger's new home is https://github.com/jonathanslenders/ptpython in the ``ptpython`` package. Fix arguments.