### PR TITLE
remove extra indent from UltiSnips html.snippets

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -258,31 +258,31 @@ snippet hr "<hr>"
 endsnippet
 
 snippet html "HTML basic structure" b
-	<!DOCTYPE html>
-	<html>
-		<head>
-			<meta charset="UTF-8" />
-			<meta name="viewport" content="width=device-width" />
-			<title>${1:`!p snip.rv = snip.basename.replace('-', ' ').capitalize()`}</title>
-		</head>
-		<body>
-			${0:body}
-		</body>
-	</html>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>${1:`!p snip.rv = snip.basename.replace('-', ' ').capitalize()`}</title>
+	</head>
+	<body>
+		${0:body}
+	</body>
+</html>
 endsnippet
 
 snippet htmll "HTML basic structure with the lang attribute" b
-	<!DOCTYPE html>
-	<html lang="${1:es}">
-		<head>
-			<meta charset="UTF-8" />
-			<meta name="viewport" content="width=device-width" />
-			<title>${2:`!p snip.rv = snip.basename.replace('-', ' ').capitalize()`}</title>
-		</head>
-		<body>
-			${0:body}
-		</body>
-	</html>
+<!DOCTYPE html>
+<html lang="${1:es}">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width" />
+		<title>${2:`!p snip.rv = snip.basename.replace('-', ' ').capitalize()`}</title>
+	</head>
+	<body>
+		${0:body}
+	</body>
+</html>
 endsnippet
 
 snippet i "<i>" w


### PR DESCRIPTION
In the UltiSnips html.snippets, the `html` and `htmll` snippets begin with a tab on each line, which leads to the entire HTML document having (to my eyes) an extra level of indentation.  There may be a reason for this that I'm not seeing, but I prefer to not have the tab and thought I'd send in a PR for this change.  Thanks for the awesome snippet engine!