### PR TITLE
Add exit jump mark for TeX inline text modifiers

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -204,32 +204,32 @@ snippet fcite \footcite[]{}
 	\\footcite[${1}]{${2}}${0}
 #Formating text: italic, bold, underline, small capital, emphase ..
 snippet it italic text
-	\\textit{${0:${VISUAL:text}}}
+	\\textit{${1:${VISUAL:text}}} ${0}
 snippet bf bold face text
-	\\textbf{${0:${VISUAL:text}}}
+	\\textbf{${1:${VISUAL:text}}} ${0}
 snippet under underline text
-	\\underline{${0:${VISUAL:text}}}
+	\\underline{${1:${VISUAL:text}}} ${0}
 snippet emp emphasize text
-	\\emph{${0:${VISUAL:text}}}
+	\\emph{${1:${VISUAL:text}}} ${0}
 snippet sc small caps text
-	\\textsc{${0:${VISUAL:text}}}
+	\\textsc{${1:${VISUAL:text}}} ${0}
 #Choosing font
 snippet sf sans serife text
-	\\textsf{${0:${VISUAL:text}}}
+	\\textsf{${1:${VISUAL:text}}} ${0}
 snippet rm roman font text
-	\\textrm{${0:${VISUAL:text}}}
+	\\textrm{${1:${VISUAL:text}}} ${0}
 snippet tt typewriter (monospace) text
-	\\texttt{${0:${VISUAL:text}}}
+	\\texttt{${1:${VISUAL:text}}} ${0}
 #Math font
 snippet mf mathfrak
-	\\mathfrak{${0:${VISUAL:text}}}
+	\\mathfrak{${1:${VISUAL:text}}} ${0}
 snippet mc mathcal
-	\\mathcal{${0:${VISUAL:text}}}
+	\\mathcal{${1:${VISUAL:text}}} ${0}
 snippet ms mathscr
-	\\mathscr{${0:${VISUAL:text}}}
+	\\mathscr{${1:${VISUAL:text}}} ${0}
 #misc
 snippet ft \footnote
-	\\footnote{${0:${VISUAL:text}}}
+	\\footnote{${1:${VISUAL:text}}} ${0}
 snippet fig figure environment (includegraphics)
 	\\begin{figure}
 	\\begin{center}


### PR DESCRIPTION
This was already the case for other inline commands like \cite but not for the text modifiers and `footnote`. It quite interrupts the writing flow being stuck in the curly braces.