### PR TITLE
GO: Json marshalable object

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -242,5 +242,13 @@ snippet gg
 	var ${1:var} = struct{
 		${2:name} ${3:type}
 	}{
-		${2:name}: ${4:value},
+		$2: ${4:value},
+	}
+
+# Marshalable json alias
+snippet ja
+	type ${1:parentType}Alias $1
+
+	func (p *$1) MarshalJSON() ([]byte, error) {
+		return json.Marshal(&struct{ *$1Alias }{(*$1Alias)(p)})
 	}


### PR DESCRIPTION
To avoid infinity recursion when MarshalJSON method is defined required
to declare an alias type to wrap an original struct.