### PR TITLE
Markdown headlines

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -72,13 +72,13 @@ snippet **
 snippet __
 	__${1:bold}__
 snippet ===
-	`repeat('=', strlen(getline(line(".") - 3)))`
+	`repeat('=', strlen(getline(line('.') - 3)))`
 
 	${0}
 snippet -
 	-   ${0}
 snippet ---
-	`repeat('-', strlen(getline(line(".") - 3)))`
+	`repeat('-', strlen(getline(line('.') - 3)))`
 
 	${0}
 snippet blockquote

--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -72,13 +72,13 @@ snippet **
 snippet __
 	__${1:bold}__
 snippet ===
-	`repeat('=', strlen(getline(line(".") - 1)) - strlen(getline('.')))`
+	`repeat('=', strlen(getline(line(".") - 3)) - strlen(getline(line('.') - 2)))`
 
 	${0}
 snippet -
 	-   ${0}
 snippet ---
-	`repeat('-', strlen(getline(line(".") - 1)) - strlen(getline('.')))`
+	`repeat('-', strlen(getline(line(".") - 3)) - strlen(getline(line('.') - 2)))`
 
 	${0}
 snippet blockquote

--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -81,7 +81,6 @@ snippet ---
 	`repeat('-', strlen(getline(line(".") - 1)) - strlen(getline('.')))`
 
 	${0}
-
 snippet blockquote
 	{% blockquote %}
 	${0:quote}

--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -72,13 +72,13 @@ snippet **
 snippet __
 	__${1:bold}__
 snippet ===
-	`repeat('=', strlen(getline(line(".") - 3)) - strlen(getline(line('.') - 2)))`
+	`repeat('=', strlen(getline(line(".") - 3)))`
 
 	${0}
 snippet -
 	-   ${0}
 snippet ---
-	`repeat('-', strlen(getline(line(".") - 3)) - strlen(getline(line('.') - 2)))`
+	`repeat('-', strlen(getline(line(".") - 3)))`
 
 	${0}
 snippet blockquote


### PR DESCRIPTION
This PR started as an issue, here: SirVer/ultisnips#842.

Let's assume I've opened a markdown file that has the following contents:
```markdown
Some headline
---|
```
Assuming that the `|` character is where the cursor is positioned and I invoke the snippet expansion mapping, then the [`---`-snippet](https://github.com/honza/vim-snippets/blob/2e5f7adc40bc666bad7375357337149f7fe6e6f6/snippets/markdown.snippets#L80-L84) will be invoked and I would expect this result:
```markdown
Some headline
-------------

|

```
What I instead get is this:
```markdown
Some headline


|

```
The line where the dashes should have been entered has been cleared out completely, as if a `dd` was run, but no content was inserted.

### The problem

I'm a user of UltiSnips, and I'm not sure if something changed at some point in the code of that project, but what appears to be happening is the following:

Lets take the [`---`-snippet](https://github.com/honza/vim-snippets/blob/2e5f7adc40bc666bad7375357337149f7fe6e6f6/snippets/markdown.snippets#L80-L84):
```viml
snippet ---
	`repeat('-', strlen(getline(line(".") - 1)) - strlen(getline('.')))`

	${0}

```

The function `line('.')` evaluates to the current position of the cursor. While the snippet hopes that the cursor will be positioned where the `---` was, it's actually two lines further down, where the `${0}` lies.
Assuming we're working on the markdown file written above, `line('.')` will evaluate to `4`, instead of `2`.

This results in `getline()` reading and returning an empty line, and `strlen()` always returning `0`.

I don't know if this behaviour applies to all snippet engines, but it's how UltiSnips works as of [`5352d98f`](https://github.com/SirVer/ultisnips/commit/5352d98f212e273b3e8b1d84efdbe2d6a6d557e9).

### An additional redundancy

The current code also has an additional error that is simply a redundancy. It should be mentioned, however, that this may be something that's once more specific to how UltiSnips works.

Because of the fact that the cursor will be placed where `${0}` lies, this means that `getline('.')` will always return an empty string, meaning that ` - strlen(getline('.'))` will always subtract zero (making it pointless).

What makes this even more redundant is the fact that it seems like the first thing the current version of UltiSnips does is delete the snippet abbreviation (`---` in this case) and only thereafter it evaluates the snippet contents. This means that while the purpose of ` - strlen(getline('.'))` was likely to ensure that however long the headline was it should add three less `-` than that because there are already three present, with the current version of UltiSnips, that line is empty: the `---` are not there. The entire subtraction is redundant.