### PR TITLE
UltiSnips/java.snippets: Adds numbers to word in getArgs, Removes whitespace after braces

### DIFF
--- a/UltiSnips/java.snippets
+++ b/UltiSnips/java.snippets
@@ -124,7 +124,7 @@ for i in args:
 	\tthis." + i[1] + " = " + i[1] + ";\n\t}\n"
 
 	snip.rv += "\n\tpublic " + i[0] + " get" + camel(i[1]) + "() {\n\
-	\t\treturn " + i[1] + ";\n\t}\n"
+	\treturn " + i[1] + ";\n\t}\n"
 `
 }
 endsnippet
@@ -326,11 +326,11 @@ snippet md "Method With javadoc" b
  * ${7:Short Description}`!p
 for i in getArgs(t[4]):
 	snip.rv += "\n\t * @param " + i[1] + " usage..."`
- * `!p
+ *`!p
 if "throws" in t[5]:
 	snip.rv = "\n\t * @throws " + t[6]
 else:
-	snip.rv = ""` `!p
+	snip.rv = ""``!p
 if not "void" in t[2]:
 	snip.rv = "\n\t * @return object"
 else:
@@ -356,8 +356,7 @@ endsnippet
 snippet /se?tge?t|ge?tse?t|gs/ "setter and getter" br
 public void set${1:Name}(${2:String} `!p snip.rv = mixedCase(t[1])`) {
 	this.`!p snip.rv = mixedCase(t[1])` = `!p snip.rv = mixedCase(t[1])`;
-}
-
+}`!p snip.rv += "\n"`
 public $2 get$1() {
 	return `!p snip.rv = mixedCase(t[1])`;
 }

--- a/UltiSnips/java.snippets
+++ b/UltiSnips/java.snippets
@@ -21,7 +21,7 @@ def nl(snip):
 		snip.rv += " "
 def getArgs(group):
 	import re
-	word = re.compile('[a-zA-Z><.]+ \w+')
+	word = re.compile('[a-zA-Z0-9><.]+ \w+')
 	return [i.split(" ") for i in word.findall(group) ]
 
 def camel(word):
@@ -109,7 +109,7 @@ for i in args:
 	snip.rv += "\n\tprivate " + i[0] + " " + i[1]+ ";"
 if len(args) > 0:
 	snip.rv += "\n"`
-	public `!p snip.rv = snip.basename or "unknown"`($1) { `!p
+	public `!p snip.rv = snip.basename or "unknown"`($1) {`!p
 args = getArgs(t[1])
 for i in args:
 	snip.rv += "\n\t\tthis." + i[1] + " = " + i[1] + ";"
@@ -123,8 +123,8 @@ for i in args:
 	snip.rv += "\n\tpublic void set" + camel(i[1]) + "(" + i[0] + " " + i[1] + ") {\n" + "\
 	\tthis." + i[1] + " = " + i[1] + ";\n\t}\n"
 
-	snip.rv += "\n\tpublic " + i[0] + " get" + camel(i[1]) + "() {\
-	\n\t\treturn " + i[1] + ";\n\t}\n"
+	snip.rv += "\n\tpublic " + i[0] + " get" + camel(i[1]) + "() {\n\
+	\t\treturn " + i[1] + ";\n\t}\n"
 `
 }
 endsnippet
@@ -138,7 +138,7 @@ for i in args:
 	snip.rv += "\n\tprivate " + i[0] + " " + i[1]+ ";"
 if len(args) > 0:
 	snip.rv += "\n"`
-	public `!p snip.rv = snip.basename or "unknown"`($1) { `!p
+	public `!p snip.rv = snip.basename or "unknown"`($1) {`!p
 args = getArgs(t[1])
 for i in args:
 	snip.rv += "\n\t\tthis.%s = %s;" % (i[1], i[1])
@@ -266,7 +266,7 @@ for i in args:
 	snip.rv += "\n\tprivate " + i[0] + " " + i[1]+ ";"
 if len(args) > 0:
 	snip.rv += "\n"`
-public `!p snip.rv = snip.basename or "unknown"`($1) { `!p
+public `!p snip.rv = snip.basename or "unknown"`($1) {`!p
 args = getArgs(t[1])
 for i in args:
 	snip.rv += "\n\t\tthis.%s = %s;" % (i[1], i[1])


### PR DESCRIPTION
For UltiSnips/java.snippets: currently variables added into clc parameters are ignored when they contain numbers, this PR changes it so numbers are allowed. Use case: [some classes have numbers in them](https://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/math/Vector2.html)

Braces also had a few characters of white space, which I've removed. It's easier to see it in a [screenshot with highlighted white space](https://i.sli.mg/VEAS8D.png) (left is current master, right is this PR's changes)

I don't think this breaks anything but haven't tested it extensively. I did try all 3 clc snippets and the md snippet and they look okay to me.