### PR TITLE
add visual interpolation to tex snippets

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -16,57 +16,57 @@ snippet dmo \DeclareMathOperator
 # \begin{}...\end{}
 snippet begin \begin{} ... \end{} block
 	\begin{${1:env}}
-		${0}
+		${0:${VISUAL}}
 	\end{$1}
 # Tabular
 snippet tab tabular (or arbitrary) environment
 	\begin{${1:tabular}}{${2:c}}
-		${0}
+		${0:${VISUAL}}
 	\end{$1}
 snippet thm thm (or arbitrary) environment with optional argument
 	\begin[${1:author}]{${2:thm}}
-		${0}
+		${0:${VISUAL}}
 	\end{$2}
 snippet center center environment
 	\begin{center}
-		${0}
+		${0:${VISUAL}}
 	\end{center}
 # Align(ed)
 snippet ali align(ed) environment
 	\begin{align${1:ed}}
 		\label{eq:${2}}
-		${0}
+		${0:${VISUAL}}
 	\end{align$1}
 # Gather(ed)
 snippet gat gather(ed) environment
 	\begin{gather${1:ed}}
-		${0}
+		${0:${VISUAL}}
 	\end{gather$1}
 # Equation
 snippet eq equation environment
 	\begin{equation}
-		${0}
+		${0:${VISUAL}}
 	\end{equation}
 # Equation
 snippet eql Labeled equation environment
 	\begin{equation}
 		\label{eq:${2}}
-	${0}
+	${0:${VISUAL}}
 	\end{equation}
 # Equation
 snippet eq* unnumbered equation environment
 	\begin{equation*}
-		${0}
+		${0:${VISUAL}}
 	\end{equation*}
 # Unnumbered Equation
 snippet \ unnumbered equation: \[ ... \]
 	\[
-		${0}
+		${0:${VISUAL}}
 	\]
 # Equation array
 snippet eqnarray eqnarray environment
 	\begin{eqnarray}
-		${0}
+		${0:${VISUAL}}
 	\end{eqnarray}
 # Label
 snippet lab \label
@@ -90,7 +90,7 @@ snippet itemize itemize environment
 		\item ${0}
 	\end{itemize}
 snippet item \item
-	\item ${1}
+	\item ${1:${VISUAL}}
 # Description
 snippet desc description environment
 	\begin{description}
@@ -103,18 +103,18 @@ snippet ]i \item (recursive)
 # Matrix
 snippet mat smart matrix environment
 	\begin{${1:p/b/v/V/B/small}matrix}
-		${0}
+		${0:${VISUAL}}
 	\end{$1matrix}
 # Cases
 snippet cas cases environment
 	\begin{cases}
 		${1:equation}, &\text{ if }${2:case}\\
-		${0}
+		${0:${VISUAL}}
 	\end{cases}
 # Split
 snippet spl split environment
 	\begin{split}
-		${0}
+		${0:${VISUAL}}
 	\end{split}
 # Part
 snippet part document \part
@@ -203,32 +203,32 @@ snippet fcite \footcite[]{}
 	\footcite[${1}]{${2}}${0}
 #Formating text: italic, bold, underline, small capital, emphase ..
 snippet it italic text
-	\textit{${0:text}}
+	\textit{${0:${VISUAL:text}}}
 snippet bf bold face text
-	\textbf{${0:text}}
+	\textbf{${0:${VISUAL:text}}}
 snippet under underline text
-	\underline{${0:text}}
+	\underline{${0:${VISUAL:text}}}
 snippet emp emphasize text
-	\emph{${0:text}}
+	\emph{${0:${VISUAL:text}}}
 snippet sc small caps text
-	\textsc{${0:text}}
+	\textsc{${0:${VISUAL:text}}}
 #Choosing font
 snippet sf sans serife text
-	\textsf{${0:text}}
+	\textsf{${0:${VISUAL:text}}}
 snippet rm roman font text
-	\textrm{${0:text}}
+	\textrm{${0:${VISUAL:text}}}
 snippet tt typewriter (monospace) text
-	\texttt{${0:text}}
+	\texttt{${0:${VISUAL:text}}}
 #Math font
 snippet mf mathfrak
-	\mathfrak{${0:text}}
+	\mathfrak{${0:${VISUAL:text}}}
 snippet mc mathcal
-	\mathcal{${0:text}}
+	\mathcal{${0:${VISUAL:text}}}
 snippet ms mathscr
-	\mathscr{${0:text}}
+	\mathscr{${0:${VISUAL:text}}}
 #misc
 snippet ft \footnote
-	\footnote{${0:text}}
+	\footnote{${0:${VISUAL:text}}}
 snippet fig figure environment (includegraphics)
 	\begin{figure}
 	\begin{center}
@@ -260,19 +260,19 @@ snippet lim \lim_{}
 	\lim_{${1:n \to \infty}} ${0}
 snippet frame frame environment
 	\begin{frame}[${1:t}]{${2:title}}
-		${0}
+		${0:${VISUAL}}
 	\end{frame}
 snippet block block environment
 	\begin{block}{${1:title}}
-	${0}
+	${0:${VISUAL}}
 	\end{block}
 snippet alert alertblock environment
 	\begin{alertblock}{${1:title}}
-	${0}
+	${0:${VISUAL}}
 	\end{alertblock}
 snippet example exampleblock environment
 	\begin{exampleblock}{${1:title}}
-	${0}
+	${0:${VISUAL}}
 	\end{exampleblock}
 snippet col2 two-column environment
 	\begin{columns}
@@ -301,7 +301,7 @@ snippet lra langle rangle
 # Code listings
 snippet lst
 	\begin{listing}[language=${1:language}]
-		${0}
+		${0:${VISUAL}}
 	\end{listing}
 snippet lsi
 	\lstinline|${1}| ${0}


### PR DESCRIPTION
Adds the ability to surround visual selection with tex snippets. Shouldn't change default behaviour. See [here](http://vimcasts.org/episodes/ultisnips-visual-placeholder/) for a video.

I've left out a few that do apply but might want python (such as the itemize ones), as I'm not sure how to do them.

Repro:
Visual select, tab, type snippet, tab
visual selection should now be surrounded.