### PR TITLE
Add CommonJS snippet

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -162,4 +162,10 @@ snippet req "require an AMD module"
 require([${1:'dependencies'}], ${2:callback});
 endsnippet
 
+# CommonJS snippets
+
+snippet vreq "assign a CommonJS-style module to a var"
+var ${0:${1/(.+\/)*(\w+)(-|\b|$)(\..+$)?/\u$2/g}} = require('${1}');
+endsnippet
+
 # vim:ft=snippets:


### PR DESCRIPTION
Snippet for including CommonJS/Node.js-styled modules. Works for core and file modules! Generates idiomatic variable names by default when using hyphenated file names. Ex:

```
vreq<tab>./../models/some-model.js
```

expands to

```js
var SomeModel = require('./../models/some-model.js');
```