### PR TITLE
python: do not use multiple commands on a single line

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -627,19 +627,23 @@ endsnippet
 #####################
 
 snippet pdb "Set PDB breakpoint" b
-import pdb; pdb.set_trace()
+import pdb
+pdb.set_trace()
 endsnippet
 
 snippet ipy "Embed IPython shell" b
-import IPython; IPython.embed()
+import IPython
+IPython.embed()
 endsnippet
 
 snippet ipdb "Set IPDB breakpoint" b
-import ipdb; ipdb.set_trace()
+import ipdb
+ipdb.set_trace()
 endsnippet
 
 snippet pudb "Set PUDB breakpoint" b
-import pudb; pudb.set_trace()
+import pudb
+pudb.set_trace()
 endsnippet
 
 snippet ae "Assert equal" b

--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -128,31 +128,39 @@ snippet _
 	__${1:init}__
 # python debugger (pdb)
 snippet pdb
-	import pdb; pdb.set_trace()
+	import pdb
+	pdb.set_trace()
 # ipython debugger (ipdb)
 snippet ipdb
-	import ipdb; ipdb.set_trace()
+	import ipdb
+	ipdb.set_trace()
 # embed ipython itself
 snippet iem
-	import IPython; IPython.embed()
+	import IPython
+	IPython.embed()
 # ipython debugger (pdbbb)
 snippet pdbbb
-	import pdbpp; pdbpp.set_trace()
+	import pdbpp
+	pdbpp.set_trace()
 # remote python debugger (rpdb)
 snippet rpdb
-	import rpdb; rpdb.set_trace()
+	import rpdb
+	rpdb.set_trace()
 # ptpython
 snippet ptpython
 	from ptpython.repl import embed
 	embed(globals(), locals(), vi_mode=${1:False}, history_filename=${2:None})
 # python console debugger (pudb)
 snippet pudb
-	import pudb; pudb.set_trace()
+	import pudb
+	pudb.set_trace()
 # pdb in nosetests
 snippet nosetrace
-	from nose.tools import set_trace; set_trace()
+	from nose.tools import set_trace
+	set_trace()
 snippet pprint
-	import pprint; pprint.pprint(${1})
+	import pprint
+	pprint.pprint(${1})
 snippet "
 	"""${0:doc}
 	"""


### PR DESCRIPTION
Otherwise style checkers will usually complain about it, and e.g.
'flake8' cannot be made to ignore it with '# noqa' at the end.