### PR TITLE
Add coma at the end of lambda snippets for cpp

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -146,9 +146,9 @@ snippet itera
 ## Lambdas
 # lamda (one line)
 snippet ld
-	[${1}](${2}){${3}}
+	[${1}](${2}){${3}};
 # lambda (multi-line)
 snippet lld
 	[${1}](${2}){
 		${3}
-	}
+	};


### PR DESCRIPTION
in CPP lambda declarations needs to be coma terminated : [doc](http://en.cppreference.com/w/cpp/language/lambda)