### PR TITLE
Respect optional typehints in PHP Constructors

### DIFF
--- a/UltiSnips/php.snippets
+++ b/UltiSnips/php.snippets
@@ -224,10 +224,10 @@ endsnippet
 
 snippet construct "__construct()" b
 /**
- * @param $2mixed ${1/, /\n     * \@param mixed /g}
+ * @param$2 ${1/, /\n     * \@param /g}
  */
 public function __construct(${1:$dependencies})
-{${1/\$(\w+)(, )*/\n        $this->$1 = $$1;/g}
+{${1/\w* ?\$(\w+)(, )*/\n        $this->$1 = $$1;/g}
 }
 $0
 endsnippet


### PR DESCRIPTION
In modern php, almost all constructor dependencies will have a type
hint, which should be copied over in the PHPDoc and omitted in the
implementation.

This change will handle both cases with a typehint and without a
typehint gracefully.

---

Fixes #830 

---

Preview of new behaviour: <https://www.dropbox.com/s/71fyxfh5ti5wflz/typehints.mov>