### PR TITLE
fixed quotes on html 5 video snippet

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -873,6 +873,8 @@ snippet var
 	<var>${0}</var>
 snippet video
 	<video src="${1}" height="${2}" width="${3}" preload="${5:none}" autoplay="${6:autoplay}">${7}</video>
+snippet video.
+	<video class="${1}" src="${2}" height="${3}" width="${4}" preload="${6:none}" autoplay="${7:autoplay}">${8}</video>
 snippet wbr
 	<wbr />
 snippet viewport

--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -872,9 +872,9 @@ snippet ul+
 snippet var
 	<var>${0}</var>
 snippet video
-	<video src="${1}" height="${2}" width="${3}" preload="${5:none}" autoplay="${6:autoplay}">${7}</video>
+	<video src="${1}" height="${2}" width="${3}" preload="${4:none}" autoplay="${5:autoplay}">${6}</video>
 snippet video.
-	<video class="${1}" src="${2}" height="${3}" width="${4}" preload="${6:none}" autoplay="${7:autoplay}">${8}</video>
+	<video class="${1}" src="${2}" height="${3}" width="${4}" preload="${5:none}" autoplay="${6:autoplay}">${7}</video>
 snippet wbr
 	<wbr />
 snippet viewport

--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -872,7 +872,7 @@ snippet ul+
 snippet var
 	<var>${0}</var>
 snippet video
-	<video src="${1} height="${2}" width="${3}" preload="${5:none}" autoplay="${6:autoplay}>${7}</video>
+	<video src="${1}" height="${2}" width="${3}" preload="${5:none}" autoplay="${6:autoplay}">${7}</video>
 snippet wbr
 	<wbr />
 snippet viewport


### PR DESCRIPTION
Fixed mismatched quotes on html video element snippet, and threw in a video with class snippet for good measure. Referenced in: https://github.com/honza/vim-snippets/issues/1034
Cheers!