### PR TITLE
python: Allow to set triple quote style separately

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -70,7 +70,10 @@ def get_quoting_style(snip):
 	return DOUBLE_QUOTES
 
 def triple_quotes(snip):
-	return get_quoting_style(snip) * 3
+	style = snip.opt("g:ultisnips_python_triple_quoting_style")
+	if not style:
+		return get_quoting_style(snip) * 3
+	return (SINGLE_QUOTES if style == 'single' else DOUBLE_QUOTES) * 3
 
 def triple_quotes_handle_trailing(snip, quoting_style):
 	"""


### PR DESCRIPTION
I prefer using single quotes for all string literals except multiline strings, where I use double quotes. This change allows such style of quoting and doesn't change the behavior for those who use one style for all cases.