### PR TITLE
	snippet `pmdoc`: fix year generate error and make variables more readable

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -690,16 +690,16 @@ ${1:${VISUAL:doc}}
 `!p snip.rv = triple_quotes(snip)`
 endsnippet
 
-snippet pmdoc "pocoo style module doc sting" b
+snippet pmdoc "pocoo style module doc string" b
 # -*- coding: utf-8 -*-
 """
 	`!p snip.rv = get_dir_and_file_name(snip)`
 	`!p snip.rv = '~' * len(get_dir_and_file_name(snip))`
 
-	${1:YOURDOCSTRING}
+	${1:DESCRIPTION}
 
-	:copyright: (c) `date +Y%` by ${2:YOURNAME}.
-	:license: ${3:YOURLICENSE}, see LICENSE for more details.
+	:copyright: (c) `date +%Y` by ${2:YOUR_NAME}.
+	:license: ${3:LICENSE_NAME}, see LICENSE for more details.
 """
 $0
 endsnippet


### PR DESCRIPTION
Sorry, I should test it before.