### PR TITLE
Enhanced Ultisnips Elixir snippets

### DIFF
--- a/UltiSnips/elixir.snippets
+++ b/UltiSnips/elixir.snippets
@@ -1,0 +1,126 @@
+snippet if
+if ${1:condition} do
+	${2:expression}
+${3:end}
+endsnippet
+
+snippet unless
+unless ${1:condition} do
+	${2:expression}
+${3:end}
+endsnippet
+
+snippet else
+else
+	${1:expression}
+end
+endsnippet
+
+snippet iff
+if ${1:condition}, do: ${2:expression}${3:, else: ${4:expression}}
+endsnippet
+
+snippet unlesss
+unless ${1:condition}, do: ${2:expression}${3:, else: ${4:expression}}
+endsnippet
+
+snippet def
+def ${1:name}${2:(${3:parameters})}${4: when ${5:guard-condition}} do
+	${0:expression}
+end
+endsnippet
+
+snippet defp
+defp ${1:name}${2:(${3:parameters})}${4: when ${5:guard-condition}} do
+	${0:expression}
+end
+endsnippet
+
+snippet deff
+def ${1:name}${2:(${3:parameters})}, do: ${0:expression}
+endsnippet
+
+snippet defpp
+defp ${1:name}${2:(${3:parameters})}, do: ${0:expression}
+endsnippet
+
+snippet fn "inline function" s
+fn ${1:${2:args} }-> ${0:expression} end
+endsnippet
+
+snippet for
+for ${1:item} <- ${2:items}${3:, into: ${4:%{}}} do
+	${0:expression}
+end
+endsnippet
+
+snippet cond "cond do" s
+cond do
+	${1:pattern match} -> ${2:expression}${3:
+	->$4}
+end${0}
+endsnippet
+
+snippet rec "receive do" s
+receive do
+	${1:pattern match} -> ${2:expression}${3:
+	->$4}
+end${0}
+endsnippet
+
+snippet case "case do" s
+case ${1:expression} do
+	${2:pattern match} -> ${3:expression}${4:
+	->$5}
+end${0}
+endsnippet
+
+snippet try
+try do
+	${1:expression}
+rescue
+	${2:pattern match} -> ${3:expression}${4:
+	->$5}
+end${0}
+endsnippet
+
+snippet -> "case/cond pattern match" s
+${1:pattern match} -> ${2:expression}${3:
+->$4}
+endsnippet
+
+snippet @doc
+@doc """
+${1:A really good excuse for the code that follows.}
+"""
+def${0}
+endsnippet
+
+snippet @mod
+@moduledoc """
+${1:A really good excuse for this entire module.}
+"""
+endsnippet
+
+snippet req
+require ${1:Module}${2:, as: ${3:NewName}}
+endsnippet
+
+snippet ali
+alias ${1:Module}${2:, as: ${3:NewName}}
+endsnippet
+
+# To encourage the use or :only over :except.
+snippet imp
+import ${1:Module}${2:, only: [${3:function}: ${4:arity}]}
+endsnippet
+
+snippet test
+test "${1:behaves in some way}"${2:, %{${3:test_context}: ${4:dictionary}}} do
+	${0:test case}
+end
+endsnippet
+
+snippet pry
+require IEx; IEx.pry
+endsnippet

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -1,81 +1,81 @@
 snippet do
 	do
-		${0}
+		${0:expression}
 	end
 snippet if if .. do .. end
-	if ${1} do
-		${0}
+	if ${1:condition} do
+		${0:expression}
 	end
 snippet if: if .. do: ..
 	if ${1:condition}, do: ${0}
 snippet ife if .. do .. else .. end
 	if ${1:condition} do
-		${2}
+		${2:expression}
 	else
-		${0}
+		${0:expression}
 	end
 snippet ife: if .. do: .. else:
-	if ${1:condition}, do: ${2}, else: ${0}
+	if ${1:condition}, do: ${2:expression}, else: ${0:expression}
 snippet unless unless .. do .. end
-	unless ${1} do
-		${0}
+	unless ${1:condition} do
+		${0:expression}
 	end
 snippet unless: unless .. do: ..
 	unless ${1:condition}, do: ${0}
 snippet unlesse unless .. do .. else .. end
 	unless ${1:condition} do
-		${2}
+		${2:expression}
 	else
-		${0}
+		${0:expression}
 	end
 snippet unlesse: unless .. do: .. else:
-	unless ${1:condition}, do: ${2}, else: ${0}
+	unless ${1:condition}, do: ${2:expression}, else: ${0:expression}
 snippet cond
 	cond do
-		${1} ->
-			${0}
+		${1:condition} ->
+			${0:expression}
 	end
 snippet case
-	case ${1} do
-		${2} ->
-			${0}
+	case ${1:expression} do
+		${2:pattern match} ->
+			${0:expression}
 	end
 snippet for
 	for ${1:item} <- ${2:items} do
-		${0}
+		${0:expression}
 	end
 snippet fori
-	for ${1:item} <- ${2:items}, into: ${3} do
-		${0}
+	for ${1:item} <- ${2:items}, into: ${3:%{}} do
+		${0:expression}
 	end
 snippet df
-	def ${1:name}, do: ${2}
+	def ${1:name}, do: ${2:expression}
 snippet def
 	def ${1:name} do
-		${0}
+		${0:expression}
 	end
 snippet defd
 	@doc """
 	${1:doc string}
 	"""
 	def ${2:name} do
-		${0}
+		${0:expression}
 	end
 snippet defim
 	defimpl ${1:protocol_name}, for: ${2:data_type} do
-		${0}
+		${0:expression}
 	end
 snippet defma
 	defmacro ${1:name} do
-		${0}
+		${0:expression}
 	end
 snippet defmo
 	defmodule ${1:module_name} do
-		${0}
+		${0:expression}
 	end
 snippet defp
 	defp ${1:name} do
-		${0}
+		${0:expression}
 	end
 snippet defpr
 	defprotocol ${1:name}, [${0:function}]
@@ -83,22 +83,22 @@ snippet defr
 	defrecord ${1:record_name}, ${0:fields}
 snippet doc
 	@doc """
-	${0}
+	${0:doc string}
 	"""
 snippet fn
-	fn ${1:args} -> ${0} end
+	fn ${1:args} -> ${0:expression} end
 snippet fun
 	function do
-		${0}
+		${0:expression}
 	end
 snippet mdoc
 	@moduledoc """
-	${0}
+	${0:doc string}
 	"""
 snippet rec
 	receive do
-	${1} ->
-		${0}
+	${1:pattern match} ->
+		${0:expression}
 	end
 snippet req
 	require ${0:module_name}
@@ -108,17 +108,17 @@ snippet ali
 	alias ${0:module_name}
 snippet test
 	test "${1:test_name}" do
-		${0}
+		${0:test case}
 	end
 snippet testa
 	test "${1:test_name}", %{${2:arg: arg}} do
-		${0}
+		${0:test case}
 	end
 snippet try try .. rescue .. end
 	try do
-		${1}
+		${1:expression}
 	rescue
-		${2} -> ${0}
+		${2:pattern match} -> ${0:expression}
 	end
 snippet pry
 	require IEx; IEx.pry


### PR DESCRIPTION
Many of these collapse several snippets Elixir snippets into a single Ultisnip
Elixir snippet. Notably, snippets for `if` and `unless` don't have
else-including companions, but, rather, the included `end` is an optional final
section and there's an `else` snippet.