### PR TITLE
Remove trailing slash from auto-closing tags

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -138,18 +138,18 @@ snippet address
 		${0}
 	</address>
 snippet area
-	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${0}" />
+	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${0}">
 snippet area+
-	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${4}" />
+	<area shape="${1:rect}" coords="${2}" href="${3}" alt="${4}">
 	area+
 snippet area:c
-	<area shape="circle" coords="${1}" href="${2}" alt="${0}" />
+	<area shape="circle" coords="${1}" href="${2}" alt="${0}">
 snippet area:d
-	<area shape="default" coords="${1}" href="${2}" alt="${0}" />
+	<area shape="default" coords="${1}" href="${2}" alt="${0}">
 snippet area:p
-	<area shape="poly" coords="${1}" href="${2}" alt="${0}" />
+	<area shape="poly" coords="${1}" href="${2}" alt="${0}">
 snippet area:r
-	<area shape="rect" coords="${1}" href="${2}" alt="${0}" />
+	<area shape="rect" coords="${1}" href="${2}" alt="${0}">
 snippet article
 	<article>
 		${0}
@@ -179,7 +179,7 @@ snippet audio
 snippet b
 	<b>${0}</b>
 snippet base
-	<base href="${1}" target="${0}" />
+	<base href="${1}" target="${0}">
 snippet bdi
 	<bdi>${0}</bdo>
 snippet bdo
@@ -197,7 +197,7 @@ snippet body
 		${0}
 	</body>
 snippet br
-	<br />
+	<br>
 snippet button
 	<button type="${1:submit}">${0}</button>
 snippet button.
@@ -219,17 +219,14 @@ snippet cite
 snippet code
 	<code>${0}</code>
 snippet col
-	<col />
-snippet col+
-	<col />
-	col+
+	<col>
 snippet colgroup
 	<colgroup>
 		${0}
 	</colgroup>
 snippet colgroup+
 	<colgroup>
-		<col />
+		<col>
 		col+${0}
 	</colgroup>
 snippet command
@@ -309,7 +306,7 @@ snippet dt+
 snippet em
 	<em>${0}</em>
 snippet embed
-	<embed src="${1}" type="${0}" />
+	<embed src="${1}" type="${0}">
 snippet fieldset
 	<fieldset>
 		${0}
@@ -402,7 +399,7 @@ snippet h6#
 	<h6 id="${1}">${0}</h6>
 snippet head
 	<head>
-		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+		<meta http-equiv="content-type" content="text/html; charset=utf-8">
 
 		<title>${1:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
 		${0}
@@ -428,7 +425,7 @@ snippet hgroup.
 		${0}
 	</hgroup>
 snippet hr
-	<hr />
+	<hr>
 snippet html
 	<html>
 	${0}
@@ -441,8 +438,8 @@ snippet html5
 	<!DOCTYPE html>
 	<html>
 		<head>
-			<meta charset="utf-8" />
-			<meta name="viewport" content="width=device-width" />
+			<meta charset="utf-8">
+			<meta name="viewport" content="width=device-width">
 			<title>${1:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
 			${2:link}
 		</head>
@@ -454,8 +451,8 @@ snippet html5l
 	<!DOCTYPE html>
 	<html lang="${1:es}">
 		<head>
-			<meta charset="utf-8" />
-			<meta name="viewport" content="width=device-width" />
+			<meta charset="utf-8">
+			<meta name="viewport" content="width=device-width">
 			<title>${2:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
 			${3:link}
 		</head>
@@ -472,59 +469,59 @@ snippet iframe.
 snippet iframe#
 	<iframe id="${1}" src="${2}" frameborder="0"></iframe>
 snippet img
-	<img src="${1}" alt="${2}" />
+	<img src="${1}" alt="${2}">
 snippet img.
-	<img class="${1}" src="${2}" alt="${3}" />
+	<img class="${1}" src="${2}" alt="${3}">
 snippet img#
-	<img id="${1}" src="${2}" alt="${3}" />
+	<img id="${1}" src="${2}" alt="${3}">
 snippet input
-	<input type="${1:text/submit/hidden/button/image}" name="${2}" id="${3:$2}" value="${4}" />
+	<input type="${1:text/submit/hidden/button/image}" name="${2}" id="${3:$2}" value="${4}">
 snippet input.
-	<input class="${1}" type="${2:text/submit/hidden/button/image}" name="${3}" id="${4:$3}" value="${5}" />
+	<input class="${1}" type="${2:text/submit/hidden/button/image}" name="${3}" id="${4:$3}" value="${5}">
 snippet input:text
-	<input type="text" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="text" name="${1}" id="${2:$1}" value="${3}">
 snippet input:submit
-	<input type="submit" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="submit" name="${1}" id="${2:$1}" value="${3}">
 snippet input:hidden
-	<input type="hidden" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="hidden" name="${1}" id="${2:$1}" value="${3}">
 snippet input:button
-	<input type="button" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="button" name="${1}" id="${2:$1}" value="${3}">
 snippet input:image
-	<input type="image" name="${1}" id="${2:$1}" src="${3}" alt="${4}" />
+	<input type="image" name="${1}" id="${2:$1}" src="${3}" alt="${4}">
 snippet input:checkbox
-	<input type="checkbox" name="${1}" id="${2:$1}" />
+	<input type="checkbox" name="${1}" id="${2:$1}">
 snippet input:radio
-	<input type="radio" name="${1}" id="${2:$1}" />
+	<input type="radio" name="${1}" id="${2:$1}">
 snippet input:color
-	<input type="color" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="color" name="${1}" id="${2:$1}" value="${3}">
 snippet input:date
-	<input type="date" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="date" name="${1}" id="${2:$1}" value="${3}">
 snippet input:datetime
-	<input type="datetime" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="datetime" name="${1}" id="${2:$1}" value="${3}">
 snippet input:datetime-local
-	<input type="datetime-local" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="datetime-local" name="${1}" id="${2:$1}" value="${3}">
 snippet input:email
-	<input type="email" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="email" name="${1}" id="${2:$1}" value="${3}">
 snippet input:file
-	<input type="file" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="file" name="${1}" id="${2:$1}" value="${3}">
 snippet input:month
-	<input type="month" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="month" name="${1}" id="${2:$1}" value="${3}">
 snippet input:number
-	<input type="number" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="number" name="${1}" id="${2:$1}" value="${3}">
 snippet input:password
-	<input type="password" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="password" name="${1}" id="${2:$1}" value="${3}">
 snippet input:range
-	<input type="range" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="range" name="${1}" id="${2:$1}" value="${3}">
 snippet input:reset
-	<input type="reset" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="reset" name="${1}" id="${2:$1}" value="${3}">
 snippet input:search
-	<input type="search" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="search" name="${1}" id="${2:$1}" value="${3}">
 snippet input:time
-	<input type="time" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="time" name="${1}" id="${2:$1}" value="${3}">
 snippet input:url
-	<input type="url" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="url" name="${1}" id="${2:$1}" value="${3}">
 snippet input:week
-	<input type="week" name="${1}" id="${2:$1}" value="${3}" />
+	<input type="week" name="${1}" id="${2:$1}" value="${3}">
 snippet ins
 	<ins>${0}</ins>
 snippet kbd
@@ -556,19 +553,19 @@ snippet lia+
 	<li><a href="${2:#}">${1}</a></li>
 	lia+
 snippet link
-	<link rel="${1}" href="${2}" title="${3}" type="${4}" />
+	<link rel="${1}" href="${2}" title="${3}" type="${4}">
 snippet link:atom
-	<link rel="alternate" href="${1:atom.xml}" title="Atom" type="application/atom+xml" />
+	<link rel="alternate" href="${1:atom.xml}" title="Atom" type="application/atom+xml">
 snippet link:s
-	<link rel="stylesheet" href="${1:style.css}" />
+	<link rel="stylesheet" href="${1:style.css}">
 snippet link:css
-	<link rel="stylesheet" href="${1:style.css}" type="text/css" media="${2:all}" />
+	<link rel="stylesheet" href="${1:style.css}" type="text/css" media="${2:all}">
 snippet link:favicon
-	<link rel="shortcut icon" href="${1:favicon.ico}" type="image/x-icon" />
+	<link rel="shortcut icon" href="${1:favicon.ico}" type="image/x-icon">
 snippet link:rss
-	<link rel="alternate" href="${1:rss.xml}" title="RSS" type="application/atom+xml" />
+	<link rel="alternate" href="${1:rss.xml}" title="RSS" type="application/atom+xml">
 snippet link:touch
-	<link rel="apple-touch-icon" href="${1:favicon.png}" />
+	<link rel="apple-touch-icon" href="${1:favicon.png}">
 snippet main
 	<main role="main">
 		${0}
@@ -604,17 +601,17 @@ snippet menu:t
 		${0}
 	</menu>
 snippet meta
-	<meta http-equiv="${1}" content="${2}" />
+	<meta http-equiv="${1}" content="${2}">
 snippet meta:s
-	<meta ${0} />
+	<meta ${0}>
 snippet meta:d
-	<meta name="description" content="${0}" />
+	<meta name="description" content="${0}">
 snippet meta:compat
-	<meta http-equiv="X-UA-Compatible" content="IE=${1:7,8,edge}" />
+	<meta http-equiv="X-UA-Compatible" content="IE=${1:7,8,edge}">
 snippet meta:refresh
-	<meta http-equiv="refresh" content="text/html;charset=UTF-8" />
+	<meta http-equiv="refresh" content="text/html;charset=UTF-8">
 snippet meta:utf
-	<meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+	<meta http-equiv="content-type" content="text/html;charset=UTF-8">
 snippet meter
 	<meter>${0}</meter>
 snippet nav
@@ -641,14 +638,14 @@ snippet object
 snippet movie
 	<object width="$2" height="$3" classid="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B"
 	codebase="http://www.apple.com/qtactivex/qtplugin.cab">
-		<param name="src" value="$1" />
-		<param name="controller" value="$4" />
-		<param name="autoplay" value="$5" />
+		<param name="src" value="$1">
+		<param name="controller" value="$4">
+		<param name="autoplay" value="$5">
 		<embed src="${1:movie.mov}"
 			width="${2:320}" height="${3:240}"
 			controller="${4:true}" autoplay="${5:true}"
 			scale="tofit" cache="true"
-			pluginspage="http://www.apple.com/quicktime/download/" />
+			pluginspage="http://www.apple.com/quicktime/download/">
 	</object>
 snippet ol
 	<ol>
@@ -688,7 +685,7 @@ snippet p.
 snippet p#
 	<p id="${1}">${0}</p>
 snippet param
-	<param name="${1}" value="${2}" />
+	<param name="${1}" value="${2}">
 snippet pre
 	<pre>
 		${0}
@@ -751,7 +748,7 @@ snippet select+
 snippet small
 	<small>${0}</small>
 snippet source
-	<source src="${1}" type="${2}" media="${0}" />
+	<source src="${1}" type="${2}" media="${0}">
 snippet span
 	<span>${0}</span>
 snippet span.
@@ -830,7 +827,7 @@ snippet tr+
 		td+${0}
 	</tr>
 snippet track
-	<track src="${1}" srclang="${2}" label="${3}" default="${4:default} />${5}
+	<track src="${1}" srclang="${2}" label="${3}" default="${4:default}>${5}
 snippet ul
 	<ul>
 		${0}
@@ -855,6 +852,6 @@ snippet video
 snippet video.
 	<video class="${1}" src="${2}" height="${3}" width="${4}" preload="${5:none}" autoplay="${6:autoplay}">${7}</video>
 snippet wbr
-	<wbr />
+	<wbr>
 snippet viewport
 	<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This breaks compatibility with XHTML (see #845).
The slashes are even forbidden in HTML4 (but optional in HTML5).
Source: <http://xahlee.info/js/html5_non-closing_tag.html>