### PR TITLE
Add Proptypes and Default props to React snippets

### DIFF
--- a/snippets/javascript.es6.react.snippets
+++ b/snippets/javascript.es6.react.snippets
@@ -29,13 +29,13 @@ snippet rcon
 # Proptypes for React Class
 snippet rcpt
 	static propTypes = {
-		${1:prop}: PropTypes.${0:type},
+		${1}: PropTypes.${0},
 	}
 
 # Default props for React Class
 snippet rcdp
 	static defaultProps = {
-		${1:prop}: ${0:'value'},
+		${1}: ${0},
 	}
 
 # Presentational component
@@ -49,13 +49,13 @@ snippet rcom
 # Proptypes for Presentational component
 snippet rpt
 	${1}.propTypes = {
-		${2:prop}: PropTypes.${0:type},
+		${2}: PropTypes.${0},
 	}
 
 # Default props for Presentational component
 snippet rdp
 	${1}.defaultProps = {
-		${2:prop}: ${0:'value'},
+		${2}: ${0},
 	}
 
 # Lifecycle Methods

--- a/snippets/javascript.es6.react.snippets
+++ b/snippets/javascript.es6.react.snippets
@@ -4,7 +4,7 @@ snippet ri1
 
 # Import both React and Component
 snippet ri2
-	import React, { Component } from 'react'
+	import React, { Component, PropTypes } from 'react'
 
 # React class
 snippet rcla
@@ -26,12 +26,35 @@ snippet rcon
 		}
 	}
 
+# Proptypes for React Class
+snippet rcpt
+	static propTypes = {
+		${1:prop}: PropType.${0:type}
+	}
+
+# Default props for React Class
+snipet rcdp
+	static defaultProps = {
+		${1:prop}: ${0:'value'}
+	}
+
 # Presentational component
 snippet rcom
 	(props) => {
 		return (
 			${0:<div></div>}
 		)
+	}
+# Proptypes for Presentational component
+snippet rpt
+	${1}.propTypes = {
+		${2:prop}: PropType.${0:type}
+	}
+
+# Default props for Presentational component
+snippet rdp
+	${1}.defaultProps = {
+		${2:prop}: ${0:'value'}
 	}
 
 # Lifecycle Methods

--- a/snippets/javascript.es6.react.snippets
+++ b/snippets/javascript.es6.react.snippets
@@ -29,13 +29,13 @@ snippet rcon
 # Proptypes for React Class
 snippet rcpt
 	static propTypes = {
-		${1:prop}: PropType.${0:type}
+		${1:prop}: PropTypes.${0:type},
 	}
 
 # Default props for React Class
-snipet rcdp
+snippet rcdp
 	static defaultProps = {
-		${1:prop}: ${0:'value'}
+		${1:prop}: ${0:'value'},
 	}
 
 # Presentational component
@@ -45,16 +45,17 @@ snippet rcom
 			${0:<div></div>}
 		)
 	}
+
 # Proptypes for Presentational component
 snippet rpt
 	${1}.propTypes = {
-		${2:prop}: PropType.${0:type}
+		${2:prop}: PropTypes.${0:type},
 	}
 
 # Default props for Presentational component
 snippet rdp
 	${1}.defaultProps = {
-		${2:prop}: ${0:'value'}
+		${2:prop}: ${0:'value'},
 	}
 
 # Lifecycle Methods


### PR DESCRIPTION
This adds proptypes and default props to react snippets in `snipmate`

This was not done for `UltiSnips` as there is no react file. I could port those over in a follow-up if you would like!

:) 

Thank you!