### PR TITLE
robot: fix Set Variable keyword

### DIFF
--- a/UltiSnips/robot.snippets
+++ b/UltiSnips/robot.snippets
@@ -122,7 +122,7 @@ Set Test Variable    \${${1:name}}    ${2:${value}}
 endsnippet
 
 snippet sv "Set Variable"
-Set Variable    \${${1:name}}    ${2:${value}}
+\${${1:name}}=    Set Variable    ${2:${value}}
 endsnippet
 
 snippet svi "Set Variable If"


### PR DESCRIPTION
The syntax of `Set Variable` is slightly different from `Set Global Variable`, `Set Test Variable`, and `Set Suite Variable`.