### PR TITLE
add word boundary flag to ultisnips/javascript `fun` snippet

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -46,7 +46,7 @@ for (var ${2:i} = ${1:Things.length} - 1; $2 >= 0; $2--) {
 }
 endsnippet
 
-snippet fun "function (fun)"
+snippet fun "function (fun)" w
 function ${1:function_name}(${2:argument}) {
 	${VISUAL}$0
 }


### PR DESCRIPTION
Motivation: I commonly want to define a callback inline; with the word boundary flag being applied, I fall foul of this old issue https://github.com/SirVer/ultisnips/issues/320. 