### PR TITLE
Rename identically named `try` snippets in python.snippets

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -115,21 +115,21 @@ snippet try Try/Except
 		${1:${VISUAL}}
 	except ${2:Exception} as ${3:e}:
 		${0:raise $3}
-snippet try Try/Except/Else
+snippet trye Try/Except/Else
 	try:
 		${1:${VISUAL}}
 	except ${2:Exception} as ${3:e}:
 		${4:raise $3}
 	else:
 		${0}
-snippet try Try/Except/Finally
+snippet tryf Try/Except/Finally
 	try:
 		${1:${VISUAL}}
 	except ${2:Exception} as ${3:e}:
 		${4:raise $3}
 	finally:
 		${0}
-snippet try Try/Except/Else/Finally
+snippet tryef Try/Except/Else/Finally
 	try:
 		${1:${VISUAL}}
 	except ${2:Exception} as ${3:e}:


### PR DESCRIPTION
I renamed 3 of the 4 `try` snippets in accordance to how they are named in Ultisnips.

This fixed #1026 for me.