### PR TITLE
Adding set comprehension

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -709,3 +709,4 @@ snippet pmdoc "pocoo style module doc string" b
 $0
 endsnippet
 
+# vim:ft=snippets:

--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -709,4 +709,16 @@ snippet pmdoc "pocoo style module doc string" b
 $0
 endsnippet
 
+##################
+# Comprehensions #
+##################
+
+snippet lcp "list comprehension"
+[$1 for $2 in ${3:${VISUAL}}]$0
+endsnippet
+
+snippet dcp "dict comprehension"
+{$1: $2 for $3 in ${4:${VISUAL}}}$0
+endsnippet
+
 # vim:ft=snippets:

--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -709,16 +709,3 @@ snippet pmdoc "pocoo style module doc string" b
 $0
 endsnippet
 
-##################
-# Comprehensions #
-##################
-
-snippet lcp "list comprehension"
-[$1 for $2 in ${3:${VISUAL}}]$0
-endsnippet
-
-snippet dcp "dict comprehension"
-{$1: $2 for $3 in ${4:${VISUAL}}}$0
-endsnippet
-
-# vim:ft=snippets:

--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -252,3 +252,6 @@ snippet lcp list comprehension
 
 snippet dcp dict comprehension
 	{${1}: ${2} for ${3} in ${4:${VISUAL}}}${0}
+
+snippet scp set comprehension
+	{${1} for ${2} in ${3:${VISUAL}}}${0}

--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -245,3 +245,10 @@ snippet kwargs
 	**kwargs${1:,}${0}
 snippet akw
 	*args, **kwargs${1:,}${0}
+
+# comprehensions
+snippet lcp list comprehension
+	[${1} for ${2} in ${3:${VISUAL}}]${0}
+
+snippet dcp dict comprehension
+	{${1}: ${2} for ${3} in ${4:${VISUAL}}}${0}


### PR DESCRIPTION
Forgot that this was possible, so this is more of an addendum to #975.

```
🤔 ~/c/p/vim-snippets (2a84212)|py-comprehensions✓
± [i]: python -c "print {j for j in xrange(10)}"
set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
```