### PR TITLE
Strict typed snippets for PHP getters

### DIFF
--- a/UltiSnips/php.snippets
+++ b/UltiSnips/php.snippets
@@ -1,5 +1,14 @@
 priority -50
 
+global !p
+import vim
+
+# Set g:ultisnips_php_scalar_types to 1 if you'd like to enable PHP 7's scalar types for return values
+def isPHPScalarTypesEnabled():
+	isEnabled = vim.eval("get(g:, 'ultisnips_php_scalar_types', 0)") == "1"
+	return isEnabled or re.match('<\?php\s+declare\(strict_types=[01]\);', '\n'.join(vim.current.window.buffer))
+endglobal
+
 ## Snippets from SnipMate, taken from
 ## https://github.com/scrooloose/snipmate-snippets.git
 
@@ -9,7 +18,7 @@ snippet gm "PHP Class Getter" b
  *
  * @return ${2:string}
  */
-public function get${1/\w+\s*/\u$0/}()
+public function get${1/\w+\s*/\u$0/}()`!p snip.rv = ': '+t[2] if isPHPScalarTypesEnabled() else ''`
 {
     return $this->$1;
 }
@@ -36,7 +45,7 @@ snippet gs "PHP Class Getter Setter" b
  *
  * @return ${2:string}
  */
-public function get${1/\w+\s*/\u$0/}()
+public function get${1/\w+\s*/\u$0/}()`!p snip.rv = ': '+t[2] if isPHPScalarTypesEnabled() else ''`
 {
     return $this->$1;
 }

--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -2,6 +2,8 @@ snippet <?
 	<?php
 
 	${0}
+snippet dst "declare(strict_types=1)"
+	declare(strict_types=${1:1});
 snippet ec
 	echo ${0};
 snippet <?e


### PR DESCRIPTION
Strict typed snippets for PHP getters that check `declare(strict_types=1)` or for `g:ultisnips_php_scalar_types=1`. This is for issue #741 

![](http://67.media.tumblr.com/5759b3aa9d2150321e5979e51dcb136b/tumblr_o98k7fpFOh1s2wio8o1_500.gif)