### PR TITLE
[LaTeX] Escape the newline after sectioning snippets

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -113,28 +113,28 @@ snippet it "Individual item" b
 endsnippet
 
 snippet part "Part" b
-\part{${1:part name}}
+\part{${1:part name}}%
 \label{prt:${2:${1/(\w+)|\W+/(?1:\L$0\E:_)/ga}}}
 
 $0
 endsnippet
 
 snippet cha "Chapter" b
-\chapter{${1:chapter name}}
+\chapter{${1:chapter name}}%
 \label{cha:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0
 endsnippet
 
 snippet sec "Section" b
-\section{${1:section name}}
+\section{${1:section name}}%
 \label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0
 endsnippet
 
 snippet sec* "Section" b
-\section*{${1:section name}}
+\section*{${1:section name}}%
 \label{sec:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 ${0}
@@ -142,42 +142,42 @@ endsnippet
 
 
 snippet sub "Subsection" b
-\subsection{${1:subsection name}}
+\subsection{${1:subsection name}}%
 \label{sub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0
 endsnippet
 
 snippet sub* "Subsection" b
-\subsection*{${1:subsection name}}
+\subsection*{${1:subsection name}}%
 \label{sub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 ${0}
 endsnippet
 
 snippet ssub "Subsubsection" b
-\subsubsection{${1:subsubsection name}}
+\subsubsection{${1:subsubsection name}}%
 \label{ssub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0
 endsnippet
 
 snippet ssub* "Subsubsection" b
-\subsubsection*{${1:subsubsection name}}
+\subsubsection*{${1:subsubsection name}}%
 \label{ssub:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 ${0}
 endsnippet
 
 snippet par "Paragraph" b
-\paragraph{${1:paragraph name}}
+\paragraph{${1:paragraph name}}%
 \label{par:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0
 endsnippet
 
 snippet subp "Subparagraph" b
-\subparagraph{${1:subparagraph name}}
+\subparagraph{${1:subparagraph name}}%
 \label{par:${2:${1/\\\w+\{(.*?)\}|\\(.)|(\w+)|([^\w\\]+)/(?4:_:\L$1$2$3\E)/ga}}}
 
 $0


### PR DESCRIPTION
A comment marker escapes the newline after a sectioning command like `\chapter`. This way the `\label` command follows the sectioning command immediately as far as LaTeX is concerned, avoiding possible problems with page references. A warning about the newline was issued by the
chktex linter:

    Delete this space to maintain correct pagereferences.