### PR TITLE
Fix python.snippets syntax error

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -23,9 +23,9 @@ snippet docs
 	"""
 
 # Unittest skip
-snippet sk "skip unittests" b
-@unittest.skip(${1:skip_reason})
-endsnippet
+snippet sk
+	@unittest.skip(${0:skip_reason})
+
 
 snippet wh
 	while ${1:condition}:


### PR DESCRIPTION
Fix syntax error at PR #1092, which is mentioned at issue #1096 

Works with UltiSnips & python 3.7.2