### PR TITLE
semicolon prepended to iife in js

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -65,9 +65,9 @@ function($1) {
 endsnippet
 
 snippet iife "Immediately-Invoked Function Expression (iife)"
-(function(${1:window}) {
+;(function(${1:window}) {
 	${VISUAL}$0
-}(${2:$1}));
+}(${2:$1}))
 endsnippet
 
 snippet timeout "setTimeout function"


### PR DESCRIPTION
this is generally agreed upon, even by both sides of the semicolon in js debate,because it will prevent some errors in minifying code.