### PR TITLE
fix stylus indentation.

### DIFF
--- a/snippets/stylus.snippets
+++ b/snippets/stylus.snippets
@@ -1,993 +1,993 @@
 snippet !
-		!important
+	!important
 snippet bdi:m+
-		-moz-border-image url(${1}) ${2:0} ${3:0} ${4:0} ${5:0} ${6:stretch} ${0:stretch}
+	-moz-border-image url(${1}) ${2:0} ${3:0} ${4:0} ${5:0} ${6:stretch} ${0:stretch}
 snippet bdi:m
-		-moz-border-image ${0}
+	-moz-border-image ${0}
 snippet bdrz:m
-		-moz-border-radius ${0}
+	-moz-border-radius ${0}
 snippet bxsh:m+
-		-moz-box-shadow ${1:0} ${2:0} ${3:0} ${0}
+	-moz-box-shadow ${1:0} ${2:0} ${3:0} ${0}
 snippet bxsh:m
-		-moz-box-shadow ${0}
+	-moz-box-shadow ${0}
 snippet bdi:w+
-		-webkit-border-image url(${1}) ${2:0} ${3:0} ${4:0} ${5:0} ${6:stretch} ${0:stretch}
+	-webkit-border-image url(${1}) ${2:0} ${3:0} ${4:0} ${5:0} ${6:stretch} ${0:stretch}
 snippet bdi:w
-		-webkit-border-image ${0}
+	-webkit-border-image ${0}
 snippet bdrz:w
-		-webkit-border-radius ${0}
+	-webkit-border-radius ${0}
 snippet bxsh:w+
-		-webkit-box-shadow ${1:0} ${2:0} ${3:0} ${0}
+	-webkit-box-shadow ${1:0} ${2:0} ${3:0} ${0}
 snippet bxsh:w
-		-webkit-box-shadow ${0}
+	-webkit-box-shadow ${0}
 snippet @f
-		@font-face ${0}
+	@font-face ${0}
 snippet @i
-		@import '${0}'
+	@import '${0}'
 snippet @r
-		@require '${0}'
+	@require '${0}'
 snippet @m
-		@media ${1:screen}
+	@media ${1:screen}
 snippet @msmw
-		@media screen and (min-width: ${0}px)
+	@media screen and (min-width: ${0}px)
 snippet @ext
-		@extend .${1}
-		${0}
+	@extend .${1}
+	${0}
 snippet bg+
-		background ${1} url(${2}) ${3:0} ${4:0} ${0:no-repeat}
+	background ${1} url(${2}) ${3:0} ${4:0} ${0:no-repeat}
 snippet bga
-		background-attachment ${0}
+	background-attachment ${0}
 snippet bga:f
-		background-attachment fixed
+	background-attachment fixed
 snippet bga:s
-		background-attachment scroll
+	background-attachment scroll
 snippet bgbk
-		background-break ${0}
+	background-break ${0}
 snippet bgbk:bb
-		background-break bounding-box
+	background-break bounding-box
 snippet bgbk:c
-		background-break continuous
+	background-break continuous
 snippet bgbk:eb
-		background-break each-box
+	background-break each-box
 snippet bgcp
-		background-clip ${0}
+	background-clip ${0}
 snippet bgcp:bb
-		background-clip border-box
+	background-clip border-box
 snippet bgcp:cb
-		background-clip content-box
+	background-clip content-box
 snippet bgcp:nc
-		background-clip no-clip
+	background-clip no-clip
 snippet bgcp:pb
-		background-clip padding-box
+	background-clip padding-box
 snippet bgc
-		background-color ${0}
+	background-color ${0}
 snippet bgc:t
-		background-color transparent
+	background-color transparent
 snippet bgi
-		background-image url(${0})
+	background-image url(${0})
 snippet bgi:n
-		background-image none
+	background-image none
 snippet bgo
-		background-origin ${0}
+	background-origin ${0}
 snippet bgo:bb
-		background-origin border-box
+	background-origin border-box
 snippet bgo:cb
-		background-origin content-box
+	background-origin content-box
 snippet bgo:pb
-		background-origin padding-box
+	background-origin padding-box
 snippet bgpx
-		background-position-x ${0}
+	background-position-x ${0}
 snippet bgpy
-		background-position-y ${0}
+	background-position-y ${0}
 snippet bgp
-		background-position ${1:0} ${0:0}
+	background-position ${1:0} ${0:0}
 snippet bgr
-		background-repeat ${0}
+	background-repeat ${0}
 snippet bgr:n
-		background-repeat no-repeat
+	background-repeat no-repeat
 snippet bgr:x
-		background-repeat repeat-x
+	background-repeat repeat-x
 snippet bgr:y
-		background-repeat repeat-y
+	background-repeat repeat-y
 snippet bgr:r
-		background-repeat repeat
+	background-repeat repeat
 snippet bgz
-		background-size ${0}
+	background-size ${0}
 snippet bgz:a
-		background-size auto
+	background-size auto
 snippet bgz:ct
-		background-size contain
+	background-size contain
 snippet bgz:cv
-		background-size cover
+	background-size cover
 snippet bg
-		background ${0}
+	background ${0}
 snippet bg:ie
-		filter progid:DXImageTransform.Microsoft.AlphaImageLoader(src='${1}',sizingMethod='${0:crop}')
+	filter progid:DXImageTransform.Microsoft.AlphaImageLoader(src='${1}',sizingMethod='${0:crop}')
 snippet bg:n
-		background none
+	background none
 snippet bd+
-		border ${1:1px} ${2:solid} ${0}
+	border ${1:1px} ${2:solid} ${0}
 snippet bdb+
-		border-bottom ${1:1px} ${2:solid} ${0}
+	border-bottom ${1:1px} ${2:solid} ${0}
 snippet bdbc
-		border-bottom-color ${0}
+	border-bottom-color ${0}
 snippet bdbi
-		border-bottom-image url(${0})
+	border-bottom-image url(${0})
 snippet bdbi:n
-		border-bottom-image none
+	border-bottom-image none
 snippet bdbli
-		border-bottom-left-image url(${0})
+	border-bottom-left-image url(${0})
 snippet bdbli:c
-		border-bottom-left-image continue
+	border-bottom-left-image continue
 snippet bdbli:n
-		border-bottom-left-image none
+	border-bottom-left-image none
 snippet bdblrz
-		border-bottom-left-radius ${0}
+	border-bottom-left-radius ${0}
 snippet bdbri
-		border-bottom-right-image url(${0})
+	border-bottom-right-image url(${0})
 snippet bdbri:c
-		border-bottom-right-image continue
+	border-bottom-right-image continue
 snippet bdbri:n
-		border-bottom-right-image none
+	border-bottom-right-image none
 snippet bdbrrz
-		border-bottom-right-radius ${0}
+	border-bottom-right-radius ${0}
 snippet bdbs
-		border-bottom-style ${0}
+	border-bottom-style ${0}
 snippet bdbs:n
-		border-bottom-style none
+	border-bottom-style none
 snippet bdbw
-		border-bottom-width ${0}
+	border-bottom-width ${0}
 snippet bdb
-		border-bottom ${0}
+	border-bottom ${0}
 snippet bdb:n
-		border-bottom none
+	border-bottom none
 snippet bdbk
-		border-break ${0}
+	border-break ${0}
 snippet bdbk:c
-		border-break close
+	border-break close
 snippet bdcl
-		border-collapse ${0}
+	border-collapse ${0}
 snippet bdcl:c
-		border-collapse collapse
+	border-collapse collapse
 snippet bdcl:s
-		border-collapse separate
+	border-collapse separate
 snippet bdc
-		border-color ${0}
+	border-color ${0}
 snippet bdci
-		border-corner-image url(${0})
+	border-corner-image url(${0})
 snippet bdci:c
-		border-corner-image continue
+	border-corner-image continue
 snippet bdci:n
-		border-corner-image none
+	border-corner-image none
 snippet bdf
-		border-fit ${0}
+	border-fit ${0}
 snippet bdf:c
-		border-fit clip
+	border-fit clip
 snippet bdf:of
-		border-fit overwrite
+	border-fit overwrite
 snippet bdf:ow
-		border-fit overwrite
+	border-fit overwrite
 snippet bdf:r
-		border-fit repeat
+	border-fit repeat
 snippet bdf:sc
-		border-fit scale
+	border-fit scale
 snippet bdf:sp
-		border-fit space
+	border-fit space
 snippet bdf:st
-		border-fit stretch
+	border-fit stretch
 snippet bdi
-		border-image url(${1}) ${2:0} ${3:0} ${4:0} ${5:0} ${6:stretch} ${0:stretch}
+	border-image url(${1}) ${2:0} ${3:0} ${4:0} ${5:0} ${6:stretch} ${0:stretch}
 snippet bdi:n
-		border-image none
+	border-image none
 snippet bdl+
-		border-left ${1:1px} ${2:solid} ${0}
+	border-left ${1:1px} ${2:solid} ${0}
 snippet bdlc
-		border-left-color ${0}
+	border-left-color ${0}
 snippet bdli
-		border-left-image url(${0})
+	border-left-image url(${0})
 snippet bdli:n
-		border-left-image none
+	border-left-image none
 snippet bdls
-		border-left-style ${0}
+	border-left-style ${0}
 snippet bdls:n
-		border-left-style none
+	border-left-style none
 snippet bdlw
-		border-left-width ${0}
+	border-left-width ${0}
 snippet bdl
-		border-left ${0}
+	border-left ${0}
 snippet bdl:n
-		border-left none
+	border-left none
 snippet bdlt
-		border-length ${0}
+	border-length ${0}
 snippet bdlt:a
-		border-length auto
+	border-length auto
 snippet bdrz
-		border-radius ${0}
+	border-radius ${0}
 snippet bdr+
-		border-right ${1:1px} ${2:solid} ${0}
+	border-right ${1:1px} ${2:solid} ${0}
 snippet bdrc
-		border-right-color ${0}
+	border-right-color ${0}
 snippet bdri
-		border-right-image url(${0})
+	border-right-image url(${0})
 snippet bdri:n
-		border-right-image none
+	border-right-image none
 snippet bdrs
-		border-right-style ${0}
+	border-right-style ${0}
 snippet bdrs:n
-		border-right-style none
+	border-right-style none
 snippet bdrw
-		border-right-width ${0}
+	border-right-width ${0}
 snippet bdr
-		border-right ${0}
+	border-right ${0}
 snippet bdr:n
-		border-right none
+	border-right none
 snippet bdsp
-		border-spacing ${0}
+	border-spacing ${0}
 snippet bds
-		border-style ${0}
+	border-style ${0}
 snippet bds:ds
-		border-style dashed
+	border-style dashed
 snippet bds:dtds
-		border-style dot-dash
+	border-style dot-dash
 snippet bds:dtdtds
-		border-style dot-dot-dash
+	border-style dot-dot-dash
 snippet bds:dt
-		border-style dotted
+	border-style dotted
 snippet bds:db
-		border-style double
+	border-style double
 snippet bds:g
-		border-style groove
+	border-style groove
 snippet bds:h
-		border-style hidden
+	border-style hidden
 snippet bds:i
-		border-style inset
+	border-style inset
 snippet bds:n
-		border-style none
+	border-style none
 snippet bds:o
-		border-style outset
+	border-style outset
 snippet bds:r
-		border-style ridge
+	border-style ridge
 snippet bds:s
-		border-style solid
+	border-style solid
 snippet bds:w
-		border-style wave
+	border-style wave
 snippet bdt+
-		border-top ${1:1px} ${2:solid} ${0}
+	border-top ${1:1px} ${2:solid} ${0}
 snippet bdtc
-		border-top-color ${0}
+	border-top-color ${0}
 snippet bdti
-		border-top-image url(${0})
+	border-top-image url(${0})
 snippet bdti:n
-		border-top-image none
+	border-top-image none
 snippet bdtli
-		border-top-left-image url(${0})
+	border-top-left-image url(${0})
 snippet bdtli:c
-		border-corner-image continue
+	border-corner-image continue
 snippet bdtli:n
-		border-corner-image none
+	border-corner-image none
 snippet bdtlrz
-		border-top-left-radius ${0}
+	border-top-left-radius ${0}
 snippet bdtri
-		border-top-right-image url(${0})
+	border-top-right-image url(${0})
 snippet bdtri:c
-		border-top-right-image continue
+	border-top-right-image continue
 snippet bdtri:n
-		border-top-right-image none
+	border-top-right-image none
 snippet bdtrrz
-		border-top-right-radius ${0}
+	border-top-right-radius ${0}
 snippet bdts
-		border-top-style ${0}
+	border-top-style ${0}
 snippet bdts:n
-		border-top-style none
+	border-top-style none
 snippet bdtw
-		border-top-width ${0}
+	border-top-width ${0}
 snippet bdt
-		border-top ${0}
+	border-top ${0}
 snippet bdt:n
-		border-top none
+	border-top none
 snippet bdw
-		border-width ${0}
+	border-width ${0}
 snippet bd
-		border ${0}
+	border ${0}
 snippet bd:n
-		border none
+	border none
 snippet b
-		bottom ${0}
+	bottom ${0}
 snippet b:a
-		bottom auto
+	bottom auto
 snippet bxsh+
-		box-shadow ${1:0} ${2:0} ${3:0} ${0}
+	box-shadow ${1:0} ${2:0} ${3:0} ${0}
 snippet bxsh
-		box-shadow ${0}
+	box-shadow ${0}
 snippet bxsh:n
-		box-shadow none
+	box-shadow none
 snippet bxz
-		box-sizing ${0}
+	box-sizing ${0}
 snippet bxz:bb
-		box-sizing border-box
+	box-sizing border-box
 snippet bxz:cb
-		box-sizing content-box
+	box-sizing content-box
 snippet cps
-		caption-side ${0}
+	caption-side ${0}
 snippet cps:b
-		caption-side bottom
+	caption-side bottom
 snippet cps:t
-		caption-side top
+	caption-side top
 snippet cl
-		clear ${0}
+	clear ${0}
 snippet cl:b
-		clear both
+	clear both
 snippet cl:l
-		clear left
+	clear left
 snippet cl:n
-		clear none
+	clear none
 snippet cl:r
-		clear right
+	clear right
 snippet cp
-		clip ${0}
+	clip ${0}
 snippet cp:a
-		clip auto
+	clip auto
 snippet cp:r
-		clip rect(${1:0} ${2:0} ${3:0} ${0:0})
+	clip rect(${1:0} ${2:0} ${3:0} ${0:0})
 snippet c
-		color ${0}
+	color ${0}
 snippet ct
-		content ${0}
+	content ${0}
 snippet ct:a
-		content attr(${0})
+	content attr(${0})
 snippet ct:cq
-		content close-quote
+	content close-quote
 snippet ct:c
-		content counter(${0})
+	content counter(${0})
 snippet ct:cs
-		content counters(${0})
+	content counters(${0})
 snippet ct:ncq
-		content no-close-quote
+	content no-close-quote
 snippet ct:noq
-		content no-open-quote
+	content no-open-quote
 snippet ct:n
-		content normal
+	content normal
 snippet ct:oq
-		content open-quote
+	content open-quote
 snippet coi
-		counter-increment ${0}
+	counter-increment ${0}
 snippet cor
-		counter-reset ${0}
+	counter-reset ${0}
 snippet cur
-		cursor ${0}
+	cursor ${0}
 snippet cur:a
-		cursor auto
+	cursor auto
 snippet cur:c
-		cursor crosshair
+	cursor crosshair
 snippet cur:d
-		cursor default
+	cursor default
 snippet cur:ha
-		cursor hand
+	cursor hand
 snippet cur:he
-		cursor help
+	cursor help
 snippet cur:m
-		cursor move
+	cursor move
 snippet cur:p
-		cursor pointer
+	cursor pointer
 snippet cur:t
-		cursor text
+	cursor text
 snippet d
-		display ${0}
+	display ${0}
 snippet d:mib
-		display -moz-inline-box
+	display -moz-inline-box
 snippet d:mis
-		display -moz-inline-stack
+	display -moz-inline-stack
 snippet d:b
-		display block
+	display block
 snippet d:cp
-		display compact
+	display compact
 snippet d:ib
-		display inline-block
+	display inline-block
 snippet d:itb
-		display inline-table
+	display inline-table
 snippet d:i
-		display inline
+	display inline
 snippet d:li
-		display list-item
+	display list-item
 snippet d:n
-		display none
+	display none
 snippet d:ri
-		display run-in
+	display run-in
 snippet d:tbcp
-		display table-caption
+	display table-caption
 snippet d:tbc
-		display table-cell
+	display table-cell
 snippet d:tbclg
-		display table-column-group
+	display table-column-group
 snippet d:tbcl
-		display table-column
+	display table-column
 snippet d:tbfg
-		display table-footer-group
+	display table-footer-group
 snippet d:tbhg
-		display table-header-group
+	display table-header-group
 snippet d:tbrg
-		display table-row-group
+	display table-row-group
 snippet d:tbr
-		display table-row
+	display table-row
 snippet d:tb
-		display table
+	display table
 snippet ec
-		empty-cells ${0}
+	empty-cells ${0}
 snippet ec:h
-		empty-cells hide
+	empty-cells hide
 snippet ec:s
-		empty-cells show
+	empty-cells show
 snippet exp
-		expression()
+	expression()
 snippet fl
-		float ${0}
+	float ${0}
 snippet fl:l
-		float left
+	float left
 snippet fl:n
-		float none
+	float none
 snippet fl:r
-		float right
+	float right
 snippet f+
-		font ${1:1em} ${2:Arial},${0:sans-serif}
+	font ${1:1em} ${2:Arial},${0:sans-serif}
 snippet fef
-		font-effect ${0}
+	font-effect ${0}
 snippet fef:eb
-		font-effect emboss
+	font-effect emboss
 snippet fef:eg
-		font-effect engrave
+	font-effect engrave
 snippet fef:n
-		font-effect none
+	font-effect none
 snippet fef:o
-		font-effect outline
+	font-effect outline
 snippet femp
-		font-emphasize-position ${0}
+	font-emphasize-position ${0}
 snippet femp:a
-		font-emphasize-position after
+	font-emphasize-position after
 snippet femp:b
-		font-emphasize-position before
+	font-emphasize-position before
 snippet fems
-		font-emphasize-style ${0}
+	font-emphasize-style ${0}
 snippet fems:ac
-		font-emphasize-style accent
+	font-emphasize-style accent
 snippet fems:c
-		font-emphasize-style circle
+	font-emphasize-style circle
 snippet fems:ds
-		font-emphasize-style disc
+	font-emphasize-style disc
 snippet fems:dt
-		font-emphasize-style dot
+	font-emphasize-style dot
 snippet fems:n
-		font-emphasize-style none
+	font-emphasize-style none
 snippet fem
-		font-emphasize ${0}
+	font-emphasize ${0}
 snippet ff
-		font-family ${0}
+	font-family ${0}
 snippet ff:c
-		font-family ${0:'Monotype Corsiva','Comic Sans MS'},cursive
+	font-family ${0:'Monotype Corsiva','Comic Sans MS'},cursive
 snippet ff:f
-		font-family ${0:Capitals,Impact},fantasy
+	font-family ${0:Capitals,Impact},fantasy
 snippet ff:m
-		font-family ${0:Monaco,'Courier New'},monospace
+	font-family ${0:Monaco,'Courier New'},monospace
 snippet ff:ss
-		font-family ${0:Helvetica,Arial},sans-serif
+	font-family ${0:Helvetica,Arial},sans-serif
 snippet ff:s
-		font-family ${0:Georgia,'Times New Roman'},serif
+	font-family ${0:Georgia,'Times New Roman'},serif
 snippet fza
-		font-size-adjust ${0}
+	font-size-adjust ${0}
 snippet fza:n
-		font-size-adjust none
+	font-size-adjust none
 snippet fz
-		font-size ${0}
+	font-size ${0}
 snippet fsm
-		font-smooth ${0}
+	font-smooth ${0}
 snippet fsm:aw
-		font-smooth always
+	font-smooth always
 snippet fsm:a
-		font-smooth auto
+	font-smooth auto
 snippet fsm:n
-		font-smooth never
+	font-smooth never
 snippet fst
-		font-stretch ${0}
+	font-stretch ${0}
 snippet fst:c
-		font-stretch condensed
+	font-stretch condensed
 snippet fst:e
-		font-stretch expanded
+	font-stretch expanded
 snippet fst:ec
-		font-stretch extra-condensed
+	font-stretch extra-condensed
 snippet fst:ee
-		font-stretch extra-expanded
+	font-stretch extra-expanded
 snippet fst:n
-		font-stretch normal
+	font-stretch normal
 snippet fst:sc
-		font-stretch semi-condensed
+	font-stretch semi-condensed
 snippet fst:se
-		font-stretch semi-expanded
+	font-stretch semi-expanded
 snippet fst:uc
-		font-stretch ultra-condensed
+	font-stretch ultra-condensed
 snippet fst:ue
-		font-stretch ultra-expanded
+	font-stretch ultra-expanded
 snippet fs
-		font-style ${0}
+	font-style ${0}
 snippet fs:i
-		font-style italic
+	font-style italic
 snippet fs:n
-		font-style normal
+	font-style normal
 snippet fs:o
-		font-style oblique
+	font-style oblique
 snippet fv
-		font-variant ${0}
+	font-variant ${0}
 snippet fv:n
-		font-variant normal
+	font-variant normal
 snippet fv:sc
-		font-variant small-caps
+	font-variant small-caps
 snippet fw
-		font-weight ${0}
+	font-weight ${0}
 snippet fw:b
-		font-weight bold
+	font-weight bold
 snippet fw:br
-		font-weight bolder
+	font-weight bolder
 snippet fw:lr
-		font-weight lighter
+	font-weight lighter
 snippet fw:n
-		font-weight normal
+	font-weight normal
 snippet f
-		font ${0}
+	font ${0}
 snippet h
-		height ${0}
+	height ${0}
 snippet h:a
-		height auto
+	height auto
 snippet l
-		left ${0}
+	left ${0}
 snippet l:a
-		left auto
+	left auto
 snippet lts
-		letter-spacing ${0}
+	letter-spacing ${0}
 snippet lh
-		line-height ${0}
+	line-height ${0}
 snippet lisi
-		list-style-image url(${0})
+	list-style-image url(${0})
 snippet lisi:n
-		list-style-image none
+	list-style-image none
 snippet lisp
-		list-style-position ${0}
+	list-style-position ${0}
 snippet lisp:i
-		list-style-position inside
+	list-style-position inside
 snippet lisp:o
-		list-style-position outside
+	list-style-position outside
 snippet list
-		list-style-type ${0}
+	list-style-type ${0}
 snippet list:c
-		list-style-type circle
+	list-style-type circle
 snippet list:dclz
-		list-style-type decimal-leading-zero
+	list-style-type decimal-leading-zero
 snippet list:dc
-		list-style-type decimal
+	list-style-type decimal
 snippet list:d
-		list-style-type disc
+	list-style-type disc
 snippet list:lr
-		list-style-type lower-roman
+	list-style-type lower-roman
 snippet list:n
-		list-style-type none
+	list-style-type none
 snippet list:s
-		list-style-type square
+	list-style-type square
 snippet list:ur
-		list-style-type upper-roman
+	list-style-type upper-roman
 snippet lis
-		list-style ${0}
+	list-style ${0}
 snippet lis:n
-		list-style none
+	list-style none
 snippet mb
-		margin-bottom ${0}
+	margin-bottom ${0}
 snippet mb:a
-		margin-bottom auto
+	margin-bottom auto
 snippet ml
-		margin-left ${0}
+	margin-left ${0}
 snippet ml:a
-		margin-left auto
+	margin-left auto
 snippet mr
-		margin-right ${0}
+	margin-right ${0}
 snippet mr:a
-		margin-right auto
+	margin-right auto
 snippet mt
-		margin-top ${0}
+	margin-top ${0}
 snippet mt:a
-		margin-top auto
+	margin-top auto
 snippet m
-		margin ${0}
+	margin ${0}
 snippet m:4
-		margin ${1:0} ${2:0} ${3:0} ${0:0}
+	margin ${1:0} ${2:0} ${3:0} ${0:0}
 snippet m:3
-		margin ${1:0} ${2:0} ${0:0}
+	margin ${1:0} ${2:0} ${0:0}
 snippet m:2
-		margin ${1:0} ${0:0}
+	margin ${1:0} ${0:0}
 snippet m:0
-		margin 0
+	margin 0
 snippet m:a
-		margin auto
+	margin auto
 snippet mah
-		max-height ${0}
+	max-height ${0}
 snippet mah:n
-		max-height none
+	max-height none
 snippet maw
-		max-width ${0}
+	max-width ${0}
 snippet maw:n
-		max-width none
+	max-width none
 snippet mih
-		min-height ${0}
+	min-height ${0}
 snippet miw
-		min-width ${0}
+	min-width ${0}
 snippet op
-		opacity ${0}
+	opacity ${0}
 snippet op:ie
-		filter progid:DXImageTransform.Microsoft.Alpha(Opacity=${0:100})
+	filter progid:DXImageTransform.Microsoft.Alpha(Opacity=${0:100})
 snippet op:ms
-		-ms-filter 'progid:DXImageTransform.Microsoft.Alpha(Opacity=${0:100})'
+	-ms-filter 'progid:DXImageTransform.Microsoft.Alpha(Opacity=${0:100})'
 snippet orp
-		orphans ${0}
+	orphans ${0}
 snippet o+
-		outline ${1:1px} ${2:solid} ${0}
+	outline ${1:1px} ${2:solid} ${0}
 snippet oc
-		outline-color ${0}
+	outline-color ${0}
 snippet oc:i
-		outline-color invert
+	outline-color invert
 snippet oo
-		outline-offset ${0}
+	outline-offset ${0}
 snippet os
-		outline-style ${0}
+	outline-style ${0}
 snippet ow
-		outline-width ${0}
+	outline-width ${0}
 snippet o
-		outline ${0}
+	outline ${0}
 snippet o:n
-		outline none
+	outline none
 snippet ovs
-		overflow-style ${0}
+	overflow-style ${0}
 snippet ovs:a
-		overflow-style auto
+	overflow-style auto
 snippet ovs:mq
-		overflow-style marquee
+	overflow-style marquee
 snippet ovs:mv
-		overflow-style move
+	overflow-style move
 snippet ovs:p
-		overflow-style panner
+	overflow-style panner
 snippet ovs:s
-		overflow-style scrollbar
+	overflow-style scrollbar
 snippet ovx
-		overflow-x ${0}
+	overflow-x ${0}
 snippet ovx:a
-		overflow-x auto
+	overflow-x auto
 snippet ovx:h
-		overflow-x hidden
+	overflow-x hidden
 snippet ovx:s
-		overflow-x scroll
+	overflow-x scroll
 snippet ovx:v
-		overflow-x visible
+	overflow-x visible
 snippet ovy
-		overflow-y ${0}
+	overflow-y ${0}
 snippet ovy:a
-		overflow-y auto
+	overflow-y auto
 snippet ovy:h
-		overflow-y hidden
+	overflow-y hidden
 snippet ovy:s
-		overflow-y scroll
+	overflow-y scroll
 snippet ovy:v
-		overflow-y visible
+	overflow-y visible
 snippet ov
-		overflow ${0}
+	overflow ${0}
 snippet ov:a
-		overflow auto
+	overflow auto
 snippet ov:h
-		overflow hidden
+	overflow hidden
 snippet ov:s
-		overflow scroll
+	overflow scroll
 snippet ov:v
-		overflow visible
+	overflow visible
 snippet pb
-		padding-bottom ${0}
+	padding-bottom ${0}
 snippet pl
-		padding-left ${0}
+	padding-left ${0}
 snippet pr
-		padding-right ${0}
+	padding-right ${0}
 snippet pt
-		padding-top ${0}
+	padding-top ${0}
 snippet p
-		padding ${0}
+	padding ${0}
 snippet p:4
-		padding ${1:0} ${2:0} ${3:0} ${0:0}
+	padding ${1:0} ${2:0} ${3:0} ${0:0}
 snippet p:3
-		padding ${1:0} ${2:0} ${0:0}
+	padding ${1:0} ${2:0} ${0:0}
 snippet p:2
-		padding ${1:0} ${0:0}
+	padding ${1:0} ${0:0}
 snippet p:0
-		padding 0
+	padding 0
 snippet pgba
-		page-break-after ${0}
+	page-break-after ${0}
 snippet pgba:aw
-		page-break-after always
+	page-break-after always
 snippet pgba:a
-		page-break-after auto
+	page-break-after auto
 snippet pgba:l
-		page-break-after left
+	page-break-after left
 snippet pgba:r
-		page-break-after right
+	page-break-after right
 snippet pgbb
-		page-break-before ${0}
+	page-break-before ${0}
 snippet pgbb:aw
-		page-break-before always
+	page-break-before always
 snippet pgbb:a
-		page-break-before auto
+	page-break-before auto
 snippet pgbb:l
-		page-break-before left
+	page-break-before left
 snippet pgbb:r
-		page-break-before right
+	page-break-before right
 snippet pgbi
-		page-break-inside ${0}
+	page-break-inside ${0}
 snippet pgbi:a
-		page-break-inside auto
+	page-break-inside auto
 snippet pgbi:av
-		page-break-inside avoid
+	page-break-inside avoid
 snippet pos
-		position ${0}
+	position ${0}
 snippet pos:a
-		position absolute
+	position absolute
 snippet pos:f
-		position fixed
+	position fixed
 snippet pos:r
-		position relative
+	position relative
 snippet pos:s
-		position static
+	position static
 snippet q
-		quotes ${0}
+	quotes ${0}
 snippet q:en
-		quotes '\201C' '\201D' '\2018' '\2019'
+	quotes '\201C' '\201D' '\2018' '\2019'
 snippet q:n
-		quotes none
+	quotes none
 snippet q:ru
-		quotes '\00AB' '\00BB' '\201E' '\201C'
+	quotes '\00AB' '\00BB' '\201E' '\201C'
 snippet rz
-		resize ${0}
+	resize ${0}
 snippet rz:b
-		resize both
+	resize both
 snippet rz:h
-		resize horizontal
+	resize horizontal
 snippet rz:n
-		resize none
+	resize none
 snippet rz:v
-		resize vertical
+	resize vertical
 snippet r
-		right ${0}
+	right ${0}
 snippet r:a
-		right auto
+	right auto
 snippet tbl
-		table-layout ${0}
+	table-layout ${0}
 snippet tbl:a
-		table-layout auto
+	table-layout auto
 snippet tbl:f
-		table-layout fixed
+	table-layout fixed
 snippet tal
-		text-align-last ${0}
+	text-align-last ${0}
 snippet tal:a
-		text-align-last auto
+	text-align-last auto
 snippet tal:c
-		text-align-last center
+	text-align-last center
 snippet tal:l
-		text-align-last left
+	text-align-last left
 snippet tal:r
-		text-align-last right
+	text-align-last right
 snippet ta
-		text-align ${0}
+	text-align ${0}
 snippet ta:c
-		text-align center
+	text-align center
 snippet ta:l
-		text-align left
+	text-align left
 snippet ta:r
-		text-align right
+	text-align right
 snippet td
-		text-decoration ${0}
+	text-decoration ${0}
 snippet td:l
-		text-decoration line-through
+	text-decoration line-through
 snippet td:n
-		text-decoration none
+	text-decoration none
 snippet td:o
-		text-decoration overline
+	text-decoration overline
 snippet td:u
-		text-decoration underline
+	text-decoration underline
 snippet te
-		text-emphasis ${0}
+	text-emphasis ${0}
 snippet te:ac
-		text-emphasis accent
+	text-emphasis accent
 snippet te:a
-		text-emphasis after
+	text-emphasis after
 snippet te:b
-		text-emphasis before
+	text-emphasis before
 snippet te:c
-		text-emphasis circle
+	text-emphasis circle
 snippet te:ds
-		text-emphasis disc
+	text-emphasis disc
 snippet te:dt
-		text-emphasis dot
+	text-emphasis dot
 snippet te:n
-		text-emphasis none
+	text-emphasis none
 snippet th
-		text-height ${0}
+	text-height ${0}
 snippet th:a
-		text-height auto
+	text-height auto
 snippet th:f
-		text-height font-size
+	text-height font-size
 snippet th:m
-		text-height max-size
+	text-height max-size
 snippet th:t
-		text-height text-size
+	text-height text-size
 snippet ti
-		text-indent ${0}
+	text-indent ${0}
 snippet ti:-
-		text-indent -9999px
+	text-indent -9999px
 snippet tj
-		text-justify ${0}
+	text-justify ${0}
 snippet tj:a
-		text-justify auto
+	text-justify auto
 snippet tj:d
-		text-justify distribute
+	text-justify distribute
 snippet tj:ic
-		text-justify inter-cluster
+	text-justify inter-cluster
 snippet tj:ii
-		text-justify inter-ideograph
+	text-justify inter-ideograph
 snippet tj:iw
-		text-justify inter-word
+	text-justify inter-word
 snippet tj:k
-		text-justify kashida
+	text-justify kashida
 snippet tj:t
-		text-justify tibetan
+	text-justify tibetan
 snippet to+
-		text-outline ${1:0} ${2:0} ${0}
+	text-outline ${1:0} ${2:0} ${0}
 snippet to
-		text-outline ${0}
+	text-outline ${0}
 snippet to:n
-		text-outline none
+	text-outline none
 snippet tr
-		text-replace ${0}
+	text-replace ${0}
 snippet tr:n
-		text-replace none
+	text-replace none
 snippet tsh+
-		text-shadow ${1:0} ${2:0} ${3:0} ${0}
+	text-shadow ${1:0} ${2:0} ${3:0} ${0}
 snippet tsh
-		text-shadow ${0}
+	text-shadow ${0}
 snippet tsh:n
-		text-shadow none
+	text-shadow none
 snippet tt
-		text-transform ${0}
+	text-transform ${0}
 snippet tt:c
-		text-transform capitalize
+	text-transform capitalize
 snippet tt:l
-		text-transform lowercase
+	text-transform lowercase
 snippet tt:n
-		text-transform none
+	text-transform none
 snippet tt:u
-		text-transform uppercase
+	text-transform uppercase
 snippet tw
-		text-wrap ${0}
+	text-wrap ${0}
 snippet tw:no
-		text-wrap none
+	text-wrap none
 snippet tw:n
-		text-wrap normal
+	text-wrap normal
 snippet tw:s
-		text-wrap suppress
+	text-wrap suppress
 snippet tw:u
-		text-wrap unrestricted
+	text-wrap unrestricted
 snippet t
-		top ${0}
+	top ${0}
 snippet t:a
-		top auto
+	top auto
 snippet va
-		vertical-align ${0}
+	vertical-align ${0}
 snippet va:bl
-		vertical-align baseline
+	vertical-align baseline
 snippet va:b
-		vertical-align bottom
+	vertical-align bottom
 snippet va:m
-		vertical-align middle
+	vertical-align middle
 snippet va:sub
-		vertical-align sub
+	vertical-align sub
 snippet va:sup
-		vertical-align super
+	vertical-align super
 snippet va:tb
-		vertical-align text-bottom
+	vertical-align text-bottom
 snippet va:tt
-		vertical-align text-top
+	vertical-align text-top
 snippet va:t
-		vertical-align top
+	vertical-align top
 snippet v
-		visibility ${0}
+	visibility ${0}
 snippet v:c
-		visibility collapse
+	visibility collapse
 snippet v:h
-		visibility hidden
+	visibility hidden
 snippet v:v
-		visibility visible
+	visibility visible
 snippet whsc
-		white-space-collapse ${0}
+	white-space-collapse ${0}
 snippet whsc:ba
-		white-space-collapse break-all
+	white-space-collapse break-all
 snippet whsc:bs
-		white-space-collapse break-strict
+	white-space-collapse break-strict
 snippet whsc:k
-		white-space-collapse keep-all
+	white-space-collapse keep-all
 snippet whsc:l
-		white-space-collapse loose
+	white-space-collapse loose
 snippet whsc:n
-		white-space-collapse normal
+	white-space-collapse normal
 snippet whs
-		white-space ${0}
+	white-space ${0}
 snippet whs:n
-		white-space normal
+	white-space normal
 snippet whs:nw
-		white-space nowrap
+	white-space nowrap
 snippet whs:pl
-		white-space pre-line
+	white-space pre-line
 snippet whs:pw
-		white-space pre-wrap
+	white-space pre-wrap
 snippet whs:p
-		white-space pre
+	white-space pre
 snippet wid
-		widows ${0}
+	widows ${0}
 snippet w
-		width ${0}
+	width ${0}
 snippet w:a
-		width auto
+	width auto
 snippet wob
-		word-break ${0}
+	word-break ${0}
 snippet wob:ba
-		word-break break-all
+	word-break break-all
 snippet wob:bs
-		word-break break-strict
+	word-break break-strict
 snippet wob:k
-		word-break keep-all
+	word-break keep-all
 snippet wob:l
-		word-break loose
+	word-break loose
 snippet wob:n
-		word-break normal
+	word-break normal
 snippet wos
-		word-spacing ${0}
+	word-spacing ${0}
 snippet wow
-		word-wrap ${0}
+	word-wrap ${0}
 snippet wow:no
-		word-wrap none
+	word-wrap none
 snippet wow:n
-		word-wrap normal
+	word-wrap normal
 snippet wow:s
-		word-wrap suppress
+	word-wrap suppress
 snippet wow:u
-		word-wrap unrestricted
+	word-wrap unrestricted
 snippet z
-		z-index ${0}
+	z-index ${0}
 snippet z:a
-		z-index auto
+	z-index auto
 snippet zoo
-		zoom 1
+	zoom 1
 snippet :h
-		:hover
+	:hover
 snippet :fc
-		:first-child
+	:first-child
 snippet :lc
-		:last-child
+	:last-child
 snippet :nc
-		:nth-child(${0})
+	:nth-child(${0})
 snippet :nlc
-		:nth-last-child(${0})
+	:nth-last-child(${0})
 snippet :oc
-		:only-child
+	:only-child
 snippet :a
-		:after
+	:after
 snippet :b
-		:before
+	:before
 snippet ::a
-		::after
+	::after
 snippet ::b
-		::before
+	::before
 snippet if
-		if ${0}
+	if ${0}
 snippet mix
-		${1}(${0})
+	${1}(${0})
 snippet for
-		for ${1:i} in ${0}
+	for ${1:i} in ${0}
 snippet keyf
-		@keyframes ${0}
+	@keyframes ${0}


### PR DESCRIPTION
Quickly ran:
`sed -i 's/^\t\t/\t/g'` against stylus.snippets, should fix issue https://github.com/honza/vim-snippets/issues/613