### PR TITLE
PHP: trigger php 'array' snippet only for beginning of line.

### DIFF
--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -325,7 +325,7 @@ snippet foreachkil
 		${0:<!-- html... -->}
 	<?php endforeach; ?>
 # $... = array (...)
-snippet array
+snippet array b
 	$${1:arrayName} = array('${2}' => ${3});
 snippet try
 	try {


### PR DESCRIPTION
currently the 'array' snippet is also triggered when you are in phpDoc blocks like

```
/**
 * @param array $foo
```