### PR TITLE
add fnt,refl,tb3x4 for markdown

### DIFF
--- a/UltiSnips/markdown.snippets
+++ b/UltiSnips/markdown.snippets
@@ -1,5 +1,27 @@
 priority -50
 
+global !p
+def create_table(snip):
+    # retrieving single line from current string and treat it like tabstops count
+    placeholders_string = snip.buffer[snip.line].strip().split("x",1)
+    rows_amount = int(placeholders_string[0])
+    columns_amount = int(placeholders_string[1])
+
+    # erase current line
+    snip.buffer[snip.line] = ''
+
+    # create anonymous snippet with expected content and number of tabstops
+    anon_snippet_title = ' | '.join(['$' + str(col) for col in range(1,columns_amount+1)]) + "\n"
+    anon_snippet_delimiter = ':-|' * (columns_amount-1) + ":-\n"
+    anon_snippet_body = ""
+    for row in range(1,rows_amount+1):
+        anon_snippet_body += ' | '.join(['$' + str(row*columns_amount+col) for col in range(1,columns_amount+1)]) + "\n"
+    anon_snippet_table = anon_snippet_title + anon_snippet_delimiter + anon_snippet_body
+
+    # expand anonymous snippet
+    snip.expand_anon(anon_snippet_table)
+endglobal
+
 ###########################
 # Sections and Paragraphs #
 ###########################
@@ -48,6 +70,23 @@ snippet cbl "Codeblock" b
 $1
 \`\`\`
 $0
+endsnippet
+
+snippet refl "Reference Link"
+[${1:${VISUAL:Text}}][${2:id}]$0
+
+[$2]:${4:http://${3:www.url.com}} "${5:$4}"
+endsnippet
+
+snippet fnt "Footnote"
+[^${1:${VISUAL:Footnote}}]$0
+
+[^$1]:${2:Text}
+endsnippet
+
+post_jump "create_table(snip)"
+snippet "tb(\d+x\d+)" "Customizable table" br
+`!p snip.rv = match.group(1)`
 endsnippet
 
 # vim:ft=snippets:


### PR DESCRIPTION
Add footnote, reference link, and customizable table for markdown. For example, tb3x5 will insert a table with 3 rows and 5 columns. tb2x7 will insert a table with 2 rows and 7 columns.