### PR TITLE
added function vim_snippets#FilenameWithExt

### DIFF
--- a/autoload/vim_snippets.vim
+++ b/autoload/vim_snippets.vim
@@ -19,6 +19,24 @@ fun! vim_snippets#Filename(...)
   endif
 endf
 
+" optional arg1: string in which to replace '$1' by filename with extension
+"   and path dropped. Defaults to $1
+" optional arg2: return this value if buffer has no filename
+"  But why not use the template in this case, too?
+"  Doesn't make sense to me
+fun! vim_snippets#FilenameWithExt(...)
+  let template = get(a:000, 0, "$1")
+  let arg2 = get(a:000, 1, "")
+
+  let basename = expand('%:t')
+
+  if basename == ''
+    return arg2
+  else
+    return substitute(template, '$1', basename, 'g')
+  endif
+endf
+
 " original code:
 " fun! Filename(...)
 "     let filename = expand('%:t:r')

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -1,3 +1,26 @@
+# GPL3 license
+snippet gpl3
+	/*
+	 * @file: `vim_snippets#FilenameWithExt('$1', 'name')`
+	 * `g:snips_program_description`
+	 * Copyright `&enc[:3] == "utf" ? "©" : "(c)"` `strftime("%Y")` `g:snips_author` <`g:snips_email`>
+	 *
+	 * This program is free software: you can redistribute it and/or modify
+	 * it under the terms of the GNU General Public License as published by
+	 * the Free Software Foundation, either version 3 of the License, or
+	 * (at your option) any later version.
+	 *
+	 * This program is distributed in the hope that it will be useful,
+	 * but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 * GNU General Public License for more details.
+	 *
+	 * You should have received a copy of the GNU General Public License
+	 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	 */
+	 
+	${0}
+
 ## Main
 # main
 snippet main


### PR DESCRIPTION
This function may be needed in snippets using the file name. For example, in the license header or doxygen \file parameter.