### PR TITLE
Move Node snippets to separate file

### DIFF
--- a/UltiSnips/javascript-node.snippets
+++ b/UltiSnips/javascript-node.snippets
@@ -12,11 +12,11 @@ snippet ex "module.exports"
 module.exports = ${1};
 endsnippet
 
-snippet hcs
+snippet hcs "http.createServer"
 http.createServer(${1}).listen(${2});
 endsnippet
 
-snippet ncs
+snippet ncs "net.createServer"
 net.createServer(function(${1:socket}){
 	${1}.on('data', function(${3:data}){
 		${4}
@@ -27,25 +27,25 @@ net.createServer(function(${1:socket}){
 }).listen(${6:8124});
 endsnippet
 
-snippet pipe
+snippet pipe "pipe"
 pipe(${1:stream})${2}
 endsnippet
 
 # Express snippets
 
-snippet eget
+snippet eget "express GET"
 ${1:app}.get('${2}', ${3});
 endsnippet
 
-snippet epost
+snippet epost "express POST"
 ${1:app}.post('${2}', ${3});
 endsnippet
 
-snippet eput
+snippet eput "express PUT"
 ${1:app}.put('${2}', ${3});
 endsnippet
 
-snippet edelete
+snippet edelete "express DELETE"
 ${1:app}.delete('${2}', ${3});
 endsnippet
 

--- a/UltiSnips/javascript-node.snippets
+++ b/UltiSnips/javascript-node.snippets
@@ -1,0 +1,6 @@
+priority -50
+
+snippet vreq "assign a CommonJS-style module to a var"
+var ${0:${1/(.+\/)*(\w+)(-|\b|$)(\..+$)?/\u$2/g}} = require('${1}');
+endsnippet
+

--- a/UltiSnips/javascript-node.snippets
+++ b/UltiSnips/javascript-node.snippets
@@ -49,3 +49,17 @@ snippet edelete "express DELETE"
 ${1:app}.delete('${2}', ${3});
 endsnippet
 
+# process snippets
+
+snippet stdout "stdout"
+process.stdout
+endsnippet
+
+snippet stdin "stdin"
+process.stdin
+endsnippet
+
+snippet stderr "stderr"
+process.stderr
+endsnippet
+

--- a/UltiSnips/javascript-node.snippets
+++ b/UltiSnips/javascript-node.snippets
@@ -1,6 +1,51 @@
 priority -50
 
+snippet #! "shebang"
+#!/usr/bin/env node
+endsnippet
+
 snippet vreq "assign a CommonJS-style module to a var"
 var ${0:${1/(.+\/)*(\w+)(-|\b|$)(\..+$)?/\u$2/g}} = require('${1}');
+endsnippet
+
+snippet ex "module.exports"
+module.exports = ${1};
+endsnippet
+
+snippet hcs
+http.createServer(${1}).listen(${2});
+endsnippet
+
+snippet ncs
+net.createServer(function(${1:socket}){
+	${1}.on('data', function(${3:data}){
+		${4}
+	});
+	${1}.on('end', function(){
+		${5}
+	});
+}).listen(${6:8124});
+endsnippet
+
+snippet pipe
+pipe(${1:stream})${2}
+endsnippet
+
+# Express snippets
+
+snippet eget
+${1:app}.get('${2}', ${3});
+endsnippet
+
+snippet epost
+${1:app}.post('${2}', ${3});
+endsnippet
+
+snippet eput
+${1:app}.put('${2}', ${3});
+endsnippet
+
+snippet edelete
+${1:app}.delete('${2}', ${3});
 endsnippet
 

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -162,10 +162,4 @@ snippet req "require an AMD module"
 require([${1:'dependencies'}], ${2:callback});
 endsnippet
 
-# CommonJS snippets
-
-snippet vreq "assign a CommonJS-style module to a var"
-var ${0:${1/(.+\/)*(\w+)(-|\b|$)(\..+$)?/\u$2/g}} = require('${1}');
-endsnippet
-
 # vim:ft=snippets:


### PR DESCRIPTION
I moved the Node module snippet to a separate file and added some sensible snippets from the snipMate folder. I omitted the EventEmitter snippets because they conform to regular JS event snippets and are not Node-specific.