### PR TITLE
Updated PHPUnit, Symfony and Laravel class snippets to be consistent with existing PHP snippets

### DIFF
--- a/UltiSnips/php-laravel.snippets
+++ b/UltiSnips/php-laravel.snippets
@@ -36,6 +36,8 @@ endsnippet
 
 #service service provider
 snippet l_ssp "Laravel service provider for service" b
+<?php
+
 /*!
  * \namespace   $1
  * \class       $2
@@ -62,6 +64,8 @@ endsnippet
 
 #repository service provider
 snippet l_rsp "Laravel service provider for repository" b
+<?php
+
 /*!
  * \namespace   $2
  * \class       $3
@@ -100,6 +104,8 @@ endsnippet
 
 #model
 snippet l_md "Laravel simple model" b
+<?php
+
 /*!
  * \namespace   $1
  * \class       $2
@@ -123,6 +129,8 @@ endsnippet
 
 #abstract repository
 snippet l_ar "Laravel abstract Repository" b
+<?php
+
 /*!
  * \namespace   $1
  * \class       $2
@@ -189,6 +197,8 @@ endsnippet
 
 #repository
 snippet l_r "Laravel Repository" b
+<?php
+
 /*!
  * \namespace   $1
  * \class       $3
@@ -207,6 +217,8 @@ endsnippet
 
 #service
 snippet l_s "Laravel Service" b
+<?php
+
 /*!
  * \namespace   $1
  * \class       $2
@@ -233,6 +245,8 @@ endsnippet
 
 #facade
 snippet l_f "Laravel Facade" b
+<?php
+
 /*!
  * \namespace   $1
  * \class       $2

--- a/UltiSnips/php-phpunit.snippets
+++ b/UltiSnips/php-phpunit.snippets
@@ -3,15 +3,17 @@
 priority -50
 
 snippet test "phpunit test class" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
 
 /**
- * @author `whoami`
+ * @author `!v g:snips_author`
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()

--- a/UltiSnips/php-symfony2.snippets
+++ b/UltiSnips/php-symfony2.snippets
@@ -4,15 +4,17 @@
 priority -50
 
 snippet classn "Basic class with namespace snippet" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
 
 /**
- * ${1:@author `whoami`}
+ * ${1:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
@@ -26,9 +28,11 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet contr "Symfony2 controller" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -40,7 +44,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * ${1:@author `whoami`}
+ * ${1:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
@@ -72,13 +76,15 @@ public function ${1}Action(${2})
 	${6}
 	return [];
 }`!p
-abspath = os.path.abspath(path)`
+relpath = os.path.relpath(path)`
 endsnippet
 
 snippet comm "Symfony2 command" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -90,7 +96,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * ${3:@author `whoami`}
+ * ${3:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
@@ -113,9 +119,11 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet subs "Symfony2 subscriber" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -123,7 +131,7 @@ if m:
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * ${1:@author `whoami`}
+ * ${1:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
@@ -144,9 +152,11 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet transf "Symfony2 form data transformer" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -155,7 +165,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
- * ${3:@author `whoami`}
+ * ${3:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
@@ -178,9 +188,11 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet ent "Symfony2 doctrine entity" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -188,7 +200,7 @@ if m:
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * ${3:@author `whoami`}
+ * ${3:@author `!v g:snips_author`}
  *
  * @ORM\Entity()
  * @ORM\Table(name="`!p
@@ -215,9 +227,11 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet form "Symfony2 form type" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -227,7 +241,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * ${2:@author `whoami`}
+ * ${2:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
@@ -259,9 +273,11 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet ev "Symfony2 event" b
+<?php
+
 namespace `!p
-abspath = os.path.abspath(path)
-m = re.search(r'[A-Z].+(?=/)', abspath)
+relpath = os.path.relpath(path)
+m = re.search(r'[A-Z].+(?=/)', relpath)
 if m:
 	snip.rv = m.group().replace('/', '\\')
 `;
@@ -269,7 +285,7 @@ if m:
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * ${2:@author `whoami`}
+ * ${2:@author `!v g:snips_author`}
  */
 class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()


### PR DESCRIPTION
Updated PHPUnit, Symfony and Laravel class snippets to be consistent with existing PHP snippets, using a relative path derived namespace and adding `<?php` before class definition

![](https://media1.giphy.com/media/U0Z7OnfSZuOZi/200.gif)