### PR TITLE
Add simpler arrow function snippet

### DIFF
--- a/snippets/javascript/javascript.es6.snippets
+++ b/snippets/javascript/javascript.es6.snippets
@@ -16,6 +16,10 @@ snippet =>
 	(${0}) => {
 		${1}
 	}
+snippet af
+	(${0}) => {
+		${1}
+	}
 snippet sym
 	const ${0} = Symbol('${1}');
 snippet ed


### PR DESCRIPTION
Not only `af` is 1 less keystroke, and the keys are very close (home row of the keyboard). `=` + `shift` + `.` (`=>`) are too far away from each other and takes too long to type :)