### PR TITLE
Disable all monkey patching done by RSpec.

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -653,6 +653,10 @@ snippet mthrow
 #     Rspec snippets     #
 ##########################
 snippet desc
+	describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
+		${0}
+	end
+snippet rdesc
 	RSpec.describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
 		${0}
 	end

--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -653,7 +653,7 @@ snippet mthrow
 #     Rspec snippets     #
 ##########################
 snippet desc
-	describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
+	RSpec.describe ${1:`substitute(substitute(vim_snippets#Filename(), '_spec$', '', ''), '\(_\|^\)\(.\)', '\u\2', 'g')`} do
 		${0}
 	end
 snippet descm


### PR DESCRIPTION
This ensures that `describe` blocks are prepended with `RSpec` to fix specs where monkey patching is disabled. See https://relishapp.com/rspec/rspec-core/v/3-8/docs/configuration/zero-monkey-patching-mode for more information.