### PR TITLE
Plugin snippet split into author and plugin part.

### DIFF
--- a/snippets/vim.snippets
+++ b/snippets/vim.snippets
@@ -47,6 +47,6 @@ snippet au augroup ... autocmd block
 		autocmd ${2:BufRead,BufNewFile} ${3:*.ext,*.ext3|<buffer[=N]>} ${0}
 	augroup end
 snippet bun Vundle.vim Plugin definition
-	Plugin '${0}'
+	Plugin '${1:author}/${2:plugin}'
 snippet plug Vundle.vim Plugin definition
-	Plugin '${0}'
+	Plugin '${1:author}/${2:plugin}'


### PR DESCRIPTION
I've been using these two snippets for quite some time now and thought I'll share them finally.
I understand that the `Plugin` command is an integral part of the snippets system but don't see these changes throwing off people's habits too badly.