### PR TITLE
Some variables need default value

### DIFF
--- a/plugin/vimsnippets.vim
+++ b/plugin/vimsnippets.vim
@@ -3,6 +3,19 @@ if exists("b:done_vimsnippets")
 endif
 let b:done_vimsnippets = 1
 
+" Some variables need default value
+if !exists("g:snips_author")
+    let g:snips_author = "yourname"
+endif
+
+if !exists("g:snips_email")
+    let g:snips_email = "yourname@email.com"
+endif
+
+if !exists("g:snips_github")
+    let g:snips_github = "https://github.com/yourname"
+endif
+
 " Expanding the path is not needed on Vim 7.4
 if &cp || version >= 704
     finish


### PR DESCRIPTION
so many snippets use `g:snips_email` and `g:snips_github` .
but, them not define.

who are newbie to this snippets package will get error when them expand some snippet use the variables above.

[garbas/vim-snipmate](https://github.com/garbas/vim-snipmate) has give `g:snips_author` a default value.
code is here: https://github.com/garbas/vim-snipmate/blob/master/plugin/snipMate.vim#L47-L49

[SirVer/ultisnips](https://github.com/SirVer/ultisnips) do it yet.
code is here: https://github.com/SirVer/ultisnips/blob/master/plugin/snipMate_compatibility.vim#L6-L8

so i add these code for `g:snips_*`