### PR TITLE
Cargo Unit-test Skip shortcut

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -22,6 +22,11 @@ snippet docs
 	Description: ${0}
 	"""
 
+# Unittest skip
+snippet sk "skip unittests" b
+@unittest.skip(${1:skip_reason})
+endsnippet
+
 snippet wh
 	while ${1:condition}:
 		${0:${VISUAL}}

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -59,7 +59,7 @@ snippet mod
 snippet as "assert!"
 	assert!(${1:predicate});
 snippet ase "assert_eq!"
-	assert_eq!(${1:actual}, ${2:expected});
+	assert_eq!(${1:expected}, ${2:actual});
 snippet test "Unit test function"
 	#[test]
 	fn ${1:function_name}_test() {


### PR DESCRIPTION
In my opinion, this is absolutely necessary!.
```
#[ignore]
```