### PR TITLE
Fix collision for <img> tag in html and html_minimal.

### DIFF
--- a/UltiSnips/html_minimal.snippets
+++ b/UltiSnips/html_minimal.snippets
@@ -1,7 +1,7 @@
 # more can be found in snippets/html_minimal.snippets
 # these UltiSnips override snippets because nested placeholders are being used
 
-priority -50
+priority -49
 
 snippet id
 id="$1"$2


### PR DESCRIPTION
The snippet for the `<img>` tag is provided twice. This leads to me having to chose between them each time I use it in my setup.

I'm using UltiSnips and Deoplete and I get the following prompt when completing `<img>`:
`Type number and <Enter> or click with mouse (empty cancels): 30`

This patch fixes the problem by increasing the priority of html_minimal.