### PR TITLE
HTML snippets. Remove redundant 'type' attributes

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -163,12 +163,12 @@ snippet meta "XHTML <meta>" w
 <meta name="${1:name}" content="${2:content}"`!p x(snip)`>
 endsnippet
 
-snippet scriptsrc "XHTML <script src...>" w
-<script src="$1" type="text/javascript" charset="${3:utf-8}"></script>
+snippet scriptsrc "HTML <script src...>" w
+<script src="$1" charset="${3:utf-8}"></script>
 endsnippet
 
-snippet script "XHTML <script>" w
-<script type="text/javascript" charset="utf-8">
+snippet script "HTML <script>" w
+<script charset="utf-8">
 	${0:${VISUAL}}
 </script>
 endsnippet

--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -733,7 +733,7 @@ snippet samp
 		${0}
 	</samp>
 snippet script
-	<script type="text/javascript" charset="utf-8">
+	<script charset="utf-8">
 		${0}
 	</script>
 snippet scripts
@@ -743,7 +743,7 @@ snippet scriptt
 		${0}
 	</script>
 snippet scriptsrc
-	<script src="${0}.js" type="text/javascript" charset="utf-8"></script>
+	<script src="${0}.js" charset="utf-8"></script>
 snippet section
 	<section>
 		${0}


### PR DESCRIPTION
#845

>The type attribute allows customization of the type of script represented:
>
> * Omitting the attribute, or setting it to a JavaScript MIME type, means that the script is a classic script, to be interpreted according to the JavaScript Script top-level production. Classic scripts are affected by the charset, async, and defer attributes. **Authors should omit the attribute, instead of redundantly giving a JavaScript MIME type**.

This recommendation is taken from W3C HTML 5.1 Recommendation: https://www.w3.org/TR/html51/semantics-scripting.html#the-script-element. The highlighting was made by me.
