### PR TITLE
Updates C and C++ snippets

### DIFF
--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -42,12 +42,11 @@ snippet #if
 # header include guard
 snippet once
 	#ifndef ${1:`toupper(vim_snippets#Filename('$1_H', 'UNTITLED_H'))`}
-
 	#define $1
 
 	${0}
 
-	#endif /* end of include guard: $1 */
+	#endif /* $1 */
 ##
 ## Control Statements
 # if
@@ -80,18 +79,18 @@ snippet t
 # switch
 snippet switch
 	switch (${1:/* variable */}) {
-		case ${2:/* variable case */}:
-			${3}
-			${4:break;}${5}
-		default:
-			${6}
+	case ${2:/* variable case */}:
+		${3}
+		${4:break;}${5}
+	default:
+		${6}
 	}
 # switch without default
 snippet switchndef
 	switch (${1:/* variable */}) {
-		case ${2:/* variable case */}:
-			${3}
-			${4:break;}${5}
+	case ${2:/* variable case */}:
+		${3}
+		${4:break;}${5}
 	}
 # case
 snippet case
@@ -104,12 +103,16 @@ snippet ret
 ## Loops
 # for
 snippet for
-	for (int ${2:i} = 0; $2 < ${1:count}; $2${3:++}) {
+	int ${2:i}
+
+	for (${2:i} = 0; $2 < ${1:count}; $2${3: += 1}) {
 		${4}
 	}
 # for (custom)
 snippet forr
-	for (int ${1:i} = ${2:0}; ${3:$1 < 10}; $1${4:++}) {
+	int ${1:i};
+
+	for (${1:i} = ${2:0}; ${3:$1 < 10}; $1${4: += 1}) {
 		${5}
 	}
 # while
@@ -132,7 +135,7 @@ snippet fun
 	}
 # function definition with zero parameters
 snippet fun0
-	${1:void} ${2:function_name}()
+	${1:void} ${2:function_name}(void)
 	{
 		${3}
 	}
@@ -144,7 +147,7 @@ snippet dfun0
 	 *
 	 * \return ${3:Return parameter description}
 	 */
-	${4:void} ${5:function_name}()
+	${4:void} ${5:function_name}(void)
 	{
 		${6}
 	}
@@ -187,13 +190,13 @@ snippet dfun2
 	{
 		${12}
 	}
-# function definition with two parameters
+# function definition with three parameters
 snippet fun3
 	${1:void} ${2:function_name}(${3:Type} ${4:Parameter}, ${5:Type} ${6:Parameter}, ${7:Type} ${8:Parameter})
 	{
 		${9}
 	}
-# function definition with two parameters with  Doxygen documentation
+# function definition with three parameters with  Doxygen documentation
 snippet dfun3
 	/*! \brief ${1:Brief function description here}
 	 *
@@ -218,6 +221,11 @@ snippet td
 	typedef ${1:int} ${2:MyCustomType};
 # struct
 snippet st
+	struct ${1:`vim_snippets#Filename('_$1', 'name')`} {
+		${2:Data}
+	}
+# struct with documentation
+snippet std
 	/*! \struct $1
 	 *  \brief ${3:Brief struct description}
 	 *
@@ -228,6 +236,11 @@ snippet st
 	}${5: /* optional variable list */};
 # typedef struct
 snippet tds
+	typedef struct ${2:_$1 }{
+		${3:Data}
+	} ${1:`vim_snippets#Filename('$1', 'name')`};
+# typedef struct with documentation
+snippet tdsd
 	/*! \struct $2
 	 *  \brief ${5:Brief struct description}
 	 *
@@ -237,7 +250,11 @@ snippet tds
 		m_${3:Data} /*!< ${4:Description} */
 	} ${1:`vim_snippets#Filename('$1_t', 'name')`};
 
+# enum
 snippet enum
+	enum ${1:name} { ${0} };
+# enum with documentation
+snippet enumd
 	/*! \enum $1
 	 *
 	 *  ${2:Detailed description}
@@ -245,6 +262,11 @@ snippet enum
 	enum ${1:name} { ${0} };
 # typedef enum
 snippet tde
+	typedef enum {
+		${1:Data}
+	} ${2:foo};
+# typedef enum with documentation
+snippet tded
 	/*! \enum $2
 	 *
 	 *  ${4:Detailed description}

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -103,7 +103,7 @@ snippet ret
 ## Loops
 # for
 snippet for
-	int ${2:i}
+	int $2;
 
 	for (${2:i} = 0; $2 < ${1:count}; $2${3: += 1}) {
 		${4}

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -110,7 +110,7 @@ snippet for
 	}
 # for (custom)
 snippet forr
-	int ${1:i};
+	int $1;
 
 	for (${1:i} = ${2:0}; ${3:$1 < 10}; $1${4: += 1}) {
 		${5}

--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -139,7 +139,8 @@ snippet dmfun1
 	 * \param $4 ${8:Parameter description}
 	 * \return ${9:Return parameter description}
 	 */
-	${5:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter}) {
+	${5:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter})
+	{
 		${0}
 	}
 # member function implementation with two parameter
@@ -158,7 +159,8 @@ snippet dmfun2
 	 * \param $6 ${11:Parameter description}
 	 * \return ${12:Return parameter description}
 	 */
-	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter}, ${5:Type} ${6:Parameter}) {
+	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter}, ${5:Type} ${6:Parameter})
+	{
 		${0}
 	}
 # namespace

--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -78,6 +78,14 @@ snippet mu
 ## Class
 # class
 snippet cl
+	class ${1:`vim_snippets#Filename('$1', 'name')`}
+	{
+	public:
+		$1(${2});
+		virtual ~$1();
+	};
+# class with documentation
+snippet cld
 	/*! \class $1
 	 *  \brief ${3:Brief class description}
 	 *
@@ -94,10 +102,23 @@ snippet cl
 	};
 # member function implementation
 snippet mfun
-	${4:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3}) {
+	${4:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3})
+	{
 		${0}
 	}
 # member function implementation without parameters
+snippet mfun0
+	/*! \brief ${4:Brief function description here}
+	 *
+	 *  ${5:Detailed description}
+	 *
+	 * \return ${6:Return parameter description}
+	 */
+	${3:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}()
+	{
+		${0}
+	}
+# member function implementation without parameters with documentation
 snippet dmfun0
 	/*! \brief ${4:Brief function description here}
 	 *
@@ -105,10 +126,24 @@ snippet dmfun0
 	 *
 	 * \return ${6:Return parameter description}
 	 */
-	${3:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}() {
+	${3:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}()
+	{
 		${0}
 	}
 # member function implementation with one parameter
+snippet mfun1
+	/*! \brief ${6:Brief function description here}
+	 *
+	 *  ${7:Detailed description}
+	 *
+	 * \param $4 ${8:Parameter description}
+	 * \return ${9:Return parameter description}
+	 */
+	${5:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter})
+	{
+		${0}
+	}
+# member function implementation with one parameter with documentation
 snippet dmfun1
 	/*! \brief ${6:Brief function description here}
 	 *
@@ -121,6 +156,20 @@ snippet dmfun1
 		${0}
 	}
 # member function implementation with two parameter
+snippet mfun2
+	/*! \brief ${8:Brief function description here}
+	 *
+	 *  ${9:Detailed description}
+	 *
+	 * \param $4 ${10:Parameter description}
+	 * \param $6 ${11:Parameter description}
+	 * \return ${12:Return parameter description}
+	 */
+	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter},${5:Type} ${6:Parameter})
+	{
+		${0}
+	}
+# member function implementation with two parameter with documentation
 snippet dmfun2
 	/*! \brief ${8:Brief function description here}
 	 *
@@ -135,9 +184,10 @@ snippet dmfun2
 	}
 # namespace
 snippet ns
-	namespace ${1:`vim_snippets#Filename('', 'my')`} {
+	namespace ${1:`vim_snippets#Filename('', 'my')`}
+	{
 		${0}
-	} /* namespace $1 */
+	}
 ##
 ## Input/Output
 # std::cout
@@ -163,7 +213,9 @@ snippet cca
 ## Iteration
 # for i
 snippet fori
-	for (int ${2:i} = 0; $2 < ${1:count}; $2${3:++}) {
+	int $2;
+
+	for (${2:i} = 0; $2 < ${1:count}; $2${3: += 1}) {
 		${4}
 	}
 
@@ -197,7 +249,7 @@ snippet lld
 snippet try
 	try {
 		
-	}catch(${1}) {
+	} catch(${1}) {
 		
 	}
 

--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -108,12 +108,6 @@ snippet mfun
 	}
 # member function implementation without parameters
 snippet mfun0
-	/*! \brief ${4:Brief function description here}
-	 *
-	 *  ${5:Detailed description}
-	 *
-	 * \return ${6:Return parameter description}
-	 */
 	${3:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}()
 	{
 		${0}
@@ -132,13 +126,6 @@ snippet dmfun0
 	}
 # member function implementation with one parameter
 snippet mfun1
-	/*! \brief ${6:Brief function description here}
-	 *
-	 *  ${7:Detailed description}
-	 *
-	 * \param $4 ${8:Parameter description}
-	 * \return ${9:Return parameter description}
-	 */
 	${5:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter})
 	{
 		${0}
@@ -157,15 +144,7 @@ snippet dmfun1
 	}
 # member function implementation with two parameter
 snippet mfun2
-	/*! \brief ${8:Brief function description here}
-	 *
-	 *  ${9:Detailed description}
-	 *
-	 * \param $4 ${10:Parameter description}
-	 * \param $6 ${11:Parameter description}
-	 * \return ${12:Return parameter description}
-	 */
-	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter},${5:Type} ${6:Parameter})
+	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter}, ${5:Type} ${6:Parameter})
 	{
 		${0}
 	}
@@ -179,7 +158,7 @@ snippet dmfun2
 	 * \param $6 ${11:Parameter description}
 	 * \return ${12:Return parameter description}
 	 */
-	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter},${5:Type} ${6:Parameter}) {
+	${7:void} ${1:`vim_snippets#Filename('$1', 'ClassName')`}::${2:memberFunction}(${3:Type} ${4:Parameter}, ${5:Type} ${6:Parameter}) {
 		${0}
 	}
 # namespace


### PR DESCRIPTION
Updates the C/C++ coding styles. As well as separating snippets including documentation and those that don't

Worth taking a look at the `fun3` and `dfun3` commenting fixes for c.snippets. Also worth looking at the `dmfun2` spacing between parameters that was fixed if you don't want to style changes. I noticed there wasn't a space between `catch` and its preceding `{`, for `try` in C++. Don't know if that was intentional.

Hope this helps, otherwise, sorry for wasting your time.

Thanks