### PR TITLE
pdbpp is a drop-in replacement of pdb, use it importing pdb

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -142,10 +142,6 @@ snippet ipdb
 snippet iem
 	import IPython
 	IPython.embed()
-# ipython debugger (pdbbb)
-snippet pdbbb
-	import pdbpp
-	pdbpp.set_trace()
 # remote python debugger (rpdb)
 snippet rpdb
 	import rpdb


### PR DESCRIPTION
also:
- it's `pdbpp` not `pdbbb`
- it's not part of `ipython`

:}