### PR TITLE
fix notg syntax error in javascript-jasmine

### DIFF
--- a/UltiSnips/javascript-jasmine.snippets
+++ b/UltiSnips/javascript-jasmine.snippets
@@ -145,7 +145,7 @@ expect(${1:target}).not.toBeLessThan(${2:value});
 endsnippet
 
 snippet notg "expect to not be greater than (js)" b
-expect(${1:target})..not.toBeGreaterThan(${2:value});
+expect(${1:target}).not.toBeGreaterThan(${2:value});
 endsnippet
 
 snippet notm "expect not to match (js)" b


### PR DESCRIPTION
removed extra '.' in the javascript-jasmine.snippets
'notg' snippet which leads to a

SyntaxError: Unexpected token .

        expect(6)..not.toBeGreaterThan(7);
                  ^

if not removed