### PR TITLE
Missing comment sign at line start

### DIFF
--- a/snippets/javascript/bemjson.snippets
+++ b/snippets/javascript/bemjson.snippets
@@ -42,7 +42,7 @@ snippet e
 snippet mo
 	mods : { ${1:modName} : '${2:modVal}' },
 
-mi - BEM mix mod
+# mi - BEM mix mod
 snippet mi
 	mix : [ { ${1:block} : '${2:block}' } ],
 


### PR DESCRIPTION
I've got error in latest neovim
UltiSnips.snippet.source.file._base.SnippetSyntaxError: Invalid line 'mi - BEM mix mod' in ~/.config/nvim/plugged/vim-snippets/snippets/javascript/bemjson.snippets:45