### PR TITLE
Javascript Postincrementers

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -88,12 +88,12 @@ snippet ret
 
 # for loop
 snippet for
-	for (var ${2:i} = 0, l = ${1:arr}.length; $2 < l; $2 ++) {
+	for (var ${2:i} = 0, l = ${1:arr}.length; $2 < l; $2++) {
 		var ${3:v} = $1[$2];${0:}
 	}
 # Reversed for loop
 snippet forr
-	for (var ${2:i} = ${1:arr}.length - 1; $2 >= 0; $2 --) {
+	for (var ${2:i} = ${1:arr}.length - 1; $2 >= 0; $2--) {
 		var ${3:v} = $1[$2];${0:}
 	}
 # While loop


### PR DESCRIPTION
Most of the time, I've seen the post-increment with no whitespace between:  ```i++``` instead of ```i ++```.