### PR TITLE
Remove offensive haskell snippets

### DIFF
--- a/snippets/haskell.snippets
+++ b/snippets/haskell.snippets
@@ -57,19 +57,13 @@ snippet ap
 snippet do
 	do
 
-snippet λ
-	\\${1:x} -> ${0:expression}
 snippet \
 	\\${1:x} -> ${0:expression}
 snippet (\
 	(\\${1:x} -> ${0:expression})
 snippet <-
 	${1:a} <- ${0:m a}
-snippet ←
-	${1:a} <- ${0:m a}
 snippet ->
-	${1:m a} -> ${0:a}
-snippet →
 	${1:m a} -> ${0:a}
 snippet tup
 	(${1:a}, ${0:b})


### PR DESCRIPTION
Haskell snippets won't show up in autocomplete because of this. 
https://github.com/Valloric/YouCompleteMe/issues/1214
It doesn't matter anyway. those snippets impossible to type.