### PR TITLE
Remove annoying spaces within <span>

### DIFF
--- a/UltiSnips/html.snippets
+++ b/UltiSnips/html.snippets
@@ -432,15 +432,15 @@ snippet small "<small>" w
 endsnippet
 
 snippet span "<span>" w
-<span> ${0:${VISUAL}} </span>
+<span>${0:${VISUAL}}</span>
 endsnippet
 
 snippet span# "<span> with ID & class" w
-<span`!p snip.rv=' id="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""``!p snip.rv=' class="' if t[2] else ""`${2:name}`!p snip.rv = '"' if t[2] else ""`> ${0:${VISUAL}} </span>
+<span`!p snip.rv=' id="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""``!p snip.rv=' class="' if t[2] else ""`${2:name}`!p snip.rv = '"' if t[2] else ""`>${0:${VISUAL}}</span>
 endsnippet
 
 snippet span. "<span> with class" w
-<span`!p snip.rv=' class="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""`> ${0:${VISUAL}} </span>
+<span`!p snip.rv=' class="' if t[1] else ""`${1:name}`!p snip.rv = '"' if t[1] else ""`>${0:${VISUAL}}</span>
 endsnippet
 
 snippet strong "<strong>" w


### PR DESCRIPTION
For some reason, the `span` snippets in `UltiSnips/html.snippets` contain these unnecessary spaces around the inner content. This is inconsistent with all the other inline tags - and also with the `span` snippets in `snippets/html.snippets`. This patch removes those spaces.