### PR TITLE
Erlang file name is not working any more

### DIFF
--- a/snippets/erlang.snippets
+++ b/snippets/erlang.snippets
@@ -1,14 +1,6 @@
-# module and export all
+# module
 snippet mod
-	-module(${1:`vim_snippets#Filename('', 'my')`}).
-
-	-compile([export_all]).
-
-	start() ->
-	    ${0}
-
-	stop() ->
-	    ok.
+	-module(${1:`vim_snippets#Filename()`}).
 # define directive
 snippet def
 	-define(${1:macro}, ${2:body}).
@@ -73,7 +65,7 @@ snippet %p
 	%% @private
 # OTP application
 snippet application
-	-module(${1:`vim_snippets#Filename('', 'my')`}).
+	-module(${1:`vim_snippets#Filename()`}).
 
 	-behaviour(application).
 
@@ -91,7 +83,7 @@ snippet application
 	    ok.
 # OTP supervisor
 snippet supervisor
-	-module(${1:`vim_snippets#Filename('', 'my')`}).
+	-module(${1:`vim_snippets#Filename()`}).
 
 	-behaviour(supervisor).
 
@@ -114,7 +106,7 @@ snippet supervisor
 	    {ok, {RestartStrategy, Children}}.
 # OTP gen_server
 snippet gen_server
-	-module(${0:`vim_snippets#Filename('', 'my')`}).
+	-module(${0:`vim_snippets#Filename()`}).
 
 	-behaviour(gen_server).
 
@@ -170,7 +162,7 @@ snippet gen_server
 	%%%===================================================================
 # OTP gen_fsm
 snippet gen_fsm
-	-module(${0:`vim_snippets#Filename('', 'my')`}).
+	-module(${0:`vim_snippets#Filename()`}).
 
 	-behaviour(gen_fsm).
 
@@ -348,7 +340,7 @@ snippet gen_fsm
 	%%%===================================================================
 # OTP gen_event
 snippet gen_event
-	-module(${0:`vim_snippets#Filename('', 'my')`}).
+	-module(${0:`vim_snippets#Filename()`}).
 
 	-behaviour(gen_event).
 
@@ -484,7 +476,7 @@ snippet gen_event
 	%%%===================================================================
 # EUnit snippets
 snippet eunit
-	-module(${1:`vim_snippets#Filename('', 'my')`}).
+	-module(${1:`vim_snippets#Filename()`}).
 	-include_lib("eunit/include/eunit.hrl").
 
 	${0}
@@ -515,7 +507,7 @@ snippet asexc
 	?assertException(${1:Class}, ${2:Pattern}, ${0:Expression})
 # common_test test_SUITE
 snippet testsuite
-	-module(${0:`vim_snippets#Filename('', 'my')`}).
+	-module(${0:`vim_snippets#Filename()`}).
 
 	-include_lib("common_test/include/ct.hrl").
 

--- a/snippets/erlang.snippets
+++ b/snippets/erlang.snippets
@@ -1,6 +1,16 @@
 # module
 snippet mod
 	-module(${1:`vim_snippets#Filename()`}).
+# module and export all
+snippet modall
+	-module(${1:`vim_snippets#Filename()`}).
+	-compile([export_all]).
+	 
+	start() ->
+		${0}
+	 
+	stop() ->
+		ok.
 # define directive
 snippet def
 	-define(${1:macro}, ${2:body}).


### PR DESCRIPTION
Fixed by this PR. I am using vim-snipmate, not sure if it's caused by wrong snippet driver or not.