### PR TITLE
Add ISC License snippet

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -279,3 +279,11 @@ snippet AGPL
 
 	You should have received a copy of the GNU Affero General Public License
 	along with this program. If not, see <http://www.gnu.org/licenses/>.
+snippet ISC
+	${1:one line to give the program's name and a brief description}
+	Copyright `&enc[:2] == "utf" ? "©" : "(c)"` `strftime("%Y")`, ${2:`g:snips_author`}
+
+	Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+	THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+	${0}


### PR DESCRIPTION
Shorter equivalent of the MIT and simplified BSD licenses.

Default license for packages created with npm.