### PR TITLE
ultisnips.py: add fast def snippet

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -486,6 +486,11 @@ def __coerce__(self, other):
 	${25:pass}
 endsnippet
 
+snippet deff
+def ${1:fname}(`!p snip.rv = vim.eval('indent(".") ? "self" : ""')`$2):
+	$0
+endsnippet
+
 snippet def "function with docstrings" b
 def ${1:function}(`!p
 if snip.indent:


### PR DESCRIPTION
This is addressing the issue of #806. As discussed in this [thread](https://github.com/SirVer/ultisnips/issues/779#issuecomment-260865403), this is most likely an Ultisnips bug. Therefor, the workaround is to provide a ultisnip equivalent snippet so that it is prioritized.