### PR TITLE
Cpp include snippets

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -1,5 +1,11 @@
 extends c
 
+##
+## Preprocessor
+# #include <...>
+snippet inc
+	#include <${1:iostream}>
+##
 ## STL Collections
 # std::array
 snippet array

--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -5,6 +5,8 @@ extends c
 # #include <...>
 snippet inc
 	#include <${1:iostream}>
+snippet binc
+	#include <boost/${1:shared_ptr}.hpp>
 ##
 ## STL Collections
 # std::array


### PR DESCRIPTION
Hi,

Since constantly removing the ".h" extension when working with C++ STL include files is pretty annoying I've decided to add a C++ specific version of "inc" snippet.

Additionally I've added a simple "inc" snippet for boost headers.