### PR TITLE
cpp extends c

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -1,3 +1,5 @@
+extends c
+
 ## STL Collections
 # std::array
 snippet array


### PR DESCRIPTION
Only tested using ultisnips. Depending on how other plugins parse snippet files, it might cause errors.