### PR TITLE
fix case of 'Desc' attribute in puppet/yumrepo snippet

### DIFF
--- a/snippets/puppet.snippets
+++ b/snippets/puppet.snippets
@@ -221,7 +221,7 @@ snippet package
 
 snippet yumrepo
 	yumrepo { "${1:repo name}":
-		Descr   => "${2:$1}",
+		descr   => "${2:$1}",
 		enabled => ${0:1},
 	}
 


### PR DESCRIPTION
Attribute 'Desc' must be changed to lowercase.