### PR TITLE
Fixing nested snippet for Rust `let`/`letm`

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -34,11 +34,11 @@ snippet main "Main function"
 snippet let "let variable declaration with type inference"
 	let ${1}  = ${2};
 snippet lett "let variable declaration with explicit type annotation"
-	let ${1}: ${2}  = ${2};
+	let ${1}: ${2}  = ${3};
 snippet letm "let mut variable declaration with type inference"
 	let ${1}  = ${2};
 snippet lettm "let mut variable declaration with explicit type annotation"
-	let ${1}: ${2}  = ${2};
+	let ${1}: ${2}  = ${3};
 snippet pln "println!"
 	println!("${1}");
 snippet pln, "println! with format param"

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -31,10 +31,14 @@ snippet main "Main function"
 	pub fn main() {
 		${0}
 	}
-snippet let "let variable declaration"
-	let ${1:name}${2:: ${3:type}} = ${4};
-snippet letm "let mut variable declaration"
-	let mut ${1:name}${2:: ${3:type}} = ${4};
+snippet let "let variable declaration with type inference"
+	let ${1}  = ${2};
+snippet lett "let variable declaration with explicit type annotation"
+	let ${1}: ${2}  = ${2};
+snippet letm "let mut variable declaration with type inference"
+	let ${1}  = ${2};
+snippet lettm "let mut variable declaration with explicit type annotation"
+	let ${1}: ${2}  = ${2};
 snippet pln "println!"
 	println!("${1}");
 snippet pln, "println! with format param"


### PR DESCRIPTION
When expanding the `let` pattern, one would end up with something like 
`let I: I${4:type} = I;` 
(I representing the cursor jump marks), so the nested jump marks are inserted literally.

I fixed that unwanted behaviour by replacing the `let` and `letm` patterns by `let` (for immutable variable bindings with type inference), `lett` (for immutable variable bindings with explicit type annotation), `letm` (for mutable variable bindings with type inference) and `lettm` (for mutable variable bindings with explicit type annotation).