### PR TITLE
Add a go snippet for HTTP handler methods

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -133,6 +133,11 @@ snippet fum
 		${6}
 	}
 	${0}
+# http handler function on reciever
+snippet fumh
+	func (${1:receiver} ${2:type}) ${3:funcName}(${4:w} http.ResponseWriter, ${5:r} *http.Request) {
+		${0:${VISUAL}}
+	}
 # log printf
 snippet lf
 	log.Printf("%${1:s}", ${2:var})


### PR DESCRIPTION
Following the pattern of the existing `func`/`funch` snippets, this
commit adds a `fumh` snippet to go along with `fum`.

Note: `UltiSnips/go.snippet` provides the `func` & `funch` snippets, while `snippets/go.snippet` provides the `fum` snippet that this `fumh` pairs with. I wasn't quite sure where this should live, but decided on `snippets/go.snippet`. Let me know if it should live in `UltiSnips/` instead.
