### PR TITLE
Python3 shebang

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -1,5 +1,5 @@
 snippet #!
-	#!/usr/bin/env python
+	#!/usr/bin/env python3
 	# -*- coding: utf-8 -*-
 snippet #!2
 	#!/usr/bin/env python2

--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -1,12 +1,10 @@
 snippet #!
 	#!/usr/bin/env python3
-	# -*- coding: utf-8 -*-
 snippet #!2
 	#!/usr/bin/env python2
 	# -*- coding: utf-8 -*-
 snippet #!3
 	#!/usr/bin/env python3
-	# -*- coding: utf-8 -*-
 snippet imp
 	import ${0:module}
 snippet uni


### PR DESCRIPTION
This pull request changes two things:

- it removes the `# -*- coding: utf-8 -*-` comment from python3 shebangs, as python3 uses utf-8 by default. See `python3 -c 'import sys; print(sys.getdefaultencoding())'`.
- it also replaces the unversioned python shebang with the python3 shebang. In order to make it easier to switch to a new python version nobody should use unversioned shebangs any more. See https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3#Phase_1:_Eliminate_the_python-_prefix_from_the_Python_2_package_names_and_.2Fusr.2Fbin.2Fpython_from_shebangs