### PR TITLE
it snippet no longer insert tabs and newlines

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -59,8 +59,7 @@ snippet desc "Description" b
 endsnippet
 
 snippet it "Individual item" b
-\item $1
-$0
+\item $0
 endsnippet
 
 snippet part "Part" b


### PR DESCRIPTION
The actual it behavior inserts tabs and newlines after the \item.
It becomes an hassle when performing multiple \items, forcing to delete _n_ lines and _n_ tabs, _n_ being the number of created items.

The proposed behavior intends to fix this.