### PR TITLE
Test snippet format matches a directory it is in

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
 
-SPACED=$(grep -REn '^ .+' --include '*.snippets' snippets)
+check=0
 
-if [[ $? -ne 1 ]]; then
-  echo These snippet lines are indented with spaces:
-  echo
-  echo "$SPACED"
-  echo
-  echo Tests failed!
+function test_space_indented {
+  local spaced
+  spaced=$(grep -REn '^ ' --include '*.snippets' snippets)
+
+  if [[ $? -ne 1 ]]; then
+    echo "These snippet lines are indented with spaces:"
+    echo "$spaced"
+    echo
+    (( check++ ))
+  fi
+}
+
+function test_snipmate_format {
+  local ultisnips_in_snipmate
+  ultisnips_in_snipmate=$(grep -REn 'endsnippet' --include '*.snippets' snippets)
+  if [[ $? -ne 1 ]]; then
+    echo "These snippet definitions are probably in UltiSnips format but stored in the snipmate directory"
+    echo "$ultisnips_in_snipmate"
+    echo
+    (( check++ ))
+  fi
+}
+
+test_space_indented
+test_snipmate_format
+
+if [ $check -eq 0 ]; then
+  echo "Tests passed!"
+  exit 0
+else
+  echo "$check test(s) failed out of 2!"
   exit 1
 fi
-
-echo Tests passed!
-exit 0


### PR DESCRIPTION
(see commit cfc7e5246a7a761211eb0aeea60bbfc85ea083a5)
An UltiSnips snippet was added into "snippets" directory which should
contain snipmate snippets only. This led to a parsing bug in UltiSnips.

```
An error occured. This is either a bug in UltiSnips or a bug in a
snippet definition. If you think this is a bug, please report it to
https://github.com/SirVer/ultisnips/issues/new
Please read and follow:
https://github.com/SirVer/ultisnips/blob/master/CONTRIBUTING.md#reproducing-bugs

Following is the full stack trace:
Traceback (most recent call last):
  File "$HOME/.vim/pack/minpac/start/ultisnips/pythonx/UltiSnips/err_to_scratch_buffer.py", line 16, in wrapper
    return func(self, *args, **kwds)
  File "$HOME/.vim/pack/minpac/start/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 151, in snippets_in_current_scope
    snippets = self._snips(before, True)
  File "$HOME/.vim/pack/minpac/start/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 574, in _snips
    source.ensure(filetypes)
  File "$HOME/.vim/pack/minpac/start/ultisnips/pythonx/UltiSnips/snippet/source/file/_base.py", line 32, in ensure
    self._load_snippets_for(ft)
  File "$HOME/.vim/pack/minpac/start/ultisnips/pythonx/UltiSnips/snippet/source/file/_base.py", line 54, in _load_snippets_for
    self._parse_snippets(ft, fn)
  File "$HOME/.vim/pack/minpac/start/ultisnips/pythonx/UltiSnips/snippet/source/file/_base.py", line 69, in _parse_snippets
    raise SnippetSyntaxError(filename, line_index, msg)
SnippetSyntaxError: Invalid line '@unittest.skip(${1:skip_reason})' in .vim/pack/minpac/start/vim-snippets/snippets/python.snippets:27
```