### PR TITLE
Change Rails snippet triggers

### DIFF
--- a/UltiSnips/rails.snippets
+++ b/UltiSnips/rails.snippets
@@ -15,7 +15,7 @@ t.boolean :${1:title}
 $0
 endsnippet
 
-snippet cla "Create controller class"
+snippet clac "Create controller class"
 class ${1:Model}Controller < ApplicationController
 	before_filter :find_${2:model}
 
@@ -48,7 +48,7 @@ t.float :${1:title}
 $0
 endsnippet
 
-snippet cla "Create functional test class"
+snippet clact "Create functional test class"
 require 'test_helper'
 
 class ${1:Model}ControllerTest < ActionController::TestCase


### PR DESCRIPTION
At present, `cla` maps to both Create Controller Class and Create
Functional Test class.

Using `cla` for creating a controller seems overly-general, since we may
want triggers for other types of classes, e.g. models. So I propose
changing this to `clac`.

And to remove ambiguity, I propose using `clact` for the controller test.