### PR TITLE
p to pipe operator snippet for elixir

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -184,7 +184,7 @@ snippet beh
 	@behaviour ${1:Mix.Task}
 	${0}
 snippet p
-	|>
+	|> ${0}
 snippet >e pipe to each
 	|> Enum.each(fn ${1} -> ${0} end)
 snippet >m pipe to map

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -183,6 +183,8 @@ snippet qu
 snippet beh
 	@behaviour ${1:Mix.Task}
 	${0}
+snippet p
+	|>
 snippet >e pipe to each
 	|> Enum.each(fn ${1} -> ${0} end)
 snippet >m pipe to map


### PR DESCRIPTION
I noticed there was a missing snippet simply for `|>` for elixir which is used frequently.
This has prevented me from repositioning my hand every time I wanted to input a pipe operator.