### PR TITLE
Remove unused attributes from HTML table snippet

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -258,7 +258,7 @@ snippet style "XHTML <style>" w
 endsnippet
 
 snippet table "XHTML <table>" w
-<table border="${1:0}"${2: cellspacing="${3:5}" cellpadding="${4:5}"}>
+<table>
 	${0:${VISUAL}}
 </table>
 endsnippet


### PR DESCRIPTION
This removes the border, cellspacing and cellpadding attributes from the
HTML table snippet.

See issue honza/vim-snippets#804