### PR TITLE
Slightly smarter Ultisnips snippet file snippets

### DIFF
--- a/UltiSnips/snippets.snippets
+++ b/UltiSnips/snippets.snippets
@@ -2,8 +2,8 @@ priority -50
 
 # We use a little hack so that the snippet is expanded
 # and parsed correctly
-snippet snip "Snippet definition" b
-`!p snip.rv = "snippet"` ${1:Tab_trigger} "${2:Description}" ${3:b}
+snippet snip "Snippet definition" bs
+`!p snip.rv = "snippet"` ${1:Tab_trigger}${2: "${3:Description}" ${4:b}}
 $0
 `!p snip.rv = "endsnippet"`
 endsnippet


### PR DESCRIPTION
What would folks think about a PR that changed the Ultisnips snippet for Ultisnips snippet files that triggers on `snip` (what?) so that the description was optional and whitespace was trimmed from the end of the first line (in the case that you don't want any options)?