### PR TITLE
Add "nocxx" snippet.

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -65,6 +65,18 @@ ${VISUAL}$0
 #endif /* end of include guard: $1 */
 endsnippet
 
+snippet nocxx "Disable C++ name mangling in C headers" b
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+${VISUAL}$0
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+endsnippet
+
 snippet fprintf "fprintf ..."
 fprintf(${1:stderr}, "${2:%s}\n"${2/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$3${2/([^%]|%%)*(%.)?.*/(?2:\);)/}
 endsnippet

--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -65,18 +65,6 @@ ${VISUAL}$0
 #endif /* end of include guard: $1 */
 endsnippet
 
-snippet nocxx "Disable C++ name mangling in C headers" b
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-${VISUAL}$0
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
-endsnippet
-
 snippet fprintf "fprintf ..."
 fprintf(${1:stderr}, "${2:%s}\n"${2/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$3${2/([^%]|%%)*(%.)?.*/(?2:\);)/}
 endsnippet

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -48,6 +48,17 @@ snippet once
 	${0}
 
 	#endif /* end of include guard: $1 */
+# Disable C++ name mangling in C headers
+snippet nocxx
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
+
+	${0}
+
+	#ifdef __cplusplus
+	} /* extern "C" */
+	#endif
 ##
 ## Control Statements
 # if


### PR DESCRIPTION
New snippet for the C++ name mangling protection commonly found in the header files of C libraries.