### PR TITLE
Rust: Add dbg! macro snippet 'db'

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -44,6 +44,8 @@ snippet pln, "println! with format param"
 	println!("${1}{${2}}", ${3});
 snippet fmt "format!"
 	format!("${1}{${2}}", ${3});
+snippet d "dbg! debugging macro"
+	dbg!(${1});
 
 # Modules
 snippet ec "extern crate"


### PR DESCRIPTION
This was added with Rust 1.32 and is super useful compared to doing
just `print!` debugging.

See https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html#the-dbg-macro
for examples.