### PR TITLE
Add snippet for elixir @doc false

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -102,6 +102,8 @@ snippet doc
 	@doc """
 	${0}
 	"""
+snippet docf
+	@doc false
 snippet fn
 	fn ${1:args} -> ${0} end
 snippet mdoc


### PR DESCRIPTION
Just a simple addition for `@doc false` in Elixir, since there's already one for `@moduledoc false`.