### PR TITLE
Allow configure snippet format for JavaScript

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -10,7 +10,7 @@ priority -50
 
 global !p
 from javascript_snippets import (
-	semi, space_before_function_paren
+	semi, space_before_function_paren, keyword_spacing
 )
 endglobal
 
@@ -85,29 +85,29 @@ setTimeout(function`!p snip.rv = space_before_function_paren(snip)`() {
 endsnippet
 
 snippet fi "for prop in obj using hasOwnProperty" b
-for (${1:prop} in ${2:obj}){
-	if ($2.hasOwnProperty($1)) {
+for`!p snip.rv = keyword_spacing(snip)`(${1:prop} in ${2:obj}){
+	if`!p snip.rv = keyword_spacing(snip)`($2.hasOwnProperty($1)) {
 		${VISUAL}$0
 	}
 }
 endsnippet
 
 snippet if "if (condition) { ... }"
-if (${1:true}) {
+if`!p snip.rv = keyword_spacing(snip)`(${1:true}) {
 	${VISUAL}$0
 }
 endsnippet
 
 snippet ife "if (condition) { ... } else { ... }"
-if (${1:true}) {
+if`!p snip.rv = keyword_spacing(snip)`(${1:true}) {
 	${VISUAL}$0
-} else {
+}`!p snip.rv = keyword_spacing(snip)`else`!p snip.rv = keyword_spacing(snip)`{
 	${2}
 }
 endsnippet
 
 snippet switch
-switch (${VISUAL}${1:expression}) {
+switch`!p snip.rv = keyword_spacing(snip)`(${VISUAL}${1:expression}) {
 	case '${VISUAL}${3:case}':
 		${4}
 		break`!p snip.rv = semi(snip)`
@@ -118,15 +118,15 @@ switch (${VISUAL}${1:expression}) {
 endsnippet
 
 snippet case "case 'xyz': ... break"
-case '${VISUAL}${1:case}':
+case`!p snip.rv = keyword_spacing(snip)`'${VISUAL}${1:case}':
 	${VISUAL}$0
 	break`!p snip.rv = semi(snip)`
 endsnippet
 
 snippet do "do { ... } while (condition)"
-do {
+do`!p snip.rv = keyword_spacing(snip)`{
 	${VISUAL}$0
-} while (${1:/* condition */})`!p snip.rv = semi(snip)`
+}`!p snip.rv = keyword_spacing(snip)`while`!p snip.rv = keyword_spacing(snip)`(${1:/* condition */})`!p snip.rv = semi(snip)`
 endsnippet
 
 snippet ret "Return statement"

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -1,5 +1,19 @@
 priority -50
 
+############
+#  COMMON  #
+############
+
+# The smart snippets use a global options called
+# "g:ultisnips_javascript.{option}" which can control the format
+# of trailing semicolon, space before function paren, etc.
+
+global !p
+from javascript_snippets import (
+	semi, space_before_function_paren
+)
+endglobal
+
 ###########################################################################
 #                            TextMate Snippets                            #
 ###########################################################################
@@ -8,13 +22,13 @@ getElement${1/(T)|.*/(?1:s)/}By${1:T}${1/(T)|(I)|.*/(?1:agName)(?2:d)/}('$2')
 endsnippet
 
 snippet '':f "object method string"
-'${1:${2:#thing}:${3:click}}': function(element) {
+'${1:${2:#thing}:${3:click}}': function`!p snip.rv = space_before_function_paren(snip)`(element) {
 	${VISUAL}$0
 }${10:,}
 endsnippet
 
 snippet :f "Object Method"
-${1:method_name}: function(${3:attribute}) {
+${1:method_name}: function`!p snip.rv = space_before_function_paren(snip)`(${3:attribute}) {
 	${VISUAL}$0
 }${10:,}
 endsnippet
@@ -28,40 +42,46 @@ ${1:key}: ${2:"${3:value}"}${4:, }
 endsnippet
 
 snippet proto "Prototype (proto)"
-${1:class_name}.prototype.${2:method_name} = function(${3:first_argument}) {
+${1:class_name}.prototype.${2:method_name} = function`!p snip.rv = space_before_function_paren(snip)`(${3:first_argument}) {
 	${VISUAL}$0
-};
+}`!p snip.rv = semi(snip)`
 
 endsnippet
 
 snippet fun "function (fun)" w
-function ${1:function_name}(${2:argument}) {
+function ${1:function_name}`!p snip.rv = space_before_function_paren(snip)`(${2:argument}) {
 	${VISUAL}$0
 }
 endsnippet
 
 snippet vf "Function assigned to var"
-${1:var }${2:function_name} = function $2($3) {
+${1:var }${2:function_name} = function $2`!p snip.rv = space_before_function_paren(snip)`($3) {
 	${VISUAL}$0
-};
+}`!p snip.rv = semi(snip)`
 endsnippet
 
 snippet af "Anonymous Function" i
-function($1) {
+function`!p snip.rv = space_before_function_paren(snip)`($1) {
 	${VISUAL}$0
 }
 endsnippet
 
 snippet iife "Immediately-Invoked Function Expression (iife)"
-(function(${1:window}) {
+(function`!p snip.rv = space_before_function_paren(snip)`(${1:window}) {
 	${VISUAL}$0
-}(${2:$1}));
+}(${2:$1}))`!p snip.rv = semi(snip)`
+endsnippet
+
+snippet ;fe "Minify safe iife"
+;(function`!p snip.rv = space_before_function_paren(snip)`(${1}) {
+	${VISUAL}$0
+}(${2}))
 endsnippet
 
 snippet timeout "setTimeout function"
-setTimeout(function() {
+setTimeout(function`!p snip.rv = space_before_function_paren(snip)`() {
 	${VISUAL}$0
-}${2:.bind(${3:this})}, ${1:10});
+}${2:.bind(${3:this})}, ${1:10})`!p snip.rv = semi(snip)`
 endsnippet
 
 snippet fi "for prop in obj using hasOwnProperty" b
@@ -70,6 +90,51 @@ for (${1:prop} in ${2:obj}){
 		${VISUAL}$0
 	}
 }
+endsnippet
+
+snippet if "if (condition) { ... }"
+if (${1:true}) {
+	${VISUAL}$0
+}
+endsnippet
+
+snippet ife "if (condition) { ... } else { ... }"
+if (${1:true}) {
+	${VISUAL}$0
+} else {
+	${2}
+}
+endsnippet
+
+snippet switch
+switch (${VISUAL}${1:expression}) {
+	case '${VISUAL}${3:case}':
+		${4}
+		break`!p snip.rv = semi(snip)`
+	${0}
+	default:
+		${2}
+}
+endsnippet
+
+snippet case "case 'xyz': ... break"
+case '${VISUAL}${1:case}':
+	${VISUAL}$0
+	break`!p snip.rv = semi(snip)`
+endsnippet
+
+snippet do "do { ... } while (condition)"
+do {
+	${VISUAL}$0
+} while (${1:/* condition */})`!p snip.rv = semi(snip)`
+endsnippet
+
+snippet ret "Return statement"
+return ${VISUAL}$0`!p snip.rv = semi(snip)`
+endsnippet
+
+snippet us
+'use strict'`!p snip.rv = semi(snip)`
 endsnippet
 
 # vim:ft=snippets:

--- a/pythonx/javascript_snippets.py
+++ b/pythonx/javascript_snippets.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Helper utilities to format javascript snippets.
+"""
+
+ALWAYS = 'always'
+NEVER = 'never'
+
+
+def get_option(snip, option, default=None):
+    return snip.opt('g:ultisnips_javascript["{}"]'.format(option), default)
+
+
+def semi(snip):
+    option = get_option(snip, 'semi', ALWAYS)
+
+    if option == NEVER:
+        ret = ''
+    elif option == ALWAYS:
+        ret = ';'
+    else:
+        ret = ';'
+    return ret
+
+
+def space_before_function_paren(snip):
+    option = get_option(snip, 'space-before-function-paren', NEVER)
+
+    if option == NEVER:
+        ret = ''
+    elif option == ALWAYS:
+        ret = ' '
+    else:
+        ret = ''
+    return ret

--- a/pythonx/javascript_snippets.py
+++ b/pythonx/javascript_snippets.py
@@ -34,3 +34,15 @@ def space_before_function_paren(snip):
     else:
         ret = ''
     return ret
+
+
+def keyword_spacing(snip):
+    option = get_option(snip, 'keyword-spacing', ALWAYS)
+
+    if option == NEVER:
+        ret = ''
+    elif option == ALWAYS:
+        ret = ' '
+    else:
+        ret = ''
+    return ret


### PR DESCRIPTION
Different JavaScript projects uses different formatting options. The similar issue has been raised a few years ago #578. I trying to find a better way to adopt snippets for them.

This PR uses a python interpolation feature to configure common format options for JavaScript snippets, such as

- __Space before function parenthesis__,

     ```javascript

     function withoutSpace(x) {
         // ...
     }

     var anonymousWithoutSpace = function() {};
     ```

     vs

     ```javascript
     function withSpace (x) {
         // ...
     }

     var anonymousWithSpace = function () {};
     ```

- __Semicolons instead of ASI__,

    ```javascript
    var name = "ESLint";

    var func = function () {
      return 42;
    };
    ```

    vs

    ```javascript
    var name = "ESLint"

    var func = function () {
      return 42
    }
    ```

- __Spacing before and after keywords__,

    ```javascript
    if (foo) {
        //...
    }
    ```

    vs

    ```javascript
    if(foo) {
        //...
    }
    ```

Default formatting is not changed and can be refined via `vimrc`

```viml
let g:ultisnips_javascript = {
      \ 'keyword-spacing': 'always',
      \ 'semi': 'never',
      \ 'space-before-function-paren': 'always',
      \ }
```

or at runtime

```viml
let g:ultisnips_javascript['space-before-function-paren'] = 'never'
```

Since the global snippets works only with UltiSnips format, I add some flow control snippets (`if`, `ife`, `do`) in UltiSnips format as well.