### PR TITLE
Latex: Minor Consistency Fixes

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -78,6 +78,14 @@ snippet sec "Section" b
 $0
 endsnippet
 
+snippet sec* "Section" b
+\section*{${1:section name}}
+\label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
+
+${0}
+endsnippet
+
+
 snippet sub "Subsection" b
 \subsection{${1:subsection name}}
 \label{sub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
@@ -85,11 +93,25 @@ snippet sub "Subsection" b
 $0
 endsnippet
 
+snippet sub* "Subsection" b
+\subsection*{${1:subsection name}}
+\label{sub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
+
+${0}
+endsnippet
+
 snippet ssub "Subsubsection" b
 \subsubsection{${1:subsubsection name}}
 \label{ssub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0
+endsnippet
+
+snippet ssub* "Subsubsection" b
+\subsubsection*{${1:subsubsection name}}
+\label{ssub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
+
+${0}
 endsnippet
 
 snippet par "Paragraph" b

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -134,7 +134,7 @@ $0
 endsnippet
 
 snippet pac "Package" b
-\usepackage[${1:options}]{${2:package}}$0
+\usepackage`!p snip.rv='[' if t[1] else ""`${1:options}`!p snip.rv = ']' if t[1] else ""`{${2:package}}$0
 endsnippet
 
 snippet lp "Long parenthesis"

--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -150,13 +150,13 @@ snippet sub* \subsection*
 	${0}
 # Sub Sub Section
 snippet ssub \subsubsection
-	\subsubsection{${1:subsubsection name}}
-	\label{ssub:${2:$1}}
+	\\subsubsection{${1:subsubsection name}}
+	\\label{ssub:${2:$1}}
 	${0}
 # Sub Sub Section without number
 snippet ssub* \subsubsection*
-	\subsubsection*{${1:subsubsection name}}
-	\label{ssub:${2:$1}}
+	\\subsubsection*{${1:subsubsection name}}
+	\\label{ssub:${2:$1}}
 	${0}
 # Paragraph
 snippet par \paragraph

--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -149,14 +149,14 @@ snippet sub* \subsection*
 	\\label{sub:${2:$1}}
 	${0}
 # Sub Sub Section
-snippet subs \subsubsection
-	\\subsubsection{${1:subsubsection name}}
-	\\label{ssub:${2:$1}}
+snippet ssub \subsubsection
+	\subsubsection{${1:subsubsection name}}
+	\label{ssub:${2:$1}}
 	${0}
 # Sub Sub Section without number
-snippet subs* \subsubsection*
-	\\subsubsection*{${1:subsubsection name}}
-	\\label{ssub:${2:$1}}
+snippet ssub* \subsubsection*
+	\subsubsection*{${1:subsubsection name}}
+	\label{ssub:${2:$1}}
 	${0}
 # Paragraph
 snippet par \paragraph


### PR DESCRIPTION
This just makes things more consistent with the other language snippets.

- Makes snippet naming for `\subsubsection*{}` and `\subsubsection{}` consistent between utlisnips and snipmate. 
- Automatically removes square braces from `\usepackage` if no options are supplied, otherwise identical
- Makes un-numbered section, subsection, and subsubsection labels lower case and replaces spaces with underlines in ultisnips.