### PR TITLE
Add snippet for casting in CPP

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -106,6 +106,19 @@ snippet cout
 snippet cin
 	std::cin >> ${1};
 ##
+## Casts
+# static
+snippet sca
+	static_cast<${1:unsigned}>(${2:expr})${3}
+# dynamic
+snippet dca
+	dynamic_cast<${1:unsigned}>(${2:expr})${3}
+# reinterpret
+snippet rca
+	reinterpret_cast<${1:unsigned}>(${2:expr})${3}
+# const
+snippet cca
+	const_cast<${1:unsigned}>(${2:expr})${3}
 ## Iteration
 # for i
 snippet fori


### PR DESCRIPTION
The  default type for the cast is unsigned because static_cast are often used display a number contained in a char.