### PR TITLE
defs snippet name clash

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -47,7 +47,7 @@ snippet deff
 	def ${1:fname}(${2:`indent('.') ? 'self' : ''`}):
 		${0}
 # New Method
-snippet defs
+snippet defm
 	def ${1:mname}(self, ${2:arg}):
 		${0}
 # New Property


### PR DESCRIPTION
In UltiSnips/python.snippets defs is used to define a staticmethod, in snippets/python.snippets defs is used to define a method.

defs to define a method is not a good name, defm would be better.