### PR TITLE
jasmine snippets updated old jasmine methods and added new ones from the library

### DIFF
--- a/UltiSnips/javascript-jasmine.snippets
+++ b/UltiSnips/javascript-jasmine.snippets
@@ -186,22 +186,6 @@ snippet scf "spy on and call fake (js)" b
 spyOn(${1:object}, '${2:method}').and.callFake(${3:function});
 endsnippet
 
-snippet esc "expect was called (js)" b
-expect(${1:target}).wasCalled();
-endsnippet
-
-snippet escw "expect was called with (js)" b
-expect(${1:target}).wasCalledWith(${2:arguments});
-endsnippet
-
-snippet notsc "expect was not called (js)" b
-expect(${1:target}).wasNotCalled();
-endsnippet
-
-snippet noscw "expect was not called with (js)" b
-expect(${1:target}).wasNotCalledWith(${2:arguments});
-endsnippet
-
 snippet ethbc "expect to have been called (js)" b
 expect(${1:target}).toHaveBeenCalled();
 endsnippet

--- a/UltiSnips/javascript-jasmine.snippets
+++ b/UltiSnips/javascript-jasmine.snippets
@@ -44,6 +44,24 @@ snippet any "any (js)" b
 jasmine.any($1)
 endsnippet
 
+snippet anyt "anything (js)" b
+jasmine.anything()
+endsnippet
+
+snippet objc "object containing (js)" b
+jasmine.objectContaining({
+	${VISUAL}$0
+});
+endsnippet
+
+snippet arrc "array containing (js)" b
+jasmine.arrayContaining([${1:value1}]);
+endsnippet
+
+snippet strm "string matching (js)" b
+jasmine.stringMatching("${1:matcher}")
+endsnippet
+
 snippet ru "runs (js)" b
 runs(function() {
 	$0

--- a/UltiSnips/javascript-jasmine.snippets
+++ b/UltiSnips/javascript-jasmine.snippets
@@ -171,19 +171,19 @@ spyOn(${1:object}, '${2:method}')$0;
 endsnippet
 
 snippet sr "spy on and return (js)" b
-spyOn(${1:object}, '${2:method}').andReturn(${3:arguments});
+spyOn(${1:object}, '${2:method}').and.returnValue(${3:arguments});
 endsnippet
 
 snippet st "spy on and throw (js)" b
-spyOn(${1:object}, '${2:method}').andThrow(${3:exception});
+spyOn(${1:object}, '${2:method}').and.throwError(${3:exception});
 endsnippet
 
 snippet sct "spy on and call through (js)" b
-spyOn(${1:object}, '${2:method}').andCallThrough();
+spyOn(${1:object}, '${2:method}').and.callThrough();
 endsnippet
 
 snippet scf "spy on and call fake (js)" b
-spyOn(${1:object}, '${2:method}').andCallFake(${3:function});
+spyOn(${1:object}, '${2:method}').and.callFake(${3:function});
 endsnippet
 
 snippet esc "expect was called (js)" b


### PR DESCRIPTION
1. Added new jasmine methods from the library (anything, objectContaining, stringMatching).
2. Removed wasCalled, wasCalledWith,wasNotCalled, wasNotCalledWith. These are deprecated for some time now, few older versions of jasmine(1.4) have made them aliases to new methods (toHaveBeenCalledWith) but later versions have complete dropped support (we are at 2.3 right now).
3. Updated, spy strategy methods andReturn, andThrow and andCallThrough to their current counter parts.

Jasmine reference: http://jasmine.github.io/2.3/introduction.html