### PR TITLE
:bug: Re-added some UltiSnips TeX math snippets

### DIFF
--- a/UltiSnips/texmath.snippets
+++ b/UltiSnips/texmath.snippets
@@ -1,5 +1,43 @@
 priority -50
 
+##############
+# MATH STUFF #
+##############
+
+snippet eqnn "Equation without a number" b
+\begin{equation*}
+	${0:${VISUAL}}
+\end{equation*}
+endsnippet
+
+snippet al "Align" b
+\begin{align}
+	${0:${VISUAL}}
+\end{align}
+endsnippet
+
+snippet alnn "Align without a number" b
+\begin{align*}
+	${0:${VISUAL}}
+\end{align*}
+endsnippet
+
+snippet eqa "Equation array" b
+\begin{eqnarray}
+	${1:${VISUAL}} & ${2:${VISUAL}} & ${0:${VISUAL}}
+\end{eqnarray}
+endsnippet
+
+snippet eqann "Equation array without a number" b
+\begin{eqnarray*}
+	${1:${VISUAL}} & ${2:${VISUAL}} & ${0:${VISUAL}}
+\end{eqnarray*}
+endsnippet
+
+#################
+# PHYSICS STUFF #
+#################
+
 snippet dv "Derivative" w
 \dv[${1:${VISUAL}}]{${2}}{${3}}
 endsnippet


### PR DESCRIPTION
Re-added UltiSnips snippets in `UltiSnips/texmath.snippets` that have different snippet names with the ones in `snippets/tex.snippets`.
Also added tabstops.

Fixes #1083 and #1084