### PR TITLE
Changed `stn` snippet to use `Self`

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -142,7 +142,7 @@ snippet stn "Struct with new constructor"
 	}
 
 	impl $1 {
-		pub fn new(${2}) -> $1 {
+		pub fn new(${2}) -> Self {
 			$1 { ${3} }
 		}
 	}


### PR DESCRIPTION
I think this is more idiomatic Rust since `Self` references to the own structure in Rust.