### PR TITLE
Made style for C and C++ snippets more consistent

### DIFF
--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -13,8 +13,7 @@ ${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}begin(), $1${1/^.*?(-)?(>)?$/(?2::(?1:>:
 endsnippet
 
 snippet cl "class .. (class)"
-class ${1:`!p snip.rv = snip.basename or "name"`}
-{
+class ${1:`!p snip.rv = snip.basename or "name"`} {
 public:
 	${1/(\w+).*/$1/} (${2:arguments});
 	virtual ~${1/(\w+).*/$1/} ();
@@ -25,16 +24,14 @@ private:
 endsnippet
 
 snippet ns "namespace .. (namespace)"
-namespace${1/.+/ /m}${1:`!p snip.rv = snip.basename or "name"`}
-{
+namespace${1/.+/ /m}${1:`!p snip.rv = snip.basename or "name"`} {
 	${VISUAL}${0}
 }${1/.+/ \/* /m}$1${1/.+/ *\/ /m}
 endsnippet
 
 snippet readfile "read file (readF)"
 std::vector<char> v;
-if (FILE *fp = fopen(${1:"filename"}, "r"))
-{
+if (FILE *fp = fopen(${1:"filename"}, "r")) {
 	char buf[1024];
 	while(size_t len = fread(buf, 1, sizeof(buf), fp))
 		v.insert(v.end(), buf, buf + len);

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -1,15 +1,13 @@
 ## Main
 # main
 snippet main
-	int main(int argc, const char *argv[])
-	{
+	int main(int argc, const char *argv[]) {
 		${0}
 		return 0;
 	}
 # main(void)
 snippet mainn
-	int main(void)
-	{
+	int main(void) {
 		${0}
 		return 0;
 	}
@@ -118,8 +116,7 @@ snippet do
 ## Functions
 # function definition
 snippet fun
-	${1:void} ${2:function_name}(${3})
-	{
+	${1:void} ${2:function_name}(${3}) {
 		${4}
 	}
 # function declaration
@@ -156,10 +153,8 @@ snippet fpr
 # getopt
 snippet getopt
 	int choice;
-	while (1)
-	{
-		static struct option long_options[] =
-		{
+	while (1) {
+		static struct option long_options[] = {
 			/* Use flags like so:
 			{"verbose",	no_argument,	&verbose_flag, 'V'}*/
 			/* Argument styles: no_argument, required_argument, optional_argument */
@@ -176,14 +171,13 @@ snippet getopt
 			required_argument: ":"
 			optional_argument: "::" */
 
-		choice = getopt_long( argc, argv, "vh",
+		choice = getopt_long(argc, argv, "vh",
 					long_options, &option_index);
 
 		if (choice == -1)
 			break;
 
-		switch( choice )
-		{
+		switch (choice) {
 			case 'v':
 				${2}
 				break;
@@ -203,10 +197,8 @@ snippet getopt
 	}
 
 	/* Deal with non-option arguments here */
-	if ( optind < argc )
-	{
-		while ( optind < argc )
-		{
+	if (optind < argc) {
+		while (optind < argc) {
 			${0}
 		}
 	}

--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -68,8 +68,7 @@ snippet mu
 ## Class
 # class
 snippet cl
-	class ${1:`vim_snippets#Filename('$1', 'name')`}
-	{
+	class ${1:`vim_snippets#Filename('$1', 'name')`} {
 	public:
 		$1(${2});
 		~$1();


### PR DESCRIPTION
The style is obviously highly personal but it makes more sense to pick one and stick with it.
All brackets are now on the same line.
Parentheses surrounding conditional statements and arguments (functions, if, while, switch)
aren't padded with a space anymore.