### PR TITLE
Update Dart snippets to 1.0.0 syntax

### DIFF
--- a/snippets/dart.snippets
+++ b/snippets/dart.snippets
@@ -2,8 +2,8 @@ snippet lib
 	library ${1};
 	${0}
 snippet im
-	import 'package:${0}/${0}.dart';
-	${1}
+	import 'package:${1}/${2}.dart';
+	${0}
 snippet main
 	main() {
 	  ${0}

--- a/snippets/dart.snippets
+++ b/snippets/dart.snippets
@@ -2,8 +2,8 @@ snippet lib
 	library ${1};
 	${0}
 snippet im
-	import 'package:${1}/${1}.dart';
-	${0}
+	import 'package:${0}/${0}.dart';
+	${1}
 snippet main
 	main() {
 	  ${0}

--- a/snippets/dart.snippets
+++ b/snippets/dart.snippets
@@ -1,14 +1,11 @@
 snippet lib
-	#library('${1}');
+	library ${1};
 	${0}
 snippet im
-	#import('${1}');
-	${0}
-snippet so
-	#source('${1}');
+	import ${1};
 	${0}
 snippet main
-	static void main() {
+	main() {
 	  ${0}
 	}
 snippet st

--- a/snippets/dart.snippets
+++ b/snippets/dart.snippets
@@ -2,7 +2,7 @@ snippet lib
 	library ${1};
 	${0}
 snippet im
-	import ${1};
+	import 'package:${1}/${1}.dart';
 	${0}
 snippet main
 	main() {

--- a/snippets/dart.snippets
+++ b/snippets/dart.snippets
@@ -4,6 +4,10 @@ snippet lib
 snippet im
 	import 'package:${1}/${2}.dart';
 	${0}
+snippet rgx
+	new RegExp(r'${1}')
+snippet var
+	var ${1} = ${2};
 snippet main
 	main() {
 	  ${0}


### PR DESCRIPTION
Since Dart 1.0.0, the syntax of some constructs have changed; this should fix them.