### PR TITLE
Remove extra whitespaces in rust.snippets

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -34,11 +34,11 @@ snippet main "Main function"
 snippet let "let variable declaration with type inference"
 	let ${1} = ${2};
 snippet lett "let variable declaration with explicit type annotation"
-	let ${1}: ${2}  = ${3};
+	let ${1}: ${2} = ${3};
 snippet letm "let mut variable declaration with type inference"
-	let mut ${1}  = ${2};
+	let mut ${1} = ${2};
 snippet lettm "let mut variable declaration with explicit type annotation"
-	let mut ${1}: ${2}  = ${3};
+	let mut ${1}: ${2} = ${3};
 snippet pri "print!"
 	print!("${1}");
 snippet pri, "print! with format param"


### PR DESCRIPTION
These spaces are unnecessary, aren't they?