### PR TITLE
Add Elixir @spec snippet

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -63,6 +63,8 @@ snippet wie
 		${4} ->
 			${0}
 	end
+snippet spec
+	@spec ${1:name}(${2:args}) :: ${3:returns}
 snippet df
 	def ${1:name}, do: ${2}
 snippet def

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -63,8 +63,16 @@ snippet wie
 		${4} ->
 			${0}
 	end
-snippet spec
+snippet sp
 	@spec ${1:name}(${2:args}) :: ${3:returns}
+snippet op
+	@opaque ${1:type_name} :: ${2:type}
+snippet ty
+	@type ${1:type_name} :: ${2:type}
+snippet typ
+	@typep ${1:type_name} :: ${2:type}
+snippet cb
+	@callback ${1:name}(${2:args}) :: ${3:returns}
 snippet df
 	def ${1:name}, do: ${2}
 snippet def


### PR DESCRIPTION
Snippet that expands to Elixir type spec notation. I've had this in my
own snippets file for a while and use it regularly.