### PR TITLE
Fixed spacing issue with box and bbox.

### DIFF
--- a/pythonx/vimsnippets.py
+++ b/pythonx/vimsnippets.py
@@ -78,7 +78,7 @@ def get_comment_format():
 
 
 def make_box(twidth, bwidth=None):
-    b, m, e, i = get_comment_format()
+    b, m, e, i = (s.strip() for s in get_comment_format())
     bwidth_inner = bwidth - 3 - max(len(b), len(i + e)) if bwidth else twidth + 2
     sline = b + m + bwidth_inner * m[0] + 2 * m[0]
     nspaces = (bwidth_inner - twidth) // 2


### PR DESCRIPTION
When commentstring had a trailing space, such as '# %s', the rendered
box was incorrect.