### PR TITLE
add javascript-jasmine-arrow.snippets

### DIFF
--- a/UltiSnips/javascript-jasmine-arrow.snippets
+++ b/UltiSnips/javascript-jasmine-arrow.snippets
@@ -1,0 +1,234 @@
+priority -50
+
+# JavaScript versions -- from the TextMate bundle + some additions
+# for jasmine-jquery matchers
+#
+
+snippet des "Describe (js)" b
+describe('${1:description}', () => {
+	$0
+});
+endsnippet
+
+snippet it "it (js)" b
+it('${1:description}', () => {
+	$0
+});
+endsnippet
+
+snippet bef "before each (js)" b
+beforeEach(() => {
+	$0
+});
+endsnippet
+
+snippet aft "after each (js)" b
+afterEach(() => {
+	$0
+});
+endsnippet
+
+snippet befa "before all (js)" b
+beforeAll(() => {
+	$0
+});
+endsnippet
+
+snippet afta "after all (js)" b
+afterAll(() => {
+	$0
+});
+endsnippet
+
+snippet any "any (js)" b
+jasmine.any($1)
+endsnippet
+
+snippet anyt "anything (js)" b
+jasmine.anything()
+endsnippet
+
+snippet objc "object containing (js)" b
+jasmine.objectContaining({
+	${VISUAL}$0
+});
+endsnippet
+
+snippet arrc "array containing (js)" b
+jasmine.arrayContaining([${1:value1}]);
+endsnippet
+
+snippet strm "string matching (js)" b
+jasmine.stringMatching("${1:matcher}")
+endsnippet
+
+snippet ru "runs (js)" b
+runs(() => {
+	$0
+});
+endsnippet
+
+snippet wa "waits (js)" b
+waits($1);
+endsnippet
+
+snippet ex "expect (js)" b
+expect(${1:target})$0;
+endsnippet
+
+snippet ee "expect to equal (js)" b
+expect(${1:target}).toEqual(${2:value});
+endsnippet
+
+snippet el "expect to be less than (js)" b
+expect(${1:target}).toBeLessThan(${2:value});
+endsnippet
+
+snippet eg "expect to be greater than (js)" b
+expect(${1:target}).toBeGreaterThan(${2:value});
+endsnippet
+
+snippet eb "expect to be (js)" b
+expect(${1:target}).toBe(${2:value});
+endsnippet
+
+snippet em "expect to match (js)" b
+expect(${1:target}).toMatch(${2:pattern});
+endsnippet
+
+snippet eha "expect to have attribute (js)" b
+expect(${1:target}).toHaveAttr('${2:attr}'${3:, '${4:value}'});
+endsnippet
+
+snippet et "expect to be truthy (js)" b
+expect(${1:target}).toBeTruthy();
+endsnippet
+
+snippet ef "expect to be falsy (js)" b
+expect(${1:target}).toBeFalsy();
+endsnippet
+
+snippet ed "expect to be defined (js)" b
+expect(${1:target}).toBeDefined();
+endsnippet
+
+snippet eud "expect to be defined (js)" b
+expect(${1:target}).toBeUndefined();
+endsnippet
+
+snippet en "expect to be null (js)" b
+expect(${1:target}).toBeNull();
+endsnippet
+
+snippet ec "expect to contain (js)" b
+expect(${1:target}).toContain(${2:value});
+endsnippet
+
+snippet ev "expect to be visible (js)" b
+expect(${1:target}).toBeVisible();
+endsnippet
+
+snippet eh "expect to be hidden (js)" b
+expect(${1:target}).toBeHidden();
+endsnippet
+
+snippet eth "expect to throw (js)" b
+expect(${1:target}).toThrow(${2:value});
+endsnippet
+
+snippet ethe "expect to throw error (js)" b
+expect(${1:target}).toThrowError(${2:value});
+endsnippet
+
+snippet notx "expect not (js)" b
+expect(${1:target}).not$0;
+endsnippet
+
+snippet note "expect not to equal (js)" b
+expect(${1:target}).not.toEqual(${2:value});
+endsnippet
+
+snippet notl "expect to not be less than (js)" b
+expect(${1:target}).not.toBeLessThan(${2:value});
+endsnippet
+
+snippet notg "expect to not be greater than (js)" b
+expect(${1:target}).not.toBeGreaterThan(${2:value});
+endsnippet
+
+snippet notm "expect not to match (js)" b
+expect(${1:target}).not.toMatch(${2:pattern});
+endsnippet
+
+snippet notha "expect to not have attribute (js)" b
+expect(${1:target}).not.toHaveAttr('${2:attr}'${3:, '${4:value}'});
+endsnippet
+
+snippet nott "expect not to be truthy (js)" b
+expect(${1:target}).not.toBeTruthy();
+endsnippet
+
+snippet notf "expect not to be falsy (js)" b
+expect(${1:target}).not.toBeFalsy();
+endsnippet
+
+snippet notd "expect not to be defined (js)" b
+expect(${1:target}).not.toBeDefined();
+endsnippet
+
+snippet notn "expect not to be null (js)" b
+expect(${1:target}).not.toBeNull();
+endsnippet
+
+snippet notc "expect not to contain (js)" b
+expect(${1:target}).not.toContain(${2:value});
+endsnippet
+
+snippet notv "expect not to be visible (js)" b
+expect(${1:target}).not.toBeVisible();
+endsnippet
+
+snippet noth "expect not to be hidden (js)" b
+expect(${1:target}).not.toBeHidden();
+endsnippet
+
+snippet notth "expect not to throw (js)" b
+expect(${1:target}).not.toThrow(${2:value});
+endsnippet
+
+snippet notthe "expect not to throw error (js)" b
+expect(${1:target}).not.toThrowError(${2:value});
+endsnippet
+
+snippet s "spy on (js)" b
+spyOn(${1:object}, '${2:method}')$0;
+endsnippet
+
+snippet sr "spy on and return (js)" b
+spyOn(${1:object}, '${2:method}').and.returnValue(${3:arguments});
+endsnippet
+
+snippet st "spy on and throw (js)" b
+spyOn(${1:object}, '${2:method}').and.throwError(${3:exception});
+endsnippet
+
+snippet sct "spy on and call through (js)" b
+spyOn(${1:object}, '${2:method}').and.callThrough();
+endsnippet
+
+snippet scf "spy on and call fake (js)" b
+spyOn(${1:object}, '${2:method}').and.callFake(${3:function});
+endsnippet
+
+snippet ethbc "expect to have been called (js)" b
+expect(${1:target}).toHaveBeenCalled();
+endsnippet
+
+snippet nthbc "expect not to have been called (js)" b
+expect(${1:target}).not.toHaveBeenCalled();
+endsnippet
+
+snippet ethbcw "expect to have been called with (js)" b
+expect(${1:target}).toHaveBeenCalledWith(${2:arguments});
+endsnippet
+


### PR DESCRIPTION
It is a simple modification of javascript-jasmine.snippets, ie. changing the function calls to arrow functions, in order to be able to use the same coding style in your tests and your other js code.

Here are the diffs between the base snippets and the requested one:
[diff.txt](https://github.com/honza/vim-snippets/files/806935/diff.txt)
