### PR TITLE
Added snippet for basic doxygen style cpp fucntion

### DIFF
--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -4,6 +4,48 @@ extends c
 
 # We want to overwrite everything in parent ft.
 priority -49
+###########################################################################
+# 			    Global functions 						  #
+###########################################################################
+
+global !p 
+
+def parseParamList(snip, args):
+	paramList = args.split(",")
+	s = ""
+	for w in paramList:
+		snip += w.strip()
+		if len(paramList) > 1:
+			snip.rv += '\n' + snip.mkline('',indent='') 
+
+def get_args(arglist):
+	'''
+	args = [Arg(arg) for arg in arglist.split(',') if arg]
+	args = [arg for arg in args if arg.name != 'self']
+	'''
+	args = arglist.split(',')
+	return args
+
+
+def write_docstring_args(arglist, snip):
+	
+	#args = get_args(arglist)
+	args = str(arglist).split(',')
+
+
+	if len(args) > 1:
+		c = 0
+		for arg in args:
+			if c == 0:
+				snip.rv += arg
+				c = 1 
+			else:
+				snip += '*       : %s' % arg.strip() 
+	else:
+		snip.rv = args[0]
+
+
+endglobal
 
 ###########################################################################
 #                            TextMate Snippets                            #
@@ -69,5 +111,20 @@ public:
 };
 
 #endif /* $2 */
+endsnippet
+
+
+snippet fnc "Basic c++ doxygen function template" b
+/**
+* @brief: ${4:brief} 
+*
+* @param: `!p write_docstring_args(t[3],snip)`
+*
+* @return: `!p snip.rv = t[1]` 
+*/
+${1:ReturnType} ${2:FunctionName}(${3:param})
+{
+  ${0:FunctionBody}
+}
 endsnippet
 # vim:ft=snippets:


### PR DESCRIPTION
I'm trying to create templates for doxygen style commented c++ code. 
I used python.snippets as a reference for creating the snippet itself. 
(This is my first time contributing to git, please let me know if there is something amiss, or if there is some procedure I didn't follow) 


![image](https://cloud.githubusercontent.com/assets/12117926/23440518/55d0f09a-fdea-11e6-8c56-bc87c73b43f7.png)

![image](https://cloud.githubusercontent.com/assets/12117926/23440593/d032153a-fdea-11e6-95f6-964513142c63.png)

![image](https://cloud.githubusercontent.com/assets/12117926/23440610/e4bd4682-fdea-11e6-978d-7f5e2bd8724f.png)

