### PR TITLE
Rust: cleanup and duplicate removal

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -4,25 +4,6 @@
 
 priority -50
 
-snippet let "let variable declaration" b
-let ${1:name}${2:: ${3:type}} = $4;
-endsnippet
-
-snippet letm "let mut variable declaration" b
-let mut ${1:name}${2:: ${3:type}} = $4;
-endsnippet
-
-snippet fn "A function, optionally with arguments and return type."
-fn ${1:function_name}($2)${3/..*/ -> /}$3 {
-	${VISUAL}$0
-}
-endsnippet
-
-snippet pfn "A public function, optionally with arguments and return type."
-pub fn ${1:function_name}($2)${3/..*/ -> /}$3 {
-	${VISUAL}$0
-}
-endsnippet
 
 snippet arg "Function Arguments" i
 ${1:a}: ${2:T}${3:, arg}
@@ -38,18 +19,6 @@ ${1:move }|$2| {
 }
 endsnippet
 
-snippet pri "print!(..)" b
-print!("$1"${2/..*/, /}$2);
-endsnippet
-
-snippet pln "println!(..)" b
-println!("$1"${2/..*/, /}$2);
-endsnippet
-
-snippet fmt "format!(..)"
-format!("$1"${2/..*/, /}$2);
-endsnippet
-
 snippet macro "macro_rules!" b
 macro_rules! ${1:name} {
 	(${2:matcher}) => (
@@ -58,49 +27,8 @@ macro_rules! ${1:name} {
 }
 endsnippet
 
-snippet mod "A module" b
-mod ${1:`!p snip.rv = snip.basename.lower() or "name"`} {
-	${VISUAL}$0
-}
-endsnippet
-
-snippet for "for .. in .." b
-for ${1:i} in $2 {
-	${VISUAL}$0
-}
-endsnippet
-
-snippet todo "A Todo comment"
-// [TODO]: ${1:Description} - `!v strftime("%Y-%m-%d %I:%M%P")`
-endsnippet
-
-snippet st "Struct" b
-struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
-	${VISUAL}$0
-}
-endsnippet
-
-# TODO: fancy dynamic field mirroring like Python slotclass
-snippet stn "Struct with new constructor." b
-pub struct ${1:`!p snip.rv = snip.basename.title() or "Name"`} {
-	fd$0
-}
-
-impl $1 {
-	pub fn new($2) -> $1 {
-		$1 { $3 }
-	}
-}
-endsnippet
-
 snippet fd "Struct field definition" w
 ${1:name}: ${2:Type},
-endsnippet
-
-snippet impl "Struct/Trait implementation" b
-impl ${1:Type/Trait}${2: for ${3:Type}} {
-	$0
-}
 endsnippet
 
 # vim:ft=snippets:

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -39,10 +39,17 @@ snippet letm "let mut variable declaration with type inference"
 	let mut ${1}  = ${2};
 snippet lettm "let mut variable declaration with explicit type annotation"
 	let mut ${1}: ${2}  = ${3};
+snippet pri "print!"
+	print!("${1}");
+snippet pri, "print! with format param"
+	print!("${1}", ${2});
 snippet pln "println!"
 	println!("${1}");
 snippet pln, "println! with format param"
 	println!("${1}", ${2});
+snippet fmt "format!"
+	format!("${1}", ${2});
+
 # Modules
 snippet ec "extern crate"
 	extern crate ${1:sync};


### PR DESCRIPTION
Removes many duplicates and improves consistency, especially with let, letm, lett and lettm as in ultisnips none of them included type inference yet they still had different syntax. 

This is just some initial cleanup, more consistency improvements and consolidation could definitely be done but this should improve things in the meantime. I also might look into using snippets from third-parties in the future, specifically [vscode-rust](https://github.com/editor-rs/vscode-rust/blob/master/snippets/rust.json) has an extensive list.