### PR TITLE
Prefix rspec describe with "RSpec."

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -668,7 +668,7 @@ snippet mthrow
 #     Rspec snippets     #
 ##########################
 snippet desc
-	describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
+	RSpec.describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
 		${0}
 	end
 snippet descm


### PR DESCRIPTION
The top most `describe` in an RSpec test should always be namespaced.

So instead of writing
```ruby
describe MyClass do
end
```

you should write

```ruby
RSpec.describe MyClass do
end
```