### PR TITLE
Fix placeholder index for ruby rspec snippets `iexp` and `iexpb`

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -703,9 +703,9 @@ snippet is
 snippet isn
 	it { should_not ${0} }
 snippet iexp
-	it { expect(${1:object}).${1} ${0} }
+	it { expect(${1:object}).${2} ${0} }
 snippet iexpb
-	it { expect { ${1:object} }.${1} ${0} }
+	it { expect { ${1:object} }.${2} ${0} }
 snippet iiexp
 	it { is_expected.to ${0} }
 snippet iiexpn


### PR DESCRIPTION
As the title said.