### PR TITLE
Fix Python class init snippet to work with type hinting and varargs.

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -64,6 +64,9 @@ class Arg(object):
 	def is_kwarg(self):
 		return '=' in self.arg
 
+	def is_vararg(self):
+		return '*' in self.name
+
 
 def get_args(arglist):
 	args = [Arg(arg) for arg in arglist.split(',') if arg]
@@ -213,7 +216,7 @@ def write_init_body(args, parents, snip):
 	if parents:
 		snip.rv += '\n' + snip.mkline('', indent='')
 
-	for arg in args:
+	for arg in filter(lambda arg: not arg.is_vararg(), args):
 		snip += "self._%s = %s" % (arg, arg)
 
 

--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -51,7 +51,9 @@ DOUBLE_QUOTES = '"'
 class Arg(object):
 	def __init__(self, arg):
 		self.arg = arg
-		self.name = arg.split('=')[0].strip()
+		name_and_type = arg.split('=')[0].split(':')
+		self.name = name_and_type[0].strip()
+		self.type = name_and_type[1].strip() if len(name_and_type) == 2 else None
 
 	def __str__(self):
 		return self.name


### PR DESCRIPTION
This fixes one of the issues identified in #1095. I also went ahead and changed how varargs (`*args` and `**kwargs`) are handled so that they don't get automatically saved to the class, as that usually doesn't make sense (and even if you wanted that, the previous syntax was incorrect).