### PR TITLE
python: make pdb (alike) snippets oneliners

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -142,43 +142,33 @@ snippet _
 	__${1:init}__
 # python debugger (pdb)
 snippet pdb
-	import pdb
-	pdb.set_trace()
+	__import__('pdb').set_trace()
 # bpython debugger (bpdb)
 snippet bpdb
-	import bpdb
-	bpdb.set_trace()
+	__import__('bpdb').set_trace()
 # ipython debugger (ipdb)
 snippet ipdb
-	import ipdb
-	ipdb.set_trace()
+	__import__('ipdb').set_trace()
 # embed ipython itself
 snippet iem
-	import IPython
-	IPython.embed()
+	__import__('IPython').embed()
 # remote python debugger (rpdb)
 snippet rpdb
-	import rpdb
-	rpdb.set_trace()
+	__import__('rpdb').set_trace()
 # web python debugger (wdb)
 snippet wdb
-	import wdb
-	wdb.set_trace()
+	__import__('wdb').set_trace()
 # ptpython
 snippet ptpython
-	from ptpython.repl import embed
-	embed(globals(), locals(), vi_mode=${1:False}, history_filename=${2:None})
+	__import__('ptpython.repl', fromlist=('repl')).embed(globals(), locals(), vi_mode=${1:False}, history_filename=${2:None})
 # python console debugger (pudb)
 snippet pudb
-	import pudb
-	pudb.set_trace()
+	__import__('pudb').set_trace()
 # pdb in nosetests
 snippet nosetrace
-	from nose.tools import set_trace
-	set_trace()
+	__import__('nose').tools.set_trace()
 snippet pprint
-	import pprint
-	pprint.pprint(${1})
+	__import__('pprint').pprint(${1})
 snippet "
 	"""${0:doc}
 	"""


### PR DESCRIPTION
This allows for them to be used in a lambda, and avoids warnings like
"module import not at the beginning of file" etc from linters.

It also makes it easier to remove, and the `__import__` makes it stand
out even more (when you deal with multiple `set_trace` instances).