### PR TITLE
remove space

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -212,7 +212,7 @@ snippet under underline text
 snippet over overline text
 	\\overline{${1:${VISUAL:text}}} ${0}
 snippet emp emphasize text
-	\\emph{${1:${VISUAL:text}}} ${0}
+	\\emph{${1:${VISUAL:text}}}${0}
 snippet sc small caps text
 	\\textsc{${1:${VISUAL:text}}} ${0}
 #Choosing font


### PR DESCRIPTION
between "\\emph{${1:${VISUAL:text}}}" and "${0}"

as I consider it annoying (especially for instance before a period or a comma). I wonder it those spaces should be removed in similar 