### PR TITLE
C++: Add a snippet to generate an entire .h skeleton

### DIFF
--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -54,4 +54,20 @@ snippet tp "template <typename ..> (template)"
 template <typename ${1:_InputIter}>
 endsnippet
 
+snippet cla "An entire .h generator" b
+#ifndef ${2:`!v substitute(vim_snippets#Filename('$1_H','ClassName'),'.*','\U&\E','')`}
+#define $2
+
+class ${1:`!v substitute(substitute(vim_snippets#Filename('$1','ClassName'),'^.','\u&',''), '_\(\w\)', '\u\1', 'g')`}
+{
+private:
+	${3}
+
+public:
+	$1();
+	virtual ~$1();
+};
+
+#endif /* $2 */
+endsnippet
 # vim:ft=snippets:


### PR DESCRIPTION
Hi!

Here is a snippet I created and use a lot. It's similar to the 'cl' snippet that already exists for C++ with
some improvements.

Basically, if the current file is "class.h", typing `cla<Tab>` will give:

``` C++
#ifndef CLASS_H
#define CLASS_H

class Class
{
private:
	

public:
	Class();
	virtual ~Class();
};

#endif /* CLASS_H */
```

Notice how the header guard and the class name are automatically derived from the filename with the conventional capitalization. There are three tabstops: the first one at the class name, the second one at the header guard name, and the third one after "private:".

This is my first snippet so it's very possible there are things I've not done right. I tested it extensively though.