### PR TITLE
Comment out the EOL in LaTeX section-like commands.

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -119,53 +119,53 @@ snippet spl split environment
 	\\end{split}
 # Part
 snippet part document \part
-	\\part{${1:part name}} % (fold)
+	\\part{${1:part name}} % (fold)%
 	\\label{prt:${2:$1}}
 	${0}
 	% part $2 (end)
 # Chapter
 snippet cha \chapter
-	\\chapter{${1:chapter name}}
+	\\chapter{${1:chapter name}}%
 	\\label{cha:${2:$1}}
 	${0}
 # Section
 snippet sec \section
-	\\section{${1:section name}}
+	\\section{${1:section name}}%
 	\\label{sec:${2:$1}}
 	${0}
 # Section without number
 snippet sec* \section*
-	\\section*{${1:section name}}
+	\\section*{${1:section name}}%
 	\\label{sec:${2:$1}}
 	${0}
 # Sub Section
 snippet sub \subsection
-	\\subsection{${1:subsection name}}
+	\\subsection{${1:subsection name}}%
 	\\label{sub:${2:$1}}
 	${0}
 # Sub Section without number
 snippet sub* \subsection*
-	\\subsection*{${1:subsection name}}
+	\\subsection*{${1:subsection name}}%
 	\\label{sub:${2:$1}}
 	${0}
 # Sub Sub Section
 snippet ssub \subsubsection
-	\\subsubsection{${1:subsubsection name}}
+	\\subsubsection{${1:subsubsection name}}%
 	\\label{ssub:${2:$1}}
 	${0}
 # Sub Sub Section without number
 snippet ssub* \subsubsection*
-	\\subsubsection*{${1:subsubsection name}}
+	\\subsubsection*{${1:subsubsection name}}%
 	\\label{ssub:${2:$1}}
 	${0}
 # Paragraph
 snippet par \paragraph
-	\\paragraph{${1:paragraph name}}
+	\\paragraph{${1:paragraph name}}%
 	\\label{par:${2:$1}}
 	${0}
 # Sub Paragraph
 snippet subp \subparagraph
-	\\subparagraph{${1:subparagraph name}}
+	\\subparagraph{${1:subparagraph name}}%
 	\\label{subp:${2:$1}}
 	${0}
 snippet ni \noindent


### PR DESCRIPTION
In very rare circumstances, those newlines may lead to mismatched
labels.

`chktex` for example doesn't like this either:

```
ChkTeX v1.7.6 - Copyright 1995-96 Jens T. Berger Thielemann.
Compiled with POSIX extended regex support.
Warning 24 in main.tex line 21: Delete this space to maintain correct pagereferences.
\label{sec:introduction}  
^
No errors printed; One warning printed; No user suppressed warnings; No line suppressed warnings.
See the manual for how to suppress some or all of these warnings/errors.
```