### PR TITLE
extended html in snippets/eruby

### DIFF
--- a/snippets/eruby.snippets
+++ b/snippets/eruby.snippets
@@ -1,6 +1,7 @@
 # .erb and .rhmtl files
 
 # Includes html.snippets
+extends html
 
 # Rails *****************************
 snippet rc


### PR DESCRIPTION
Adding extend html to snippets/eruby.snippets.

I tested this using UltiSnips both with and without the UltiSnips directory and it seems to work.  It seems strange that it was missing to begin with, even though there was a comment saying that it *was* included.   

