### PR TITLE
Rust: remove semicolons from constructor returns

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -88,7 +88,7 @@ pub struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
 
 impl $1 {
 	pub fn new(${2}) -> $1 {
-		$1 { ${3} };
+		$1 { ${3} }
 	}
 }
 endsnippet

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -25,7 +25,7 @@ snippet bench "Bench function" b
 	}
 snippet new "Constructor function"
 	pub fn new(${2}) -> ${1:Name} {
-		$1 { ${3} };
+		$1 { ${3} }
 	}
 snippet main "Main function"
 	pub fn main() {
@@ -143,7 +143,7 @@ snippet stn "Struct with new constructor"
 
 	impl $1 {
 		pub fn new(${2}) -> $1 {
-			$1 { ${3} };
+			$1 { ${3} }
 		}
 	}
 snippet type "Type alias"


### PR DESCRIPTION
I'm sort of new to Rust and this is quite a minor change, so excuse me if I'm wrong here but I think the current constructor snippets are incorrect. With the semicolons the return type of the constructors are () not the struct type.