### PR TITLE
Fix rust trait/iter snippet name conflict

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -28,7 +28,7 @@ snippet fmt "format!(..)"
 format!("$1"${2/..*/, /}$2);
 endsnippet
 
-snippet it ".iter()" i
+snippet .it ".iter()" i
 .iter()$0
 endsnippet
 


### PR DESCRIPTION
Fixes https://github.com/ncm2/ncm2-ultisnips/issues/15.
Expanding `trait` snippet resulted in `tra.iter()`.