### PR TITLE
Make es6 snippets available for UltiSnips users

### DIFF
--- a/UltiSnips/javascript.es6.snippets
+++ b/UltiSnips/javascript.es6.snippets
@@ -1,0 +1,28 @@
+snippet const
+	const ${1} = ${0};
+snippet let
+	let ${1} = ${0};
+snippet im
+	import ${1} from '${0}';
+snippet cla
+	class ${1} {
+		${0}
+	}
+snippet clax
+	class ${1} extends ${2} {
+		${0}
+	}
+snippet =>
+	(${1}) => {
+		${0}
+	}
+snippet af
+	(${1}) => {
+		${0}
+	}
+snippet sym
+	const ${1} = Symbol('${0}');
+snippet ed
+	export default ${0}
+snippet ${
+	${${1}}${0}


### PR DESCRIPTION
Basically I just copy the file from `snippets/javascript` folder to `UltiSnips` and thankfully, UltiSnips can read it without any issue.