### PR TITLE
Suggest a better default for Perl package names

### DIFF
--- a/snippets/perl.snippets
+++ b/snippets/perl.snippets
@@ -84,7 +84,7 @@ snippet fore
 	${1:expression} foreach @${2:array};
 # Package
 snippet package
-	package ${1:`vim_snippets#Filename(expand('%:p:s?.*lib/??:r:gs?/?::?'))`};
+	package ${1:`expand('%:p:s?.*lib/??:r:gs?/?::?')`};
 	use strict;
 	use warnings;
 
@@ -95,7 +95,7 @@ snippet package
 	__END__
 # Package syntax perl >= 5.14
 snippet packagev514
-	package ${1:`vim_snippets#Filename(expand('%:p:s?.*lib/??:r:gs?/?::?'))`} ${2:0.99};
+	package ${1:`expand('%:p:s?.*lib/??:r:gs?/?::?')`} ${2:0.99};
 	use v5.14;
 	use warnings;
 

--- a/snippets/perl.snippets
+++ b/snippets/perl.snippets
@@ -84,7 +84,9 @@ snippet fore
 	${1:expression} foreach @${2:array};
 # Package
 snippet package
-	package ${1:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`};
+	package ${1:`vim_snippets#Filename(expand('%:p:s?.*lib/??:r:gs?/?::?'))`};
+	use strict;
+	use warnings;
 
 	${0}
 
@@ -93,7 +95,9 @@ snippet package
 	__END__
 # Package syntax perl >= 5.14
 snippet packagev514
-	package ${1:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`} ${2:0.99};
+	package ${1:`vim_snippets#Filename(expand('%:p:s?.*lib/??:r:gs?/?::?'))`} ${2:0.99};
+	use v5.14;
+	use warnings;
 
 	${0}
 


### PR DESCRIPTION
The previous snippet for Perl _package_ was apparently copy-pasted from [html.snippets](https://github.com/honza/vim-snippets/blob/master/snippets/html.snippets) (see _head_ and _title_ snippets). It didn't really make sense, and for me it actually always returned an empty string.

This one looks for the path name of the file and removes everything up to the ``lib/`` folder. It then replaces ``/`` with ``::``. I think it's a pretty sensible default.

Finally, I also added ``use strict`` and ``use warnings`` to the package definition.