### PR TITLE
SCSS extends CSS snippets

### DIFF
--- a/snippets/scss.snippets
+++ b/snippets/scss.snippets
@@ -1,3 +1,5 @@
+extends css
+
 snippet $
 	$${1:variable}: ${0:value};
 snippet imp


### PR DESCRIPTION
Trying to trigger CSS snippets in SCSS files:
https://github.com/SirVer/ultisnips/issues/372

But the `extends css` was lost on this cleanup commit:
https://github.com/honza/vim-snippets/commit/6a11e1aa154552b873955ceaa25cf7c219aff805

