### PR TITLE
Blade UltiSnips: make echo statements trigger also just after a non-whitespace c…

### DIFF
--- a/UltiSnips/blade.snippets
+++ b/UltiSnips/blade.snippets
@@ -124,11 +124,11 @@ snippet yield "@yield directive"
 @yield('$1')
 endsnippet
 
-snippet { "{{ }} statement."
+snippet { "{{ }} statement." i
 {{ $1 }}
 endsnippet
 
-snippet {! "{!! !!} statement"
+snippet {! "{!! !!} statement" i
 {!! $1 !!}
 endsnippet
 


### PR DESCRIPTION
…haracter

It is very inconvenient if you want to trigger an echo snippet inside an HTML tag (e.g. `<h1>{{  }}</h1>`). This commit solves that