### PR TITLE
python: docstring: do not add a newline after '"""'

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -148,8 +148,7 @@ snippet pudb
 snippet pprint
 	import pprint; pprint.pprint(${1})
 snippet "
-	"""
-	${0:doc}
+	"""${0:doc}
 	"""
 # assertions
 snippet a=
@@ -200,8 +199,7 @@ snippet lc
 snippet li
 	logger.info(${0:msg})
 snippet epydoc
-	"""
-	${1:Description}
+	"""${1:Description}
 
 	@param ${2:param}: ${3: Description}
 	@type  $2: ${4: Type}


### PR DESCRIPTION
Ref: https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings