### PR TITLE
Add missing semicolons after assert macros in rust.snippets

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -188,6 +188,6 @@ snippet chan "Declare (Sender, Receiver) pair of asynchronous channel()"
 	let (${1:tx}, ${2:rx}): (Sender<${3:i32}>, Receiver<${4:i32}>) = channel();
 # Testing
 snippet as "assert!"
-	assert!(${1:predicate})
+	assert!(${1:predicate});
 snippet ase "assert_eq!"
-	assert_eq!(${1:expected}, ${2:actual})
+	assert_eq!(${1:expected}, ${2:actual});


### PR DESCRIPTION
Add semicolons at the end of `assert!` and `assert_eq!`.