### PR TITLE
Update javascript.snippets : f should expand near words

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -11,7 +11,7 @@ snippet fun
 		${0}
 	}
 # Anonymous Function
-snippet f
+snippet f "" w
 	function(${1}) {
 		${0}
 	}


### PR DESCRIPTION
If you write 

`http.get(f`

and hit tab, `f` won't be expanded to the function snippet.

This merge request fixes this, by specifying that it should be expanded near **w**ord boundaries.

>    w   Word boundary - With this option, the snippet is expanded if
>       the tab trigger start matches a word boundary and the tab trigger end
>       matches a word boundary. In other words the tab trigger must be
>       preceded and followed by non-word characters. Word characters are
>       defined by the 'iskeyword' setting. Use this option, for example, to
>       permit expansion where the tab trigger follows punctuation without
>       expanding suffixes of larger words.