### PR TITLE
added `pirv` and `prot` to UltiSnips snippet

### DIFF
--- a/UltiSnips/ruby.snippets
+++ b/UltiSnips/ruby.snippets
@@ -302,7 +302,7 @@ endsnippet
 snippet "\b(case|sw(itch)?)" "case <variable> when <expression> ... end" r
 case ${1:variable}
 when ${2:expression}
-$0
+  $0
 end
 endsnippet
 
@@ -324,6 +324,18 @@ snippet ###
 =begin
 	$0
 =end
+endsnippet
+
+snippet priv "private " m
+private
+
+$0
+endsnippet
+
+snippet prot "protected" m
+protected
+
+$0
 endsnippet
 
 # vim: set ts=2 sw=2 expandtab:


### PR DESCRIPTION
* Added `priv` and `prot` snippet in UltiSnips. Without this, it triggers the `snippets/ruby.snippets`; but this will add indentation/extra whitespace, in the empty line below the `private` keyword and before cursor position.

  Actual:
  ```ruby
  private
  _ _
  |
  ```
   Expected:
  ```ruby
  private

  |
  ```
* Also, indented cursor one level deep after `when` in `case` statement snippet.