### PR TITLE
update PropTypes import in react snippets

### DIFF
--- a/snippets/javascript.es6.react.snippets
+++ b/snippets/javascript.es6.react.snippets
@@ -4,7 +4,8 @@ snippet ri1
 
 # Import both React and Component
 snippet ri2
-	import React, { Component, PropTypes } from 'react'
+	import React, { Component } from 'react'
+	import PropTypes from 'prop-types'
 
 # React class
 snippet rcla


### PR DESCRIPTION
Since react 15.05, PropTypes belongs to the `prop-types` package.