### PR TITLE
Add test for incorrect indentation, add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+sudo: false
+
+notifications:
+  email: false
+
+script:
+  - ./tests.sh

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+SPACED=$(grep -REn '^ .+' --include '*.snippets' snippets);
+
+if [[ -n SPACED ]]; then
+  echo These snippet lines are indented with spaces:;
+  echo;
+  echo "$SPACED";
+  echo;
+  echo Tests failed!
+  exit 1;
+fi
+
+echo Tests passed!
+exit 0;


### PR DESCRIPTION
After finding yet more broken snippets today I've added a test for snipmate format snippets that are indented with spaces. It's maybe not the best way to do it (I don't speak shell), but it seems to work.

Coupled with Travis CI we will easily be able to tell if pull requests can this particular problem or not. @honza can you turn on travis CI for this repo? I presume you have to be the one that does it.

What do we think? A good addition to the repo?