### PR TITLE
Fix csrf snippet name in htmldjango

### DIFF
--- a/UltiSnips/htmldjango.snippets
+++ b/UltiSnips/htmldjango.snippets
@@ -186,7 +186,7 @@ snippet iblock "" bi
 {% block ${1:blockname} %}${VISUAL}{% endblock $1 %}
 endsnippet
 
-snippet csfr "" bi
+snippet csrf "" bi
 {% csrf_token %}
 endsnippet
 


### PR DESCRIPTION
The snippet was previously registered as "csfr"