### PR TITLE
Remove trailing space after export default { }

### DIFF
--- a/snippets/vue.snippets
+++ b/snippets/vue.snippets
@@ -29,7 +29,7 @@ snippet vbase
 	<script>
 		export default{
 
-		}	
+		}
 	</script>
 	<style scoped>
 


### PR DESCRIPTION
Vue-CLI default linting rules complain about trailing spaces, removed.