### PR TITLE
fix duplicated 'ast'

### DIFF
--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -617,7 +617,7 @@ snippet ascha "$this->assertClassHasAttribute($name, Example::class)"
 	$this->assertClassHasAttribute(${1:$attributeName}, ${2:Example}::class);
 snippet asi "$this->assertInstanceOf(Example::class, $actual)"
 	$this->assertInstanceOf(${1:Example}::class, ${2:$actual});
-snippet ast "$this->assertInternalType('string', $actual)"
+snippet asit "$this->assertInternalType('string', $actual)"
 	$this->assertInternalType(${1:'string'}, ${2:actual});
 snippet asco "$this->assertCount($count, $haystack)"
 	$this->assertCount(${1:$expectedCount}, ${2:$haystack});


### PR DESCRIPTION
Review:
There are two 'ast' snippets on line 598 and line 620.

Fix:
Replace the duplicated 'ast' with 'asit' on line 620.