### PR TITLE
Rust: Improve pri, pln, and fmt

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -42,13 +42,13 @@ snippet lettm "let mut variable declaration with explicit type annotation"
 snippet pri "print!"
 	print!("${1}");
 snippet pri, "print! with format param"
-	print!("{${1}}", ${2});
+	print!("${1}{${2}}", ${3});
 snippet pln "println!"
 	println!("${1}");
 snippet pln, "println! with format param"
-	println!("{${1}}", ${2});
+	println!("${1}{${2}}", ${3});
 snippet fmt "format!"
-	format!("{${1}}", ${2});
+	format!("${1}{${2}}", ${3});
 
 # Modules
 snippet ec "extern crate"

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -42,13 +42,13 @@ snippet lettm "let mut variable declaration with explicit type annotation"
 snippet pri "print!"
 	print!("${1}");
 snippet pri, "print! with format param"
-	print!("${1}", ${2});
+	print!("{${1}}", ${2});
 snippet pln "println!"
 	println!("${1}");
 snippet pln, "println! with format param"
-	println!("${1}", ${2});
+	println!("{${1}}", ${2});
 snippet fmt "format!"
-	format!("${1}", ${2});
+	format!("{${1}}", ${2});
 
 # Modules
 snippet ec "extern crate"


### PR DESCRIPTION
Using the snippets with format args pretty much always means that the
user wants to use the format args using `{}` or `{:?}`, so it makes sense
to include at least the `{}` in the snippet.

See: https://doc.rust-lang.org/std/fmt/