### PR TITLE
JavaScript snippets - React Component and getElementsByClassName

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -68,7 +68,7 @@ ${1:var }${2:function_name} = function $2`!p snip.rv = space_before_function_par
 }`!p snip.rv = semi(snip)`
 endsnippet
 
-snippet af "Anonymous Function" i
+snippet anf "Anonymous Function" i
 function`!p snip.rv = space_before_function_paren(snip)`($1) {
 	${VISUAL}$0
 }

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -26,7 +26,7 @@ endglobal
 #                            TextMate Snippets                            #
 ###########################################################################
 snippet get "Get Elements"
-getElement${1/(T)|.*/(?1:s)/}By${1:T}${1/(T)|(I)|.*/(?1:agName)(?2:d)/}('$2')
+getElement${1/(T)|(C)|.*/(?1:s)(?2:s)/}By${1:T}${1/(T)|(I)|(C).*/(?1:agName)(?2:d)(?3:lassName)/}('$2')
 endsnippet
 
 snippet '':f "object method string"

--- a/snippets/javascript/javascript-react.snippets
+++ b/snippets/javascript/javascript-react.snippets
@@ -1,5 +1,7 @@
 snippet ir
 	import React from 'react';
+snippet irc
+	import React, {Component} from 'react';
 snippet ird
 	import ReactDOM from 'react-dom';
 snippet cdm

--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -10,7 +10,7 @@ snippet fun
 		${0:${VISUAL}}
 	}
 # Anonymous Function
-snippet f "" w
+snippet anf "" w
 	function(${1}) {
 		${0:${VISUAL}}
 	}


### PR DESCRIPTION
modified the 'get' snippet for UltiSnip to accept "C" as an option for `getElementsByClassName` and added 'irc' to directly import the Component class from React. hope you find them useful!

also renamed the anonymous function snippets to avoid conflicts with the ES6 arrow function snippets.