### PR TITLE
Fix for R snippets: Close the Else-If snippet

### DIFF
--- a/UltiSnips/r.snippets
+++ b/UltiSnips/r.snippets
@@ -59,6 +59,7 @@ snippet eif "Else-If statement"
 else if (${1}) {
 	${0}
 }
+endsnippet
 
 snippet el "Else statement"
 else {


### PR DESCRIPTION
The Else-If snippet is not closed in file `Ultisnips/r.snippets`. This patch fixes this.