### PR TITLE
Elixir snippets

### DIFF
--- a/UltiSnips/elixir.sinppets
+++ b/UltiSnips/elixir.sinppets
@@ -1,0 +1,81 @@
+global !p
+import os
+
+def log(*a, **k):
+    with open(os.path.expanduser("~/Desktop/log.txt"), 'w') as f:
+        print(*a, **k, file=f)
+
+
+def write_spec(t, snip):
+    snip.rv += "@spec {0}({1}) :: TODO".format(
+        t[1],
+        ", ".join("{0}::TODO".format(arg.strip()) for arg in t[2].split(',')))
+
+
+def write_type_fields(t, snip):
+    fields = [field.split(':')[0].strip() for field in t[1].split(',')]
+    maxlength = max(len(field) for field in fields)
+
+    snip.rv += "\n{}".format(snip.indent).join(
+        "{0}{1}: {2}{3}TODO_TYPE,".format(
+            snip._initial_indent,
+            field,
+            snip._ind.shiftwidth * ' ',
+            ' ' * (maxlength - len(field)))
+        for field in fields)
+
+
+def write_typedoc_fields(t, snip):
+    log("'{}', '{}'".format(snip._initial_indent, snip.indent))
+    log(snip.__dict__)
+    fields = [field.split(':')[0].strip() for field in t[1].split(',')]
+    maxlength = max(len(field) for field in fields)
+
+    snip.rv += "\n{}".format(snip.indent).join(
+        "{0}- {1}: {2}{3}TODO_DESCRIPTION".format(
+            snip._initial_indent, 
+            field,
+            snip._ind.shiftwidth * ' ',
+            ' ' * (maxlength - len(field)))
+        for field in fields)
+
+endglobal
+
+
+snippet def "Function with docstring and typespecs"
+@doc ~S"""
+${3:One-line summary}
+"""
+`!p write_spec(t, snip)`
+def ${1:function_name}(${2:arg1}) do
+  ${4:body}
+end
+endsnippet
+
+
+snippet defm "Module with doc"
+defmodule ${1:module_name} do
+  @moduledoc ~S"""
+  ${2:One-line summary}
+  """
+  ${3:body}
+end
+endsnippet
+
+
+snippet defs "Struct with typespec"
+defstruct [
+  ${1:field1}
+]
+
+@typedoc ~S"""
+${2:Type summary}
+
+Fields:
+`!p write_typedoc_fields(t, snip)`
+"""
+
+type t :: %__MODULE__{
+`!p write_type_fields(t, snip)`
+}
+endsnippet

--- a/UltiSnips/elixir.sinppets
+++ b/UltiSnips/elixir.sinppets
@@ -1,18 +1,20 @@
+######################################
+# ELIXIR DOCUMENTATION-FULL SNIPPETS #
+######################################
+
+
 global !p
 import os
 
-def log(*a, **k):
-    with open(os.path.expanduser("~/Desktop/log.txt"), 'w') as f:
-        print(*a, **k, file=f)
-
-
 def write_spec(t, snip):
+    """Write the @spec of a function"""
     snip.rv += "@spec {0}({1}) :: TODO".format(
         t[1],
         ", ".join("{0}::TODO".format(arg.strip()) for arg in t[2].split(',')))
 
 
 def write_type_fields(t, snip):
+    """Write the fields inside of a type definition"""
     fields = [field.split(':')[0].strip() for field in t[1].split(',')]
     maxlength = max(len(field) for field in fields)
 
@@ -26,8 +28,7 @@ def write_type_fields(t, snip):
 
 
 def write_typedoc_fields(t, snip):
-    log("'{}', '{}'".format(snip._initial_indent, snip.indent))
-    log(snip.__dict__)
+    """Write the fields of a type in a @typespec"
     fields = [field.split(':')[0].strip() for field in t[1].split(',')]
     maxlength = max(len(field) for field in fields)
 
@@ -40,6 +41,15 @@ def write_typedoc_fields(t, snip):
         for field in fields)
 
 endglobal
+
+
+
+############
+# SNIPPETS #
+############
+
+# These snippets are designed to automatically include various documentation.
+# This aims at encouraging writing well-formatted and documented code.
 
 
 snippet def "Function with docstring and typespecs"

--- a/UltiSnips/elixir.snippets
+++ b/UltiSnips/elixir.snippets
@@ -1,7 +1,8 @@
+priority -50
+
 ######################################
 # ELIXIR DOCUMENTATION-FULL SNIPPETS #
 ######################################
-
 
 global !p
 import os

--- a/UltiSnips/elixir.snippets
+++ b/UltiSnips/elixir.snippets
@@ -69,6 +69,7 @@ defmodule ${1:module_name} do
   @moduledoc ~S"""
   ${2:One-line summary}
   """
+
   ${3:body}
 end
 endsnippet

--- a/UltiSnips/elixir.snippets
+++ b/UltiSnips/elixir.snippets
@@ -53,18 +53,16 @@ endglobal
 # This aims at encouraging writing well-formatted and documented code.
 
 
-snippet def "Function with docstring and typespecs"
+snippet defd "Function with docstring and typespecs"
 @doc ~S"""
 ${3:One-line summary}
 """
 `!p write_spec(t, snip)`
-def ${1:function_name}(${2:arg1}) do
-  ${4:body}
-end
+def ${1:function_name}(${2:arg1})
 endsnippet
 
 
-snippet defm "Module with doc"
+snippet defmd "Module with doc"
 defmodule ${1:module_name} do
   @moduledoc ~S"""
   ${2:One-line summary}
@@ -75,7 +73,7 @@ end
 endsnippet
 
 
-snippet defs "Struct with typespec"
+snippet defsd "Struct with typespec"
 defstruct [
   ${1:field1}
 ]

--- a/UltiSnips/elixir.snippets
+++ b/UltiSnips/elixir.snippets
@@ -29,7 +29,7 @@ def write_type_fields(t, snip):
 
 
 def write_typedoc_fields(t, snip):
-    """Write the fields of a type in a @typespec"
+    """Write the fields of a type in a @typespec"""
     fields = [field.split(':')[0].strip() for field in t[1].split(',')]
     maxlength = max(len(field) for field in fields)
 

--- a/UltiSnips/elixir.snippets
+++ b/UltiSnips/elixir.snippets
@@ -85,7 +85,7 @@ Fields:
 `!p write_typedoc_fields(t, snip)`
 """
 
-type t :: %__MODULE__{
+@type t :: %__MODULE__{
 `!p write_type_fields(t, snip)`
 }
 endsnippet


### PR DESCRIPTION
This is the first stone of the Elixir snippets.
I intend to encourage writing well documented code, and thus these snippets reduce the boilerplate of manually typing the various heredocs.

Currently working snippets:
- `def`
- `defm` for `defmodule`
- `defs` for `defstructure`