### PR TITLE
Fix overall svg canvas height/width attribute

### DIFF
--- a/snippets/javascript/javascript.d3.snippets
+++ b/snippets/javascript/javascript.d3.snippets
@@ -16,8 +16,8 @@ snippet marginconvention
 	var ${8:height} = ${9:500} - $1.top - $1.bottom;
 	
 	var ${10:svg} = d3.select("${11}").append("svg")
-	  .attr("width", $6)
-	  .attr("height", $8)
+	  .attr("width", $6 + $1.left + $1.right)
+	  .attr("height", $8 + $1.top + $1.bottom)
 	    .append("g")
 	  .attr("transform", "translate(" + $1.left + "," + $1.top + ")")
 snippet nest


### PR DESCRIPTION
Typically the appended svg on line 18-20 needs to have a width/height that includes the margins. Details about the convention can be found here: http://bl.ocks.org/mbostock/3019563