### PR TITLE
Add visual placeholders to box and bbox

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -18,7 +18,7 @@ snippet box "A nice box with the current comment symbol" b
 box = make_box(len(t[1]))
 snip.rv = box[0]
 snip += box[1]
-`${1:content}`!p
+`${1:${VISUAL:content}}`!p
 box = make_box(len(t[1]))
 snip.rv = box[2]
 snip += box[3]`
@@ -32,7 +32,7 @@ if not snip.c:
 box = make_box(len(t[1]), width)
 snip.rv = box[0]
 snip += box[1]
-`${1:content}`!p
+`${1:${VISUAL:content}}`!p
 box = make_box(len(t[1]), width)
 snip.rv = box[2]
 snip += box[3]`


### PR DESCRIPTION
Add a visual placeholder to box and bbox, so you can use them to surround visual selections.