### PR TITLE
Add comment ending ifndef block to ifndef c snippet

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -11,7 +11,7 @@ endsnippet
 snippet ifndef "#ifndef ... #define ... #endif"
 #ifndef ${1/([A-Za-z0-9_]+).*/$1/}
 #define ${1:SYMBOL} ${2:value}
-#endif
+#endif /* ifndef $1 */
 endsnippet
 
 snippet #if "#if #endif" b

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -25,7 +25,7 @@ snippet Inc
 snippet ndef
 	#ifndef $1
 	#define ${1:SYMBOL} ${2:value}
-	#endif
+	#endif /* ifndef $1 */
 # define
 snippet def
 	#define


### PR DESCRIPTION
It is generally considered good practice when defining C preprocessor if-statement blocks to include a closing comment so that the block will have the form:

    #ifndef _FOO_H_
    #define _FOO_H_
    ...
    #endif /* ifndef _FOO_H_ */

This is because preprocessor if-statements like this cannot be indented, so nesting can become messy. This should add those comments to the closing line of the `ifndef` snippet for the c language in both the Ultisnips and SnipMate formats.