### PR TITLE
Rename CPP inc snippet to prevent name collision with C inc snippet. Fixes #695.

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -3,7 +3,7 @@ extends c
 ##
 ## Preprocessor
 # #include <...>
-snippet inc
+snippet incc
 	#include <${1:iostream}>
 snippet binc
 	#include <boost/${1:shared_ptr}.hpp>


### PR DESCRIPTION
I renamed the snippet as incc. Of course, a better name could be chosen if required.