### PR TITLE
Args start at ${1}

### DIFF
--- a/snippets/javascript/javascript.es6.snippets
+++ b/snippets/javascript/javascript.es6.snippets
@@ -1,26 +1,28 @@
 snippet const
-	const ${0} = ${1};
+	const ${1} = ${0};
 snippet let
-	let ${0} = ${1};
+	let ${1} = ${0};
 snippet im
-	import ${0} from '${1}';
+	import ${1} from '${0}';
 snippet cla
-	class ${0} {
-		${1}
+	class ${1} {
+		${0}
 	}
 snippet clax
-	class ${0} extends ${1} {
-		${2}
+	class ${1} extends ${2} {
+		${0}
 	}
 snippet =>
-	(${0}) => {
-		${1}
+	(${1}) => {
+		${0}
 	}
 snippet af
-	(${0}) => {
-		${1}
+	(${1}) => {
+		${0}
 	}
 snippet sym
-	const ${0} = Symbol('${1}');
+	const ${1} = Symbol('${0}');
 snippet ed
 	export default ${0}
+snippet ${
+	${${1}}${0}


### PR DESCRIPTION
${0} should be used as the end of snippet according to other snippets.
Besides, added new snippet `${` for argument of template strings. e.g.:
```
`${<tab>` // => `${cursor}`
```