### PR TITLE
Change for, if, else, and struct to K&R style.

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -46,15 +46,13 @@ int main(int argc, char *argv[])
 endsnippet
 
 snippet for "for loop (for)"
-for (${2:i} = 0; $2 < ${1:count}; ${3:++$2})
-{
+for (${2:i} = 0; $2 < ${1:count}; ${3:++$2}) {
 	${VISUAL}${0}
 }
 endsnippet
 
 snippet fori "for int loop (fori)"
-for (${4:int} ${2:i} = 0; $2 < ${1:count}; ${3:++$2})
-{
+for (${4:int} ${2:i} = 0; $2 < ${1:count}; ${3:++$2}) {
 	${VISUAL}${0}
 }
 endsnippet
@@ -100,8 +98,7 @@ fprintf(${1:stderr}, "${2:%s}\n"${2/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$3${2/([^%]|%
 endsnippet
 
 snippet if "if .. (if)"
-if (${1:/* condition */})
-{
+if (${1:/* condition */}) {
 	${VISUAL}${0}
 }
 endsnippet
@@ -119,12 +116,9 @@ else if (${1:/* condition */}) {
 endsnippet
 
 snippet ife "if .. else (ife)"
-if (${1:/* condition */})
-{
+if (${1:/* condition */}) {
 	${2}
-}
-else
-{
+} else {
 	${3:/* else */}
 }
 endsnippet
@@ -134,8 +128,7 @@ printf("${1:%s}\n"${1/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$2${1/([^%]|%%)*(%.)?.*/(?2
 endsnippet
 
 snippet st "struct"
-struct ${1:`!p snip.rv = (snip.basename or "name") + "_t"`}
-{
+struct ${1:`!p snip.rv = (snip.basename or "name") + "_t"`} {
 	${0:/* data */}
 };
 endsnippet


### PR DESCRIPTION
As stated in issue https://github.com/honza/vim-snippets/issues/559, some snippets in the UltiSnips folder were not following the K&R style contrary to the snippets folder. One could actually achieve an inconsistent coding style while using snippets from both folders, e.g. if using the snippet "for" from UltiSnips and "forr" from snippets.

Hope this pull request helps to solve that.