### PR TITLE
Remove duplicate ruby block snippets

### DIFF
--- a/UltiSnips/ruby.snippets
+++ b/UltiSnips/ruby.snippets
@@ -266,18 +266,6 @@ snippet "(\S+)\.Index" ".index do |item| ... end" r
 end
 endsnippet
 
-snippet do "do |<key>| ... end" i
-do |${1:args}|
-	$0
-end
-endsnippet
-
-snippet Do "do ... end" i
-do
-	$0
-end
-endsnippet
-
 snippet until "until <expression> ... end"
 until ${1:expression}
 	$0


### PR DESCRIPTION
Defined here:

https://github.com/honza/vim-snippets/blob/master/snippets/ruby.snippets#L425