### PR TITLE
fix 'sbash' snippet interpreting newline and tab character

### DIFF
--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -34,7 +34,10 @@ snippet !env "#!/usr/bin/env (!env)"
 endsnippet
 
 snippet sbash "safe bash options"
-`!p snip.rv = '#!/usr/bin/env bash' +  "\nset -euo pipefail\nIFS=$'\n\t'" + "\n\n" `
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+`!p snip.rv ='\n\n' `
 endsnippet
 
 snippet temp "Tempfile"


### PR DESCRIPTION
This pullrequest: https://github.com/honza/vim-snippets/pull/704 introduced a
new bug of the 'sbash' snippet of Ultisnips. Python interpreted the \n and \t in
IFS=$'\n\t' and executed them instead of assigning it to the variable IFS.