### PR TITLE
Cleaned ${x} from snippet collection

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -5,7 +5,7 @@
 priority -50
 
 snippet def "#define ..."
-#define ${1}
+#define $1
 endsnippet
 
 snippet #ifndef "#ifndef ... #define ... #endif"
@@ -16,7 +16,7 @@ endsnippet
 
 snippet #if "#if #endif" b
 #if ${1:0}
-${VISUAL}${0}
+${VISUAL}$0
 #endif
 endsnippet
 
@@ -32,20 +32,20 @@ endsnippet
 snippet main "main() (main)"
 int main(int argc, char *argv[])
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 	return 0;
 }
 endsnippet
 
 snippet for "for loop (for)"
 for (${2:i} = 0; $2 < ${1:count}; ${3:++$2}) {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 snippet fori "for int loop (fori)"
 for (${4:int} ${2:i} = 0; $2 < ${1:count}; ${3:++$2}) {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
@@ -60,7 +60,7 @@ else:
 	snip.rv = snip.c`}
 #define $1
 
-${VISUAL}${0}
+${VISUAL}$0
 
 #endif /* end of include guard: $1 */
 endsnippet
@@ -71,7 +71,7 @@ endsnippet
 
 snippet eli "else if .. (eli)"
 else if (${1:/* condition */}) {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
@@ -86,14 +86,14 @@ struct ${1:`!p snip.rv = (snip.basename or "name") + "_t"`} {
 endsnippet
 
 snippet fun "function" b
-${1:void} ${2:function_name}(${3})
+${1:void} ${2:function_name}($3)
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 snippet fund "function declaration" b
-${1:void} ${2:function_name}(${3});
+${1:void} ${2:function_name}($3);
 endsnippet
 
 # vim:ft=snippets:

--- a/UltiSnips/coffee-react.snippets
+++ b/UltiSnips/coffee-react.snippets
@@ -12,7 +12,7 @@ snippet createClass "React define Class" b
 ${1:classname}Class = React.createClass
 	displayName: "$1"
 	render: ->
-		${2}
+		$2
 $1 = React.createFactory($1)
 endsnippet
 
@@ -23,58 +23,58 @@ endsnippet
 
 snippet propType "React propType (key/value)" b
 ${1:myVar}: React.PropTypes.${2:type}${3:.isRequired}
-${4}
+$4
 endsnippet
 
 snippet setState "React setState" b
 @setState
 	${1:myvar}: ${2:myvalue}
-	${3}
+	$3
 endsnippet
 
 snippet getInitialState "React define getInitialState" b
 getInitialState: ->
 	${1:myvar}: ${2:myvalue}
-	${3}
+	$3
 endsnippet
 
 snippet getDefaultProps "React define getDefaultProps" b
 getDefaultProps: ->
 	${1:myvar}: ${2:myvalue}
-	${3}
+	$3
 endsnippet
 
 snippet componentWillMount "React define componentWillMount" b
 componentWillMount: ->
-	${1}
+	$1
 endsnippet
 
 snippet componentDidMount "React define componentDidMount" b
 componentDidMount: ->
-	${1}
+	$1
 endsnippet
 
 snippet componentWillReceiveProps "React define componentWillReceiveProps" b
 componentWillReceiveProps: (nextProps) ->
-	${1}
+	$1
 endsnippet
 
 snippet shouldComponentUpdate "React define shouldComponentUpdate" b
 shouldComponentUpdate: (nextProps, nextState) ->
-	${1}
+	$1
 endsnippet
 
 snippet componentWillUpdate "React define componentWillUpdate" b
 componentWillUpdate: (nextProps, nextState) ->
-	${1}
+	$1
 endsnippet
 
 snippet componentDidUpdate "React define componentDidUpdate" b
 componentDidUpdate: (prevProps, prevState) ->
-	${1}
+	$1
 endsnippet
 
 snippet componentWillUnmount "React define componentWillUnmount" b
 componentWillUnmount: ->
-	${1}
+	$1
 endsnippet

--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -27,7 +27,7 @@ endsnippet
 snippet ns "namespace .. (namespace)"
 namespace${1/.+/ /m}${1:`!p snip.rv = snip.basename or "name"`}
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 }${1/.+/ \/* /m}$1${1/.+/ *\/ /m}
 endsnippet
 
@@ -61,7 +61,7 @@ snippet cla "An entire .h generator" b
 class ${1:`!v substitute(substitute(vim_snippets#Filename('$1','ClassName'),'^.','\u&',''), '_\(\w\)', '\u\1', 'g')`}
 {
 private:
-	${3}
+	$3
 
 public:
 	$1();

--- a/UltiSnips/cs.snippets
+++ b/UltiSnips/cs.snippets
@@ -259,7 +259,7 @@ finally
 endsnippet
 
 snippet throw "throw"
-throw new ${1}Exception("${2}");
+throw new $1Exception("$2");
 endsnippet
 
 

--- a/UltiSnips/d.snippets
+++ b/UltiSnips/d.snippets
@@ -23,7 +23,7 @@ mixin ${1:/*mixed_in*/} ${2:/*name*/};
 endsnippet
 
 snippet new "new (new)"
-new ${1}(${2});
+new $1($2);
 endsnippet
 
 snippet scpn "@safe const pure nothrow (scpn)"
@@ -98,7 +98,7 @@ endsnippet
 
 snippet enf "enforce (enf)" b
 enforce(${1:/*condition*/},
-	new ${2}Exception(${3:/*args*/}));
+	new $2Exception(${3:/*args*/}));
 endsnippet
 
 # Branches
@@ -106,14 +106,14 @@ endsnippet
 snippet if "if .. (if)"
 if(${1:/*condition*/})
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 snippet ife "if .. else (ife)" b
 if(${1:/*condition*/})
 {
-	${2}
+	$2
 }
 else
 {
@@ -124,14 +124,14 @@ endsnippet
 snippet el "else (el)" b
 else
 {
-	${VISUAL}${1}
+	${VISUAL}$1
 }
 endsnippet
 
 snippet elif "else if (elif)" b
 else if(${1:/*condition*/})
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
@@ -139,10 +139,10 @@ snippet sw "switch (sw)"
 switch(${1:/*var*/})
 {
 	case ${2:/*value*/}:
-		${3}
+		$3
 		break;
 	case ${4:/*value*/}:
-		${5}
+		$5
 		break;
 	${7:/*more cases*/}
 	default:
@@ -154,10 +154,10 @@ snippet fsw "final switch (fsw)"
 final switch(${1:/*var*/})
 {
 	case ${2:/*value*/}:
-		${3}
+		$3
 		break;
 	case ${4:/*value*/}:
-		${5}
+		$5
 		break;
 	${7:/*more cases*/}
 }
@@ -165,7 +165,7 @@ endsnippet
 
 snippet case "case (case)" b
 case ${1:/*value*/}:
-	${2}
+	$2
 	break;
 endsnippet
 
@@ -178,42 +178,42 @@ endsnippet
 snippet do "do while (do)" b
 do
 {
-	${VISUAL}${2}
+	${VISUAL}$2
 } while(${1:/*condition*/});
 endsnippet
 
 snippet wh "while (wh)" b
 while(${1:/*condition*/})
 {
-	${VISUAL}${2}
+	${VISUAL}$2
 }
 endsnippet
 
 snippet for "for (for)" b
 for (${4:size_t} ${2:i} = 0; $2 < ${1:count}; ${3:++$2})
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 snippet forever "forever (forever)" b
 for(;;)
 {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 snippet fore "foreach (fore)"
 foreach(${1:/*elem*/}; ${2:/*range*/})
 {
-	${VISUAL}${3}
+	${VISUAL}$3
 }
 endsnippet
 
 snippet forif "foreach if (forif)" b
 foreach(${1:/*elem*/}; ${2:/*range*/}) if(${3:/*condition*/})
 {
-	${VISUAL}${4}
+	${VISUAL}$4
 }
 endsnippet
 
@@ -222,7 +222,7 @@ snippet in "in contract (in)" b
 in
 {
 	assert(${1:/*condition*/}, "${2:error message}");
-	${3}
+	$3
 }
 body
 endsnippet
@@ -231,7 +231,7 @@ snippet out "out contract (out)" b
 out${1:(result)}
 {
 	assert(${2:/*condition*/}, "${3:error message}");
-	${4}
+	$4
 }
 body
 endsnippet
@@ -240,7 +240,7 @@ snippet inv "invariant (inv)" b
 invariant()
 {
 	assert(${1:/*condition*/}, "${2:error message}");
-	${3}
+	$3
 }
 endsnippet
 
@@ -249,21 +249,21 @@ endsnippet
 snippet fun "function definition (fun)"
 ${1:void} ${2:/*function name*/}(${3:/*args*/}) ${4:@safe pure nothrow}
 {
-	${VISUAL}${5}
+	${VISUAL}$5
 }
 endsnippet
 
 snippet void "void function definition (void)"
 void ${1:/*function name*/}(${2:/*args*/}) ${3:@safe pure nothrow}
 {
-	${VISUAL}${4}
+	${VISUAL}$4
 }
 endsnippet
 
 snippet this "ctor (this)" w
 this(${1:/*args*/})
 {
-	${VISUAL}${2}
+	${VISUAL}$2
 }
 endsnippet
 
@@ -295,16 +295,16 @@ endsnippet
 snippet scope "scope (scope)" b
 scope(${1:exit})
 {
-	${VISUAL}${2}
+	${VISUAL}$2
 }
 endsnippet
 
 # With
 
 snippet with "with (with)"
-with(${1})
+with($1)
 {
-	${VISUAL}${2}
+	${VISUAL}$2
 }
 endsnippet
 
@@ -315,7 +315,7 @@ try
 {
 	${VISUAL}${1:/*code to try*/}
 }
-catch(${2}Exception e)
+catch($2Exception e)
 {
 	${3:/*handle exception*/}
 }
@@ -326,7 +326,7 @@ try
 {
 	${VISUAL}${1:/*code to try*/}
 }
-catch(${2}Exception e)
+catch($2Exception e)
 {
 	${3:/*handle exception*/}
 }
@@ -337,14 +337,14 @@ finally
 endsnippet
 
 snippet catch "catch (catch)" b
-catch(${1}Exception e)
+catch($1Exception e)
 {
 	${2:/*handle exception*/}
 }
 endsnippet
 
 snippet thr "throw (thr)"
-throw new ${1}Exception("${2}");
+throw new $1Exception("$2");
 endsnippet
 
 
@@ -353,35 +353,35 @@ endsnippet
 snippet struct "struct (struct)"
 struct ${1:`!p snip.rv = (snip.basename or "name")`}
 {
-	${2}
+	$2
 }
 endsnippet
 
 snippet union "union (union)"
 union ${1:`!p snip.rv = (snip.basename or "name")`}
 {
-	${2}
+	$2
 }
 endsnippet
 
 snippet class "class (class)"
 class ${1:`!p snip.rv = (snip.basename or "name")`}
 {
-	${2}
+	$2
 }
 endsnippet
 
 snippet inter "interface (inter)"
 interface ${1:`!p snip.rv = (snip.basename or "name")`}
 {
-	${2}
+	$2
 }
 endsnippet
 
 snippet enum "enum (enum)"
 enum ${1:`!p snip.rv = (snip.basename or "name")`}
 {
-	${2}
+	$2
 }
 endsnippet
 
@@ -390,7 +390,7 @@ endsnippet
 
 snippet exc "exception declaration (exc)" b
 /// ${3:/*documentation*/}
-class ${1}Exception : ${2}Exception
+class $1Exception : $2Exception
 {
 	public this(string msg, string file = __FILE__, int line = __LINE__)
 	{
@@ -405,14 +405,14 @@ endsnippet
 snippet version "version (version)" b
 version(${1:/*version name*/})
 {
-	${VISUAL}${2}
+	${VISUAL}$2
 }
 endsnippet
 
 snippet debug "debug" b
 debug
 {
-	${VISUAL}${1}
+	${VISUAL}$1
 }
 endsnippet
 
@@ -422,7 +422,7 @@ endsnippet
 snippet temp "template (temp)" b
 template ${2:/*name*/}(${1:/*args*/})
 {
-	${3}
+	$3
 }
 endsnippet
 
@@ -440,7 +440,7 @@ endsnippet
 snippet unittest "unittest (unittest)" b
 unittest
 {
-	${1}
+	$1
 }
 endsnippet
 
@@ -450,21 +450,21 @@ endsnippet
 snippet opDis "opDispatch (opDis)" b
 ${1:/*return type*/} opDispatch(string s)()
 {
-	${2};
+	$2;
 }
 endsnippet
 
 snippet op= "opAssign (op=)" b
-void opAssign(${1} rhs) ${2:@safe pure nothrow}
+void opAssign($1 rhs) ${2:@safe pure nothrow}
 {
-	${2}
+	$2
 }
 endsnippet
 
 snippet opCmp "opCmp (opCmp)" b
-int opCmp(${1} rhs) @safe const pure nothrow
+int opCmp($1 rhs) @safe const pure nothrow
 {
-	${2}
+	$2
 }
 endsnippet
 
@@ -484,7 +484,7 @@ endsnippet
 snippet toString "toString (toString)" b
 string toString() @safe const pure nothrow
 {
-	${1}
+	$1
 }
 endsnippet
 
@@ -493,7 +493,7 @@ endsnippet
 
 
 snippet todo "TODO (todo)"
-// TODO: ${1}
+// TODO: $1
 endsnippet
 
 
@@ -509,16 +509,16 @@ snippet fdoc "function ddoc block (fdoc)" b
 /// ${1:description}
 ///
 /// ${2:Params:  ${3:param} = ${4:param description}
-///			 ${5}}
+///			 $5}
 ///
 /// ${6:Returns: ${7:return value}}
 ///
-/// ${8:Throws:  ${9}Exception ${10}}
+/// ${8:Throws:  $9Exception $10}
 endsnippet
 
 snippet Par "Params (Par)"
 Params:  ${1:param} = ${2:param description}
-///			${3}
+///			$3
 endsnippet
 
 snippet Ret "Returns (Ret)"
@@ -526,7 +526,7 @@ Returns:  ${1:return value/s}
 endsnippet
 
 snippet Thr "Throws (Thr)"
-Throws:  ${1}Exception ${2}
+Throws:  $1Exception $2
 endsnippet
 
 snippet Example "Examples (Example)"
@@ -556,7 +556,7 @@ snippet gpl "GPL (gpl)" b
 //
 // Copyright (C) ${1:Author}, `!v strftime("%Y")`
 
-${2}
+$2
 endsnippet
 
 snippet boost "Boost (boost)" b
@@ -565,7 +565,7 @@ snippet boost "Boost (boost)" b
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-${2}
+$2
 endsnippet
 
 
@@ -577,8 +577,8 @@ snippet module "New module (module)" b
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-module ${2}.`!v vim_snippets#Filename('$1', 'name')`;
+module $2.`!v vim_snippets#Filename('$1', 'name')`;
 
 
-${3}
+$3
 endsnippet

--- a/UltiSnips/django.snippets
+++ b/UltiSnips/django.snippets
@@ -124,7 +124,7 @@ endsnippet
 
 snippet model "Model" b
 class ${1:MODELNAME}(models.Model):
-	${0}
+	$0
 	class Meta:
 		verbose_name = "$1"
 		verbose_name_plural = "$1s"
@@ -275,19 +275,19 @@ endsnippet
 # VIEWS SNIPPETS
 
 snippet adminview "Model Admin View" b
-class ${1}Admin(admin.ModelAdmin):
+class $1Admin(admin.ModelAdmin):
 	'''
-		Admin View for ${1}
+		Admin View for $1
 	'''
-	list_display = ('${2}',)
-	list_filter = ('${3}',)
+	list_display = ('$2',)
+	list_filter = ('$3',)
 	inlines = [
-		${4}Inline,
+		$4Inline,
 	]
-	raw_id_fields = ('${5}',)
-	readonly_fields = ('${6}',)
-	search_fields = ['${7}']
-admin.site.register(${1}, ${1}Admin)
+	raw_id_fields = ('$5',)
+	readonly_fields = ('$6',)
+	search_fields = ['$7']
+admin.site.register($1, $1Admin)
 endsnippet
 
 snippet createview "Generic Create View" b
@@ -315,27 +315,27 @@ class ${1:MODEL_NAME}ListView(ListView):
 endsnippet
 
 snippet stackedinline "Stacked Inline" b
-class ${1}Inline(admin.StackedInline):
+class $1Inline(admin.StackedInline):
 	'''
-	Stacked Inline View for ${1}
+	Stacked Inline View for $1
 	'''
-	model = ${2:${1}}
+	model = ${2:$1}
 	min_num = ${3:3}
 	max_num = ${4:20}
 	extra = ${5:1}
-	raw_id_fields = (${6},)
+	raw_id_fields = ($6,)
 endsnippet
 
 snippet tabularinline "Tabular Inline" b
-class ${1}Inline(admin.TabularInline):
+class $1Inline(admin.TabularInline):
 	'''
-	Tabular Inline View for ${1}
+	Tabular Inline View for $1
 	'''
-	model = ${2:${1}}
+	model = ${2:$1}
 	min_num = ${3:3}
 	max_num = ${4:20}
 	extra = ${5:1}
-	raw_id_fields = (${6},)
+	raw_id_fields = ($6,)
 endsnippet
 
 snippet templateview "Generic Template View" b

--- a/UltiSnips/eruby.snippets
+++ b/UltiSnips/eruby.snippets
@@ -27,12 +27,12 @@ def textmate_var(var, snip):
 endglobal
 
 
-snippet % "<% ${0} %>" i
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_INLINE', snip)`${0}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_INLINE', snip)`
+snippet % "<% $0 %>" i
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_INLINE', snip)`$0`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_INLINE', snip)`
 endsnippet
 
-snippet = "<%= ${0} %>" i
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`${0}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
+snippet = "<%= $0 %>" i
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`$0`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
 endsnippet
 
 ###########################################################################
@@ -150,11 +150,11 @@ snippet licai "link_to (controller, action, id)" w
 endsnippet
 
 snippet linpp "link_to (nested path plural)" w
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`link_to ${1:"${2:link text...}"}, ${3:${10:parent}_${11:child}_path(${12:@}${13:${10}})}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`link_to ${1:"${2:link text...}"}, ${3:${10:parent}_${11:child}_path(${12:@}${13:$10})}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
 endsnippet
 
 snippet linp "link_to (nested path)" w
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`link_to ${1:"${2:link text...}"}, ${3:${12:parent}_${13:child}_path(${14:@}${15:${12}}, ${16:@}${17:${13}})}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`link_to ${1:"${2:link text...}"}, ${3:${12:parent}_${13:child}_path(${14:@}${15:$12}, ${16:@}${17:$13})}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
 endsnippet
 
 snippet lipp "link_to (path plural)" w
@@ -162,7 +162,7 @@ snippet lipp "link_to (path plural)" w
 endsnippet
 
 snippet lip "link_to (path)" w
-`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`link_to ${1:"${2:link text...}"}, ${3:${12:model}_path(${13:@}${14:${12}})}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
+`!p textmate_var('TM_RAILS_TEMPLATE_START_RUBY_EXPR', snip)`link_to ${1:"${2:link text...}"}, ${3:${12:model}_path(${13:@}${14:$12})}`!p textmate_var('TM_RAILS_TEMPLATE_END_RUBY_EXPR', snip)`
 endsnippet
 
 snippet lim "link_to model" w

--- a/UltiSnips/go.snippets
+++ b/UltiSnips/go.snippets
@@ -53,7 +53,7 @@ endsnippet
 
 snippet switch "Switch statement" b
 switch ${1:expression}${1/(.+)/ /}{
-case${0}
+case$0
 }
 endsnippet
 

--- a/UltiSnips/html_minimal.snippets
+++ b/UltiSnips/html_minimal.snippets
@@ -4,24 +4,24 @@
 priority -50
 
 snippet id
-id="${1}"${2}
+id="$1"$2
 endsnippet
 
 snippet idn
-id="${1}" name="${2:$1}"
+id="$1" name="${2:$1}"
 endsnippet
 
 snippet label_and_input
-<label for="${2:$1}">${1}</label>
-<input type="${3:text}" name="${4:$2}"${5: id="${6:$2}"} value="${7}" />${8}
+<label for="${2:$1}">$1</label>
+<input type="${3:text}" name="${4:$2}"${5: id="${6:$2}"} value="$7" />$8
 endsnippet
 
 snippet input
-<input type="${1:text}" value="${2}" name="${3}"${4: id="${5:$3}"}/>${7}
+<input type="${1:text}" value="$2" name="$3"${4: id="${5:$3}"}/>$7
 endsnippet
 
 snippet submit
-<input type="submit" value="${2}" ${3}/>${7}
+<input type="submit" value="$2" $3/>$7
 endsnippet
 
 snippet textarea

--- a/UltiSnips/htmldjango.snippets
+++ b/UltiSnips/htmldjango.snippets
@@ -4,30 +4,30 @@ extends html
 
 # Generic Tags
 snippet % "" bi
-{% ${1} %}${2}
+{% $1 %}$2
 endsnippet
 
 snippet %% "" bi
 {% ${1:tag_name} %}
-	${2}
+	$2
 {% end$1 %}
 endsnippet
 
 snippet { "" bi
-{{ ${1} }}${2}
+{{ $1 }}$2
 endsnippet
 
 # Template Tags
 
 snippet autoescape "" bi
 {% autoescape ${1:off} %}
-	${2}
+	$2
 {% endautoescape %}
 endsnippet
 
 snippet block "" bi
-{% block ${1} %}
-	${2}
+{% block $1 %}
+	$2
 {% endblock $1 %}
 endsnippet
 
@@ -37,12 +37,12 @@ endsnippet
 
 snippet comment "" bi
 {% comment %}
-	${1}
+	$1
 {% endcomment %}
 endsnippet
 
 snippet cycle "" bi
-{% cycle ${1:val1} ${2:val2} ${3:as ${4}} %}
+{% cycle ${1:val1} ${2:val2} ${3:as $4} %}
 endsnippet
 
 snippet debug "" bi
@@ -54,76 +54,76 @@ snippet extends "" bi
 endsnippet
 
 snippet filter "" bi
-{% filter ${1} %}
-	${2}
+{% filter $1 %}
+	$2
 {% endfilter %}
 endsnippet
 
 snippet firstof "" bi
-{% firstof ${1} %}
+{% firstof $1 %}
 endsnippet
 
 snippet for "" bi
-{% for ${1} in ${2} %}
-	${3}
+{% for $1 in $2 %}
+	$3
 {% endfor %}
 endsnippet
 
 snippet empty "" bi
 {% empty %}
-	${1}
+	$1
 endsnippet
 
 snippet if "" bi
-{% if ${1} %}
-	${2}
+{% if $1 %}
+	$2
 {% endif %}
 endsnippet
 
 snippet iif "" bi
-{% if ${1} %}${2}{% endif %}
+{% if $1 %}$2{% endif %}
 endsnippet
 
 snippet ielse "" bi
-{% else %}${1}
+{% else %}$1
 endsnippet
 
 snippet else "" bi
 {% else %}
-	${1}
+	$1
 endsnippet
 
 snippet ielif "" bi
-{% elif %}${1}
+{% elif %}$1
 endsnippet
 
 snippet elif "" bi
 {% elif %}
-	${1}
+	$1
 endsnippet
 
 snippet ifchanged "" bi
-{% ifchanged %}${1}{% endifchanged %}
+{% ifchanged %}$1{% endifchanged %}
 endsnippet
 
 snippet ifequal "" bi
-{% ifequal ${1} ${2} %}
-	${3}
+{% ifequal $1 $2 %}
+	$3
 {% endifequal %}
 endsnippet
 
 snippet ifnotequal "" bi
-{% ifnotequal ${1} ${2} %}
-	${3}
+{% ifnotequal $1 $2 %}
+	$3
 {% endifnotequal %}
 endsnippet
 
 snippet include "" bi
-{% include "${1}" %}
+{% include "$1" %}
 endsnippet
 
 snippet load "" bi
-{% load ${1} %}
+{% load $1 %}
 endsnippet
 
 snippet now "" bi
@@ -131,15 +131,15 @@ snippet now "" bi
 endsnippet
 
 snippet regroup "" bi
-{% regroup ${1} by ${2} as ${3} %}
+{% regroup $1 by $2 as $3 %}
 endsnippet
 
 snippet spaceless "" bi
-{% spaceless %}${1}{% endspaceless %}
+{% spaceless %}$1{% endspaceless %}
 endsnippet
 
 snippet ssi "" bi
-{% ssi ${1} %}
+{% ssi $1 %}
 endsnippet
 
 snippet trans "" bi
@@ -147,7 +147,7 @@ snippet trans "" bi
 endsnippet
 
 snippet url "" bi
-{% url ${1} as ${2} %}
+{% url $1 as $2 %}
 endsnippet
 
 snippet widthratio "" bi
@@ -155,7 +155,7 @@ snippet widthratio "" bi
 endsnippet
 
 snippet with "" bi
-{% with ${1} as ${2} %}
+{% with $1 as $2 %}
 	${VISUAL}
 {% endwith %}
 endsnippet
@@ -197,7 +197,7 @@ snippet blocktrans "" bi
 endsnippet
 
 snippet lorem "" bi
-{% lorem ${1} %}
+{% lorem $1 %}
 endsnippet
 
 # Template Filters
@@ -209,91 +209,91 @@ endsnippet
 # Note: Template tags that take no arguments are not implemented.
 
 snippet add "" bi
-add:"${1}"
+add:"$1"
 endsnippet
 
 snippet center "" bi
-center:"${1}"
+center:"$1"
 endsnippet
 
 snippet cut "" bi
-cut:"${1}"
+cut:"$1"
 endsnippet
 
 snippet date "" bi
-date:"${1}"
+date:"$1"
 endsnippet
 
 snippet default "" bi
-default:"${1}"
+default:"$1"
 endsnippet
 
 snippet defaultifnone "" bi
-default_if_none:"${1}"
+default_if_none:"$1"
 endsnippet
 
 snippet dictsort "" bi
-dictsort:"${1}"
+dictsort:"$1"
 endsnippet
 
 snippet dictsortrev "" bi
-dictsortreversed:"${1}"
+dictsortreversed:"$1"
 endsnippet
 
 snippet divisibleby "" bi
-divisibleby:"${1}"
+divisibleby:"$1"
 endsnippet
 
 snippet floatformat "" bi
-floatformat:"${1}"
+floatformat:"$1"
 endsnippet
 
 snippet getdigit "" bi
-get_digit:"${1}"
+get_digit:"$1"
 endsnippet
 
 snippet join "" bi
-join:"${1}"
+join:"$1"
 endsnippet
 
 snippet lengthis "" bi
-length_is:"${1}"
+length_is:"$1"
 endsnippet
 
 snippet pluralize "" bi
-pluralize:"${1}"
+pluralize:"$1"
 endsnippet
 
 snippet removetags "" bi
-removetags:"${1}"
+removetags:"$1"
 endsnippet
 
 snippet slice "" bi
-slice:"${1}"
+slice:"$1"
 endsnippet
 
 snippet stringformat "" bi
-stringformat:"${1}"
+stringformat:"$1"
 endsnippet
 
 snippet time "" bi
-time:"${1}"
+time:"$1"
 endsnippet
 
 snippet truncatewords "" bi
-truncatewords:${1}
+truncatewords:$1
 endsnippet
 
 snippet truncatewordshtml "" bi
-truncatewords_html:${1}
+truncatewords_html:$1
 endsnippet
 
 snippet urlizetrunc "" bi
-urlizetrunc:${1}
+urlizetrunc:$1
 endsnippet
 
 snippet wordwrap "" bi
-wordwrap:${1}
+wordwrap:$1
 endsnippet
 
 # vim:ft=snippets:

--- a/UltiSnips/java.snippets
+++ b/UltiSnips/java.snippets
@@ -48,7 +48,7 @@ $0
 endsnippet
 
 snippet /o|v/ "new Object or variable" br
-${1:Object} ${2:var} = new $1(${3});
+${1:Object} ${2:var} = new $1($3);
 endsnippet
 
 snippet f "field" b
@@ -310,13 +310,13 @@ try {
 endsnippet
 
 snippet mt "method throws" b
-${1:private} ${2:void} ${3:method}(${4}) ${5:throws $6 }{
+${1:private} ${2:void} ${3:method}($4) ${5:throws $6 }{
 	$0
 }
 endsnippet
 
 snippet m  "method" b
-${1:private} ${2:void} ${3:method}(${4}) {
+${1:private} ${2:void} ${3:method}($4) {
 	$0
 }
 endsnippet

--- a/UltiSnips/javascript-angular.snippets
+++ b/UltiSnips/javascript-angular.snippets
@@ -19,7 +19,7 @@ config(function($1) {
 endsnippet
 
 snippet acont "angular controller" i
-controller('${1:name}', [${2}function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
+controller('${1:name}', [$2function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
 	$0
 }]);
 endsnippet
@@ -31,29 +31,29 @@ controller('${1:name}', [${2:'$scope', }function(${2/('|")([A-Z_$]+)?\1?((, ?)$)
 endsnippet
 
 snippet adir "angular directive" i
-directive('${1}', [${2}function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
+directive('$1', [$2function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
 	return {
 		restrict: '${3:EA}',
 		link: function(scope, element, attrs) {
-			${0}
+			$0
 		}
 	};
 }]);
 endsnippet
 
 snippet adirs "angular directive with scope" i
-directive('${1}', [${2:'$scope', }function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
+directive('$1', [${2:'$scope', }function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
 	return {
 		restrict: '${3:EA}',
 		link: function(scope, element, attrs) {
-			${0}
+			$0
 		}
 	};
 }]);
 endsnippet
 
 snippet afact "angular factory" i
-factory('${1:name}', [${2}function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
+factory('${1:name}', [$2function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
 	$0
 }]);
 endsnippet
@@ -65,7 +65,7 @@ factory('${1:name}', [${2:'$scope', }function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$
 endsnippet
 
 snippet aserv "angular service" i
-service('${1:name}', [${2}function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
+service('${1:name}', [$2function(${2/('|")([A-Z_$]+)?\1?((, ?)$)?/$2(?3::$4)/ig}) {
 	$0
 }]);
 endsnippet

--- a/UltiSnips/javascript-node.snippets
+++ b/UltiSnips/javascript-node.snippets
@@ -5,48 +5,48 @@ snippet #! "shebang"
 endsnippet
 
 snippet vreq "assign a CommonJS-style module to a var"
-var ${0:${1/(.+\/)*(\w+)(-|\b|$)(\..+$)?/\u$2/g}} = require('${1}');
+var ${0:${1/(.+\/)*(\w+)(-|\b|$)(\..+$)?/\u$2/g}} = require('$1');
 endsnippet
 
 snippet ex "module.exports"
-module.exports = ${1};
+module.exports = $1;
 endsnippet
 
 snippet hcs "http.createServer"
-http.createServer(${1}).listen(${2});
+http.createServer($1).listen($2);
 endsnippet
 
 snippet ncs "net.createServer"
 net.createServer(function(${1:socket}){
-	${1}.on('data', function(${3:data}){
-		${4}
+	$1.on('data', function(${3:data}){
+		$4
 	});
-	${1}.on('end', function(){
-		${5}
+	$1.on('end', function(){
+		$5
 	});
 }).listen(${6:8124});
 endsnippet
 
 snippet pipe "pipe"
-pipe(${1:stream})${2}
+pipe(${1:stream})$2
 endsnippet
 
 # Express snippets
 
 snippet eget "express GET"
-${1:app}.get('${2}', ${3});
+${1:app}.get('$2', $3);
 endsnippet
 
 snippet epost "express POST"
-${1:app}.post('${2}', ${3});
+${1:app}.post('$2', $3);
 endsnippet
 
 snippet eput "express PUT"
-${1:app}.put('${2}', ${3});
+${1:app}.put('$2', $3);
 endsnippet
 
 snippet edelete "express DELETE"
-${1:app}.delete('${2}', ${3});
+${1:app}.delete('$2', $3);
 endsnippet
 
 # process snippets

--- a/UltiSnips/javascript-openui5.snippets
+++ b/UltiSnips/javascript-openui5.snippets
@@ -1,80 +1,80 @@
 snippet sapmlabel
-	var ${1} = new sap.m.Label({ 
-				design : ${2}, 
-				text : ${3}, 
-				visible : ${4}, 
-				textAlign : ${5}, 
-				textDirection : ${6}, 
-				width : ${7}, 
-				required : ${7}
+	var $1 = new sap.m.Label({ 
+				design : $2, 
+				text : $3, 
+				visible : $4, 
+				textAlign : $5, 
+				textDirection : $6, 
+				width : $7, 
+				required : $7
 			});
 
 snippet sapmtext
-	var ${1} = new sap.m.Text({
-				text :${2},
-				textDirection :${3},
-				visible :${4},
-				wrapping : ${5},
-				textAlign : ${6},
-				width :${7},
-				maxLines :${8}
+	var $1 = new sap.m.Text({
+				text :$2,
+				textDirection :$3,
+				visible :$4,
+				wrapping : $5,
+				textAlign : $6,
+				width :$7,
+				maxLines :$8
 			});
 
 snippet sapmbutton
-	var ${1} = new sap.m.Button({
-				text : ${2},
-				type : ${3},
-				width : ${4},
-				enabled :${5},
-				visible :${6},
-				icon : ${7},
-				iconFirst : ${8},
-				activeIcon :${9},
-				iconDensityAware : ${10},
+	var $1 = new sap.m.Button({
+				text : $2,
+				type : $3,
+				width : $4,
+				enabled :$5,
+				visible :$6,
+				icon : $7,
+				iconFirst : $8,
+				activeIcon :$9,
+				iconDensityAware : $10,
 			});
 snippet sapmflexbox
-	var ${1} = new sap.m.FlexBox({
-				visible : ${2},
-				height : ${3},
-				width : ${4},
-				displayInline :${5},
-				direction :${6},
-				fitContainer : ${7},
-				renderType : ${8},
-				justifyContent :${9},
-				alignItems : ${10},
+	var $1 = new sap.m.FlexBox({
+				visible : $2,
+				height : $3,
+				width : $4,
+				displayInline :$5,
+				direction :$6,
+				fitContainer : $7,
+				renderType : $8,
+				justifyContent :$9,
+				alignItems : $10,
 				items:[]
 			});
 snippet sapmhbox
-	var ${1} = new sap.m.HBox({
-				visible : ${2},
-				height : ${3},
-				width : ${4},
-				displayInline :${5},
-				direction :${6},
-				fitContainer : ${7},
-				renderType : ${8},
-				justifyContent :${9},
-				alignItems : ${10},
+	var $1 = new sap.m.HBox({
+				visible : $2,
+				height : $3,
+				width : $4,
+				displayInline :$5,
+				direction :$6,
+				fitContainer : $7,
+				renderType : $8,
+				justifyContent :$9,
+				alignItems : $10,
 				items:[]
 			});
 
 snippet sapmvbox
-	var ${1} = new sap.m.VBox({
-				visible : ${2},
-				height : ${3},
-				width : ${4},
-				displayInline :${5},
-				direction :${6},
-				fitContainer : ${7},
-				renderType : ${8},
-				justifyContent :${9},
-				alignItems : ${10},
+	var $1 = new sap.m.VBox({
+				visible : $2,
+				height : $3,
+				width : $4,
+				displayInline :$5,
+				direction :$6,
+				fitContainer : $7,
+				renderType : $8,
+				justifyContent :$9,
+				alignItems : $10,
 				items:[]
 			});
 
 snippet sapcomponent
-	sap.ui.controller("${1}", {
+	sap.ui.controller("$1", {
 	   onInit: function(){
 	   }, 
 	   onAfterRendering: function() {
@@ -86,120 +86,120 @@ snippet sapcomponent
 	});
 
 snippet sapminput
-	var ${1} = new sap.m.Input({
-		value :${2},
-		width : ${3},
-		enabled :${4},
-		visible :${5},
-		valueState :${6},
-		name : ${7},
-		placeholder : ${8},
-		editable : ${9},
-		type : ${10},
-		maxLength :${11}, 
-		valueStateText :${12}, 
-		showValueStateMessage :${13}, 
-		dateFormat :${14},
-		showValueHelp :${15},
-		showSuggestion :${16},
-		valueHelpOnly :${17},
-		filterSuggests :${18},
-		maxSuggestionWidth :${19},
-		startSuggestion : ${20},
-		showTableSuggestionValueHelp : ${21},
-		description : ${22},
-		fieldWidth : ${23},
-		valueLiveUpdate :${24},
-		suggestionItems  :[${25}],
-		suggestionColumns : [${26}],
-		suggestionRows : [${27}],
-		liveChange : ${28},
-		valueHelpRequest :${29}, 
-		suggest : ${30},
-		suggestionItemSelected : ${31}
+	var $1 = new sap.m.Input({
+		value :$2,
+		width : $3,
+		enabled :$4,
+		visible :$5,
+		valueState :$6,
+		name : $7,
+		placeholder : $8,
+		editable : $9,
+		type : $10,
+		maxLength :$11, 
+		valueStateText :$12, 
+		showValueStateMessage :$13, 
+		dateFormat :$14,
+		showValueHelp :$15,
+		showSuggestion :$16,
+		valueHelpOnly :$17,
+		filterSuggests :$18,
+		maxSuggestionWidth :$19,
+		startSuggestion : $20,
+		showTableSuggestionValueHelp : $21,
+		description : $22,
+		fieldWidth : $23,
+		valueLiveUpdate :$24,
+		suggestionItems  :[$25],
+		suggestionColumns : [$26],
+		suggestionRows : [$27],
+		liveChange : $28,
+		valueHelpRequest :$29, 
+		suggest : $30,
+		suggestionItemSelected : $31
 	});
 snippet _sthis
 	var _self = this;
 
 snippet sapmresponsivepopup
-	var ${1} = new sap.m.ResponsivePopover({
-				placement :${2} ,//sap.m.PlacementType (default: sap.m.PlacementType.Right)
-				showHeader :${3} ,//boolean (default: true)
-				title : ${4},//string
-				icon :${5} ,//sap.ui.core.URI
-				modal :${6} ,// boolean
-				offsetX :${7}, //int
-				offsetY :${8}, //int
-				contentWidth : ${9},//sap.ui.core.CSSSize
-				contentHeight :${10}, //sap.ui.core.CSSSize
-				horizontalScrolling :${11}, //boolean
-				verticalScrolling :${12}, //boolean
-				showCloseButton :${13}, //boolean (default: true)
+	var $1 = new sap.m.ResponsivePopover({
+				placement :$2 ,//sap.m.PlacementType (default: sap.m.PlacementType.Right)
+				showHeader :$3 ,//boolean (default: true)
+				title : $4,//string
+				icon :$5 ,//sap.ui.core.URI
+				modal :$6 ,// boolean
+				offsetX :$7, //int
+				offsetY :$8, //int
+				contentWidth : $9,//sap.ui.core.CSSSize
+				contentHeight :$10, //sap.ui.core.CSSSize
+				horizontalScrolling :$11, //boolean
+				verticalScrolling :$12, //boolean
+				showCloseButton :$13, //boolean (default: true)
 				//Aggregations
-				content :${14},  //sap.ui.core.Control[]
-				customHeader :${15},  //sap.m.IBar
-				subHeader : ${16}, //sap.m.IBar
-				beginButton :${17},  //sap.m.Button
-				endButton : ${18}, //sap.m.Button
+				content :$14,  //sap.ui.core.Control[]
+				customHeader :$15,  //sap.m.IBar
+				subHeader : $16, //sap.m.IBar
+				beginButton :$17,  //sap.m.Button
+				endButton : $18, //sap.m.Button
 				//Associations
-				initialFocus : ${19}, //string | sap.ui.core.Control
+				initialFocus : $19, //string | sap.ui.core.Control
 				//Events
-				beforeOpen :${20},  //fnListenerFunction or [fnListenerFunction, oListenerObject] or [oData, fnListenerFunction, oListenerObject]
-				afterOpen : ${21}, //fnListenerFunction or [fnListenerFunction, oListenerObject] or [oData, fnListenerFunction, oListenerObject]
-				beforeClose : ${22}, //fnListenerFunction or [fnListenerFunction, oListenerObject] or [oData, fnListenerFunction, oListenerObject]
-				afterClose : ${23} //fnList
+				beforeOpen :$20,  //fnListenerFunction or [fnListenerFunction, oListenerObject] or [oData, fnListenerFunction, oListenerObject]
+				afterOpen : $21, //fnListenerFunction or [fnListenerFunction, oListenerObject] or [oData, fnListenerFunction, oListenerObject]
+				beforeClose : $22, //fnListenerFunction or [fnListenerFunction, oListenerObject] or [oData, fnListenerFunction, oListenerObject]
+				afterClose : $23 //fnList
 			});
 
 snippet sapicon
-	var ${1} = new sap.ui.core.Icon({
-					src :${2} , //sap.ui.core.URI
-					size :${3} , //sap.ui.core.CSSSize
-					color :${4} , //sap.ui.core.CSSColor
-					hoverColor : ${5} ,  // sap.ui.core.CSSColor
-					activeColor :${6} , //sap.ui.core.CSSColor
-					width :${7} , //sap.ui.core.CSSSize
-					height : ${8} ,//sap.ui.core.CSSSize
-					backgroundColor :${8} , //sap.ui.core.CSSColor
-					hoverBackgroundColor :${9} , //sap.ui.core.CSSColor
-					activeBackgroundColor :${10} , //sap.ui.core.CSSColor
-					visible :${11} , //boolean (default: true)
-					decorative : ${12} ,//boolean (default: true)
+	var $1 = new sap.ui.core.Icon({
+					src :$2 , //sap.ui.core.URI
+					size :$3 , //sap.ui.core.CSSSize
+					color :$4 , //sap.ui.core.CSSColor
+					hoverColor : $5 ,  // sap.ui.core.CSSColor
+					activeColor :$6 , //sap.ui.core.CSSColor
+					width :$7 , //sap.ui.core.CSSSize
+					height : $8 ,//sap.ui.core.CSSSize
+					backgroundColor :$8 , //sap.ui.core.CSSColor
+					hoverBackgroundColor :$9 , //sap.ui.core.CSSColor
+					activeBackgroundColor :$10 , //sap.ui.core.CSSColor
+					visible :$11 , //boolean (default: true)
+					decorative : $12 ,//boolean (default: true)
 				});
 snippet extendVerticalL 
-	sap.ui.layout.VerticalLayout.extend("${1}", {
+	sap.ui.layout.VerticalLayout.extend("$1", {
 	    metadata: {
 		properties: {
-		  	${2} 
+		  	$2 
 		},
 		aggregations: {
-			${3}	
+			$3	
 		},
 		events: {
-			${4}
+			$4
 		}
 	    },
 	   init: function(){
-		${5}	
+		$5	
 	    },
 	    
-	    renderer: "${6}"
+	    renderer: "$6"
 	});	
 snippet extendHorizontalL 
-	sap.ui.layout.HorizontalLayout.extend("${1}", {
+	sap.ui.layout.HorizontalLayout.extend("$1", {
 	    metadata: {
 		properties: {
-		  	${2} 
+		  	$2 
 		},
 		aggregations: {
-			${3}	
+			$3	
 		},
 		events: {
-			${4}
+			$4
 		}
 	    },
 	   init: function(){
-		${5}	
+		$5	
 	    },
 	    
-	    renderer: "${6}"
+	    renderer: "$6"
 	});	

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -53,7 +53,7 @@ function ${1:function_name}(${2:argument}) {
 endsnippet
 
 snippet vf "Function assigned to var"
-${1:var }${2:function_name} = function $2(${3}) {
+${1:var }${2:function_name} = function $2($3) {
 	${VISUAL}$0
 };
 endsnippet

--- a/UltiSnips/php-laravel.snippets
+++ b/UltiSnips/php-laravel.snippets
@@ -53,9 +53,9 @@ use Illuminate\Support\ServiceProvider;
 class ${2:`!v expand('%:t:r')`} extends ServiceProvider {
     
     public function register() {
-        $this->app->bind('${4}Service', function ($app) {
-            return new ${5}(
-                $app->make('Repositories\\${6}Interface')
+        $this->app->bind('$4Service', function ($app) {
+            return new $5(
+                $app->make('Repositories\\$6Interface')
             );
         });
     }
@@ -121,7 +121,7 @@ class ${2:`!v expand('%:t:r')`} extends \Eloquent {
 
     public $timestamps = ${5:false};
 
-    protected $hidden  = [${6}];
+    protected $hidden  = [$6];
 
     protected $guarded = [${7:'id'}];
 }
@@ -208,10 +208,10 @@ snippet l_r "Laravel Repository" b
  * \date        `!v strftime('%d-%m-%y')`
  */
 
-namespace ${1:Repositories\\${2}};
+namespace ${1:Repositories\\$2};
 
-class ${3:`!v expand('%:t:r')`} extends \\${6} implements ${4:$3RepositoryInterface} {
-    ${7}
+class ${3:`!v expand('%:t:r')`} extends \\$6 implements ${4:$3RepositoryInterface} {
+    $7
 }
 endsnippet
 
@@ -227,7 +227,7 @@ snippet l_s "Laravel Service" b
  * \date        `!v strftime('%d-%m-%y')`
  */
 
-namespace Services\\${1};
+namespace Services\\$1;
 
 use ${3:Repositories\\${4:Interface}};
 
@@ -265,6 +265,6 @@ class ${2:`!v expand('%:t:r')`} extends Facade {
      *
      * \return      string
      */
-    protected static function getFacadeAccessor() { return '${4:${3}Service}'; }
+    protected static function getFacadeAccessor() { return '${4:$3Service}'; }
 }
 endsnippet

--- a/UltiSnips/php-phpspec.snippets
+++ b/UltiSnips/php-phpspec.snippets
@@ -23,7 +23,7 @@ class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
 ` extends ObjectBehavior
 {
-	function it_${1}()
+	function it_$1()
 	{
 		$0
 	}
@@ -31,7 +31,7 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet it "function it_does_something() { ... }"
-function it_${1}()
+function it_$1()
 {
 	${0:${VISUAL}}
 }
@@ -53,7 +53,7 @@ endsnippet
 
 # Object construction
 snippet cw "$this->beConstructedWith($arg)"
-$this->beConstructedWith(${1});
+$this->beConstructedWith($1);
 endsnippet
 
 snippet ct "$this->beConstructedThrough($methodName, [$arg])"
@@ -112,44 +112,44 @@ endsnippet
 
 # Type matchers
 snippet stype "$this->shouldHaveType('Type')"
-$this->shouldHaveType(${1});
+$this->shouldHaveType($1);
 endsnippet
 
 snippet sntype "$this->shouldNotHaveType('Type')"
-$this->shouldNotHaveType(${1});
+$this->shouldNotHaveType($1);
 endsnippet
 
 snippet srinstance "$this->shouldReturnAnInstanceOf('Type')"
-$this->shouldReturnAnInstanceOf(${1});
+$this->shouldReturnAnInstanceOf($1);
 endsnippet
 
 snippet snrinstance "$this->shouldNotReturnAnInstanceOf('Type')"
-$this->shouldNotReturnAnInstanceOf(${1});
+$this->shouldNotReturnAnInstanceOf($1);
 endsnippet
 
 snippet sbinstance "$this->shouldBeAnInstanceOf('Type')"
-$this->shouldBeAnInstanceOf(${1});
+$this->shouldBeAnInstanceOf($1);
 endsnippet
 
 snippet snbinstance "$this->shouldNotBeAnInstanceOf('Type')"
-$this->shouldNotBeAnInstanceOf(${1});
+$this->shouldNotBeAnInstanceOf($1);
 endsnippet
 
 snippet simplement "$this->shouldImplement('Type')"
-$this->shouldImplement(${1});
+$this->shouldImplement($1);
 endsnippet
 
 snippet snimplement "$this->shouldNotImplement('Type')"
-$this->shouldNotImplement(${1});
+$this->shouldNotImplement($1);
 endsnippet
 
 # Object state matchers
 snippet sbstate "$this->shouldBeXYZ()"
-$this->shouldBe${1}();
+$this->shouldBe$1();
 endsnippet
 
 snippet snbstate "$this->shouldNotBeXYZ()"
-$this->shouldNotBe${1}();
+$this->shouldNotBe$1();
 endsnippet
 
 # Count matchers

--- a/UltiSnips/php-symfony2.snippets
+++ b/UltiSnips/php-symfony2.snippets
@@ -67,25 +67,25 @@ endsnippet
 
 snippet act "Symfony2 action" b
 /**
- * @Route("${3}", name="${4}")
+ * @Route("$3", name="$4")
  * @Method({${5:"POST"}})
  * @Template()
  */
-public function ${1}Action(${2})
+public function $1Action($2)
 {
-	${6}
+	$6
 }
 endsnippet
 
 snippet actt "Symfony2 action and template" b
 /**
- * @Route("${3}", name="${4}")
+ * @Route("$3", name="$4")
  * @Method({${5:"GET"}})
  * @Template()
  */
-public function ${1}Action(${2})
+public function $1Action($2)
 {
-	${6}
+	$6
 	return [];
 }`!p
 relpath = os.path.relpath(path)`
@@ -116,8 +116,8 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 {
 	protected function configure()
 	{
-		$this->setName('${1}')
-			->setDescription('${2}')
+		$this->setName('$1')
+			->setDescription('$2')
 			->setDefinition([
 				new InputArgument('', InputArgument::REQUIRED, ''),
 				new InputOption('', null, InputOption::VALUE_NONE, ''),
@@ -186,14 +186,14 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 	/**
 	 * {@inheritDoc}
 	 */
-	public function transform(${1})
+	public function transform($1)
 	{
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function reverseTransform(${2})
+	public function reverseTransform($2)
 	{
 	}
 }
@@ -279,7 +279,7 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 	 */
 	public function getName()
 	{
-		return '${1}';
+		return '$1';
 	}
 }
 endsnippet
@@ -307,54 +307,54 @@ snip.rv = re.match(r'.*(?=\.)', fn).group()
 endsnippet
 
 snippet redir "Symfony2 redirect" b
-$this->redirect($this->generateUrl('${1}', ${2}));
+$this->redirect($this->generateUrl('$1', $2));
 endsnippet
 
 snippet usecontroller "Symfony2 use Symfony\..\Controller" b
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;${1}
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;$1
 endsnippet
 
 snippet usereauest "Symfony2 use Symfony\..\Request" b
-use Symfony\Component\HttpFoundation\Request;${1}
+use Symfony\Component\HttpFoundation\Request;$1
 endsnippet
 
 snippet useroute "Symfony2 use Sensio\..\Route" b
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;${1}
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;$1
 endsnippet
 
 snippet useresponse "Symfony2 use Symfony\..\Response" b
-use Symfony\Component\HttpFoundation\Response;${1}
+use Symfony\Component\HttpFoundation\Response;$1
 endsnippet
 
 snippet usefile "Symfony2 use Symfony\..\File" b
-use Symfony\Component\HttpFoundation\File\UploadedFile;${1}
+use Symfony\Component\HttpFoundation\File\UploadedFile;$1
 endsnippet
 
 snippet useassert "Symfony2 use Symfony\..\Constraints as Assert" b
-use Symfony\Component\Validator\Constraints as Assert;${1}
+use Symfony\Component\Validator\Constraints as Assert;$1
 endsnippet
 
 snippet usetemplate "Symfony2 use Sensio\..\Template" b
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;${1}
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;$1
 endsnippet
 
 snippet usecache "Symfony2 use Sensio\..\Cache" b
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;${1}
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;$1
 endsnippet
 
 snippet usemethod "Symfony2 use Sensio\..\Method" b
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;${1}
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;$1
 endsnippet
 
 snippet usearray "Symfony2 use Doctrine\..\ArrayCollection" b
-use Doctrine\Common\Collections\ArrayCollection;${1}
+use Doctrine\Common\Collections\ArrayCollection;$1
 endsnippet
 
 snippet useorm "Symfony2 use Doctrine\..\Mapping as ORM" b
-use Doctrine\ORM\Mapping as ORM;${1}
+use Doctrine\ORM\Mapping as ORM;$1
 endsnippet
 
 snippet usesecure "Symfony2 use JMS\..\Secure" b
-use JMS\SecurityExtraBundle\Annotation\Secure;${1}
+use JMS\SecurityExtraBundle\Annotation\Secure;$1
 endsnippet
 

--- a/UltiSnips/php.snippets
+++ b/UltiSnips/php.snippets
@@ -250,7 +250,7 @@ class `!p
 snip.rv = re.match(r'.*(?=\.)', fn).group()
 ` extends \PHPUnit_Framework_TestCase
 {
-	public function test${1}()
+	public function test$1()
 	{
 		${0:${VISUAL}}
 	}

--- a/UltiSnips/proto.snippets
+++ b/UltiSnips/proto.snippets
@@ -32,17 +32,17 @@ endsnippet
 
 snippet reqf "Required field" b
 // ${4:TODO(`whoami`): Describe this field.}
-optional ${1}`!p snip.rv = complete(t[1], FIELD_TYPES)` ${2:name} = ${3:1};  // Required
+optional $1`!p snip.rv = complete(t[1], FIELD_TYPES)` ${2:name} = ${3:1};  // Required
 endsnippet
 
 snippet optf "Optional field" b
 // ${4:TODO(`whoami`): Describe this field.}
-optional ${1}`!p snip.rv = complete(t[1], FIELD_TYPES)` ${2:name} = ${3:1};
+optional $1`!p snip.rv = complete(t[1], FIELD_TYPES)` ${2:name} = ${3:1};
 endsnippet
 
 snippet repf "Repeated field" b
 // ${4:TODO(`whoami`): Describe this field.}
-repeated ${1}`!p snip.rv = complete(t[1], FIELD_TYPES)` ${2:name} = ${3:1};
+repeated $1`!p snip.rv = complete(t[1], FIELD_TYPES)` ${2:name} = ${3:1};
 endsnippet
 
 snippet enum "Enumeration" b

--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -133,103 +133,103 @@ endsnippet
 ########################################################################
 
 snippet alert "Alert Function" b
-alert("${1:message}")${0}
+alert("${1:message}")$0
 endsnippet
 
 snippet crit "Crit Function" b
-crit("${1:message}")${0}
+crit("${1:message}")$0
 endsnippet
 
 snippet debug "Debug Function" b
-debug("${1:message}")${0}
+debug("${1:message}")$0
 endsnippet
 
 snippet defined "Defined Function" b
-defined(${1:Resource}["${2:name}"])${0}
+defined(${1:Resource}["${2:name}"])$0
 endsnippet
 
 snippet emerg "Emerg Function" b
-emerg("${1:message}")${0}
+emerg("${1:message}")$0
 endsnippet
 
 snippet extlookup "Simple Extlookup" b
-$${1:Variable} = extlookup("${2:Lookup}")${0}
+$${1:Variable} = extlookup("${2:Lookup}")$0
 endsnippet
 
 snippet extlookup "Extlookup with defaults" b
-$${1:Variable} = extlookup("${2:Lookup}", ${3:Default})${0}
+$${1:Variable} = extlookup("${2:Lookup}", ${3:Default})$0
 endsnippet
 
 snippet extlookup "Extlookup with defaults and custom data file" b
-$${1:Variable} = extlookup("${2:Lookup}", ${3:Default}, ${4:Data Source})${0}
+$${1:Variable} = extlookup("${2:Lookup}", ${3:Default}, ${4:Data Source})$0
 endsnippet
 
 snippet fail "Fail Function" b
-fail("${1:message}")${0}
+fail("${1:message}")$0
 endsnippet
 
 snippet hiera "Hiera Function" b
-$${1:Variable} = hiera("${2:Lookup}")${0}
+$${1:Variable} = hiera("${2:Lookup}")$0
 endsnippet
 
 snippet hiera "Hiera with defaults" b
-$${1:Variable} = hiera("${2:Lookup}", ${3:Default})${0}
+$${1:Variable} = hiera("${2:Lookup}", ${3:Default})$0
 endsnippet
 
 snippet hiera "Hiera with defaults and override" b
-$${1:Variable} = hiera("${2:Lookup}", ${3:Default}, ${4:Override})${0}
+$${1:Variable} = hiera("${2:Lookup}", ${3:Default}, ${4:Override})$0
 endsnippet
 
 snippet hiera_hash "Hiera Hash Function" b
-$${1:Variable} = hiera_hash("${2:Lookup}")${0}
+$${1:Variable} = hiera_hash("${2:Lookup}")$0
 endsnippet
 
 snippet hiera_hash "Hiera Hash with defaults" b
-$${1:Variable} = hiera_hash("${2:Lookup}", ${3:Default})${0}
+$${1:Variable} = hiera_hash("${2:Lookup}", ${3:Default})$0
 endsnippet
 
 snippet hiera_hash "Hiera Hash with defaults and override" b
-$${1:Variable} = hiera_hash("${2:Lookup}", ${3:Default}, ${4:Override})${0}
+$${1:Variable} = hiera_hash("${2:Lookup}", ${3:Default}, ${4:Override})$0
 endsnippet
 
 snippet hiera_include "Hiera Include Function" b
-hiera_include("${1:Lookup}")${0}
+hiera_include("${1:Lookup}")$0
 endsnippet
 
 snippet include "Include Function" b
-include ${1:classname}${0}
+include ${1:classname}$0
 endsnippet
 
 snippet info "Info Function" b
-info("${1:message}")${0}
+info("${1:message}")$0
 endsnippet
 
 snippet inline_template "Inline Template Function" b
-inline_template("<%= ${1:template} %>")${0}
+inline_template("<%= ${1:template} %>")$0
 endsnippet
 
 snippet notice "Notice Function" b
-notice("${1:message}")${0}
+notice("${1:message}")$0
 endsnippet
 
 snippet realize "Realize Function" b
-realize(${1:Resource}["${2:name}"])${0}
+realize(${1:Resource}["${2:name}"])$0
 endsnippet
 
 snippet regsubst "Regsubst Function" b
-regsubst($${1:Target}, '${2:regexp}', '${3:replacement}')${0}
+regsubst($${1:Target}, '${2:regexp}', '${3:replacement}')$0
 endsnippet
 
 snippet split "Split Function" b
-$${1:Variable} = split($${1:Target}, '${2:regexp}')${0}
+$${1:Variable} = split($${1:Target}, '${2:regexp}')$0
 endsnippet
 
 snippet versioncmp "Version Compare Function" b
-$${1:Variable} = versioncmp('${1:version}', '${2:version}')${0}
+$${1:Variable} = versioncmp('${1:version}', '${2:version}')$0
 endsnippet
 
 snippet warning "Warning Function" b
-warning("${1:message}")${0}
+warning("${1:message}")$0
 endsnippet
 
 # vim:ft=snippets:

--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -19,7 +19,7 @@ endsnippet
 snippet with "with" b
 with ${1:expr}`!p snip.rv = " as " if t[2] else ""`${2:var}:
 	${3:${VISUAL:pass}}
-${0}
+$0
 endsnippet
 
 snippet for "for loop" b

--- a/UltiSnips/r.snippets
+++ b/UltiSnips/r.snippets
@@ -24,11 +24,11 @@ setwd("${1:`!p snip.rv = os.getcwd()`}")
 endsnippet
 
 snippet as "Apply type on variable" w
-as.$1`!p snip.rv = complete(t[1], FIELD_TYPES)`(${2}${VISUAL})
+as.$1`!p snip.rv = complete(t[1], FIELD_TYPES)`($2${VISUAL})
 endsnippet
 
 snippet is "Test type on variable" w
-is.$1`!p snip.rv = complete(t[1], FIELD_TYPES)`(${2}${VISUAL})
+is.$1`!p snip.rv = complete(t[1], FIELD_TYPES)`($2${VISUAL})
 endsnippet
 
 snippet dl "Download and install a package" b
@@ -50,51 +50,51 @@ source('${0:file}')
 endsnippet
 
 snippet if "If statement"
-if (${1}) {
-	${0}
+if ($1) {
+	$0
 }
 endsnippet
 
 snippet eif "Else-If statement"
-else if (${1}) {
-	${0}
+else if ($1) {
+	$0
 }
 endsnippet
 
 snippet el "Else statement"
 else {
-	${0}
+	$0
 }
 endsnippet
 
 snippet ife "if .. else"
-if (${1}) {
-	${2}
+if ($1) {
+	$2
 } else {
-	${3}
+	$3
 }
 endsnippet
 
 snippet wh "while loop"
-while(${1}) {
-	${2}
+while($1) {
+	$2
 }
 endsnippet
 
 snippet for "for loop"
 for (${1:item} in ${2:list}) {
-	${3}
+	$3
 }
 endsnippet
 
 snippet fun "Function definition"
-${1:name} <- function (${2}) {
-	${0}
+${1:name} <- function ($2) {
+	$0
 }
 endsnippet
 
 snippet ret "Return call"
-return(${0})
+return($0)
 endsnippet
 
 snippet df "Data frame"

--- a/UltiSnips/rails.snippets
+++ b/UltiSnips/rails.snippets
@@ -22,7 +22,7 @@ class ${1:Model}Controller < ApplicationController
 	$0
 
 	private
-	def find_${2}
+	def find_$2
 		@$2 = ${3:$1}.find(params[:id]) if params[:id]
 	end
 end
@@ -253,7 +253,7 @@ after_validation_on_update $0
 endsnippet
 
 snippet asg "assert(var = assigns(:var))"
-assert(${1:var} = assigns(:${1}), "Cannot find @${1}")
+assert(${1:var} = assigns(:$1), "Cannot find @$1")
 $0
 endsnippet
 
@@ -270,11 +270,11 @@ end
 endsnippet
 
 snippet artnpp "assert_redirected_to (nested path plural)"
-assert_redirected_to ${10:${2:parent}_${3:child}_path(${4:@}${5:${2}})}
+assert_redirected_to ${10:${2:parent}_${3:child}_path(${4:@}${5:$2})}
 endsnippet
 
 snippet artnp "assert_redirected_to (nested path)"
-assert_redirected_to ${2:${12:parent}_${13:child}_path(${14:@}${15:${12}}, ${16:@}${17:${13}})}
+assert_redirected_to ${2:${12:parent}_${13:child}_path(${14:@}${15:$12}, ${16:@}${17:$13})}
 endsnippet
 
 snippet artpp "assert_redirected_to (path plural)"
@@ -282,7 +282,7 @@ assert_redirected_to ${10:${2:model}s_path}
 endsnippet
 
 snippet artp "assert_redirected_to (path)"
-assert_redirected_to ${2:${12:model}_path(${13:@}${14:${12}})}
+assert_redirected_to ${2:${12:model}_path(${13:@}${14:$12})}
 endsnippet
 
 snippet asrj "assert_rjs"
@@ -324,7 +324,7 @@ before_validation_on_update
 endsnippet
 
 snippet bt "belongs_to (bt)"
-belongs_to :${1:object}${2:, :class_name => "${3:${1/[[:alpha:]]+|(_)/(?1::\u$0)/g}}", :foreign_key => "${4:${1}_id}"}
+belongs_to :${1:object}${2:, :class_name => "${3:${1/[[:alpha:]]+|(_)/(?1::\u$0)/g}}", :foreign_key => "${4:$1_id}"}
 endsnippet
 
 snippet crw "cattr_accessor"
@@ -358,7 +358,7 @@ endsnippet
 snippet deftg "def get request"
 def test_should_get_${1:action}
 	${2:@${3:model} = ${4:$3s}(:${5:fixture_name})
-	}get :${1}${6:, :id => @$3.to_param}
+	}get :$1${6:, :id => @$3.to_param}
 	assert_response :success
 	$0
 end
@@ -367,7 +367,7 @@ endsnippet
 snippet deftp "def post request"
 def test_should_post_${1:action}
 	${3:@$2 = ${4:$2s}(:${5:fixture_name})
-	}post :${1}${6:, :id => @$2.to_param}, :${2:model} => { $0 }
+	}post :$1${6:, :id => @$2.to_param}, :${2:model} => { $0 }
 	assert_response :redirect
 
 end
@@ -400,23 +400,23 @@ end
 endsnippet
 
 snippet habtm "has_and_belongs_to_many (habtm)"
-has_and_belongs_to_many :${1:object}${2:, :join_table => "${3:table_name}", :foreign_key => "${4:${1}_id}"}
+has_and_belongs_to_many :${1:object}${2:, :join_table => "${3:table_name}", :foreign_key => "${4:$1_id}"}
 endsnippet
 
 snippet hm "has_many (hm)"
-has_many :${1:object}s${2:, :class_name => "${1}", :foreign_key => "${4:reference}_id"}
+has_many :${1:object}s${2:, :class_name => "$1", :foreign_key => "${4:reference}_id"}
 endsnippet
 
 snippet hmt "has_many (through)"
-has_many :${1:objects}, :through => :${2:join_association}${3:, :source => :${4:${2}_table_foreign_key_to_${1}_table}}
+has_many :${1:objects}, :through => :${2:join_association}${3:, :source => :${4:$2_table_foreign_key_to_$1_table}}
 endsnippet
 
 snippet hmd "has_many :dependent => :destroy"
-has_many :${1:object}s${2:, :class_name => "${1}", :foreign_key => "${4:reference}_id"}, :dependent => :destroy$0
+has_many :${1:object}s${2:, :class_name => "$1", :foreign_key => "${4:reference}_id"}, :dependent => :destroy$0
 endsnippet
 
 snippet ho "has_one (ho)"
-has_one :${1:object}${2:, :class_name => "${3:${1/[[:alpha:]]+|(_)/(?1::\u$0)/g}}", :foreign_key => "${4:${1}_id}"}
+has_one :${1:object}${2:, :class_name => "${3:${1/[[:alpha:]]+|(_)/(?1::\u$0)/g}}", :foreign_key => "${4:$1_id}"}
 endsnippet
 
 snippet logd "logger.debug"
@@ -514,11 +514,11 @@ redirect_to :controller => "${1:items}", :action => "${2:show}", :id => ${0:@ite
 endsnippet
 
 snippet renpp "redirect_to (nested path plural)"
-redirect_to(${2:${10:parent}_${11:child}_path(${12:@}${13:${10}})})
+redirect_to(${2:${10:parent}_${11:child}_path(${12:@}${13:$10})})
 endsnippet
 
 snippet renp "redirect_to (nested path)"
-redirect_to(${2:${12:parent}_${13:child}_path(${14:@}${15:${12}}, ${16:@}${17:${13}})})
+redirect_to(${2:${12:parent}_${13:child}_path(${14:@}${15:$12}, ${16:@}${17:$13})})
 endsnippet
 
 snippet repp "redirect_to (path plural)"
@@ -526,7 +526,7 @@ redirect_to(${2:${10:model}s_path})
 endsnippet
 
 snippet rep "redirect_to (path)"
-redirect_to(${2:${12:model}_path(${13:@}${14:${12}})})
+redirect_to(${2:${12:model}_path(${13:@}${14:$12})})
 endsnippet
 
 snippet reb "redirect_to :back"
@@ -882,12 +882,12 @@ end
 endsnippet
 
 snippet trans "Translation snippet"
-I18n.t('`!v substitute(substitute(substitute(@%, substitute(getcwd() . "/", "\/", "\\\\/", "g"), "", ""), "\\(\\.\\(html\\|js\\)\\.\\(haml\\|erb\\)\\|\\(_controller\\)\\?\\.rb\\)$", "", ""), "/", ".", "g")`.${2:${1/[^\w]/_/g}}${3}', :default => "${1:some_text}"${4})${5:$0}
+I18n.t('`!v substitute(substitute(substitute(@%, substitute(getcwd() . "/", "\/", "\\\\/", "g"), "", ""), "\\(\\.\\(html\\|js\\)\\.\\(haml\\|erb\\)\\|\\(_controller\\)\\?\\.rb\\)$", "", ""), "/", ".", "g")`.${2:${1/[^\w]/_/g}}$3', :default => "${1:some_text}"$4)${5:$0}
 endsnippet
 
 snippet route_spec
 it 'routes to #${1:action}' do
-	${2:get}('/${3:url}').should route_to('`!v substitute(expand('%:t:r'), '_routing_spec$', '', '')`#$1'${4:, ${5:params}})${6}
+	${2:get}('/${3:url}').should route_to('`!v substitute(expand('%:t:r'), '_routing_spec$', '', '')`#$1'${4:, ${5:params}})$6
 end
 endsnippet
 

--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -5,22 +5,22 @@
 priority -50
 
 snippet let "let variable declaration" b
-let ${1:name}${2:: ${3:type}} = ${4};
+let ${1:name}${2:: ${3:type}} = $4;
 endsnippet
 
 snippet letm "let mut variable declaration" b
-let mut ${1:name}${2:: ${3:type}} = ${4};
+let mut ${1:name}${2:: ${3:type}} = $4;
 endsnippet
 
 snippet fn "A function, optionally with arguments and return type."
-fn ${1:function_name}(${2})${3/..*/ -> /}${3} {
-	${VISUAL}${0}
+fn ${1:function_name}($2)${3/..*/ -> /}$3 {
+	${VISUAL}$0
 }
 endsnippet
 
 snippet pfn "A public function, optionally with arguments and return type."
-pub fn ${1:function_name}(${2})${3/..*/ -> /}${3} {
-	${VISUAL}${0}
+pub fn ${1:function_name}($2)${3/..*/ -> /}$3 {
+	${VISUAL}$0
 }
 endsnippet
 
@@ -29,44 +29,44 @@ ${1:a}: ${2:T}${3:, arg}
 endsnippet
 
 snippet || "Closure, anonymous function (inline)" i
-${1:move }|${2}| { $3 }
+${1:move }|$2| { $3 }
 endsnippet
 
 snippet |} "Closure, anonymous function (block)" i
-${1:move }|${2}| {
+${1:move }|$2| {
 	$3
 }
 endsnippet
 
 snippet pri "print!(..)" b
-print!("${1}"${2/..*/, /}${2});
+print!("$1"${2/..*/, /}$2);
 endsnippet
 
 snippet pln "println!(..)" b
-println!("${1}"${2/..*/, /}${2});
+println!("$1"${2/..*/, /}$2);
 endsnippet
 
 snippet fmt "format!(..)"
-format!("${1}"${2/..*/, /}${2});
+format!("$1"${2/..*/, /}$2);
 endsnippet
 
 snippet macro "macro_rules!" b
 macro_rules! ${1:name} {
 	(${2:matcher}) => (
-		${3}
+		$3
 	)
 }
 endsnippet
 
 snippet mod "A module" b
 mod ${1:`!p snip.rv = snip.basename.lower() or "name"`} {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 snippet for "for .. in .." b
-for ${1:i} in ${2} {
-	${VISUAL}${0}
+for ${1:i} in $2 {
+	${VISUAL}$0
 }
 endsnippet
 
@@ -76,19 +76,19 @@ endsnippet
 
 snippet st "Struct" b
 struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
-	${VISUAL}${0}
+	${VISUAL}$0
 }
 endsnippet
 
 # TODO: fancy dynamic field mirroring like Python slotclass
 snippet stn "Struct with new constructor." b
 pub struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
-	fd${0}
+	fd$0
 }
 
 impl $1 {
-	pub fn new(${2}) -> $1 {
-		$1 { ${3} }
+	pub fn new($2) -> $1 {
+		$1 { $3 }
 	}
 }
 endsnippet
@@ -99,7 +99,7 @@ endsnippet
 
 snippet impl "Struct/Trait implementation" b
 impl ${1:Type/Trait}${2: for ${3:Type}} {
-	${0}
+	$0
 }
 endsnippet
 

--- a/UltiSnips/supercollider.snippets
+++ b/UltiSnips/supercollider.snippets
@@ -5,6 +5,6 @@ for (${1:1}, ${2:10}) {${3: |i}|}
 endsnippet
 snippet sdef
 SynthDef(\\${1:synthName}, {${2: |${3:x}|}
-	${0}
+	$0
 }).add;
 endsnippet

--- a/UltiSnips/tcl.snippets
+++ b/UltiSnips/tcl.snippets
@@ -5,21 +5,21 @@ priority -50
 ###########################################################################
 snippet for "for... (for)" b
 for {${1:set i 0}} {${2:\$i < \$n}} {${3:incr i}} {
-	${4}
+	$4
 }
 
 endsnippet
 
 snippet foreach "foreach... (foreach)"
 foreach ${1:var} ${2:\$list} {
-	${3}
+	$3
 }
 
 endsnippet
 
 snippet if "if... (if)" b
 if {${1:condition}} {
-	${2}
+	$2
 }
 
 endsnippet
@@ -27,7 +27,7 @@ endsnippet
 snippet proc "proc... (proc)" b
 proc ${1:name} {${2:args}} \
 {
-	${3}
+	$3
 }
 
 endsnippet
@@ -35,16 +35,16 @@ endsnippet
 snippet switch "switch... (switch)" b
 switch ${1:-exact} -- ${2:\$var} {
 	${3:match} {
-		${4}
+		$4
 	}
-	default {${5}}
+	default {$5}
 }
 
 endsnippet
 
 snippet while "while... (while)" b
 while {${1:condition}} {
-	${2}
+	$2
 }
 
 endsnippet

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -53,7 +53,7 @@ snippet desc "Description" b
 endsnippet
 
 snippet it "Individual item" b
-\item ${1}
+\item $1
 $0
 endsnippet
 
@@ -61,54 +61,54 @@ snippet part "Part" b
 \part{${1:part name}}
 \label{prt:${2:${1/(\w+)|\W+/(?1:\L$0\E:_)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet cha "Chapter" b
 \chapter{${1:chapter name}}
 \label{cha:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet sec "Section" b
 \section{${1:section name}}
 \label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet sub "Subsection" b
 \subsection{${1:subsection name}}
 \label{sub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet ssub "Subsubsection" b
 \subsubsection{${1:subsubsection name}}
 \label{ssub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet par "Paragraph" b
 \paragraph{${1:paragraph name}}
 \label{par:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet subp "Subparagraph" b
 \subparagraph{${1:subparagraph name}}
 \label{par:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
-${0}
+$0
 endsnippet
 
 snippet ni "Non-indented paragraph" b
 \noindent
-${0}
+$0
 endsnippet
 
 snippet pac "Package" b

--- a/UltiSnips/vim.snippets
+++ b/UltiSnips/vim.snippets
@@ -13,11 +13,11 @@ snippet guard "script reload guard" b
 if exists('${1:did_`!p snip.rv = snip.fn.replace('.','_')`}') || &cp${2: || version < 700}
 	finish
 endif
-let $1 = 1${3}
+let $1 = 1$3
 endsnippet
 
 snippet f "function" b
-fun ${1:function_name}(${2})
+fun ${1:function_name}($2)
 	${3:" code}
 endf
 endsnippet


### PR DESCRIPTION

Following on from issue #842 the attached change cleans up all the ${x} expressions
into $x.

The following expression was used to perform the clean, handles
* ${1}->$1
* ${12}->$12 and
*  ${1}2->${1///}2 

`git grep -lz '\$\{[[:digit:]]+}'|xargs -0 sed -i -e 's/\${\([[:digit:]]\+\)}\([[:digit:]]\)/${\1\/\/\/}\2/g' -e 's/\${\([[:digit:]]\+\)}/$\1/g'
`

Regards
