### PR TITLE
Make a proper class name generating for puppet

### DIFF
--- a/snippets/puppet.snippets
+++ b/snippets/puppet.snippets
@@ -7,7 +7,7 @@
 # Header using Puppet Strings (YARD tags) https://puppet.com/docs/puppet/latest/modules_documentation.html
 # More info: https://github.com/puppetlabs/puppet-strings
 snippet classheader
-	# ${1:`vim_snippets#Filename(expand('%:p:s?.*modules/??:h:h'), 'class-name')`}
+	# ${1:`vim_snippets#Filename(substitute(expand('%:p:s?\v.{-}/(\w+)/manifests/(.+)\.pp?\1/\2?'), '/', '::', 'g'), 'class-name')`}
 	# ${2:A description of what this class does}
 	#
 	# @summary ${3:A short summary of the purpose of this class}
@@ -16,7 +16,7 @@ snippet classheader
 	#   ${6:Explanation of what this parameter affects.}
 	#
 	# @example Simple use
-	#   class { '$1': }
+	#   include $1
 	#
 	# @example Use with params
 	#   class { '$1':

--- a/snippets/puppet.snippets
+++ b/snippets/puppet.snippets
@@ -12,7 +12,7 @@ snippet classheader
 	#
 	# @summary ${3:A short summary of the purpose of this class}
 	#
-	# @param ${4:parameter1} [${5:String}]
+	# @param ${4:parameter1}
 	#   ${6:Explanation of what this parameter affects.}
 	#
 	# @example Simple use
@@ -28,7 +28,7 @@ snippet classheader
 	# @note Copyright `strftime("%Y")` $8
 	#
 	class $1(
-		$$4 = undef,
+		${5:String} $$4 = undef,
 	) {
 		${0}
 	}


### PR DESCRIPTION
It's broken now. The way to check:
```bash
mkdir -p /tmp/modules/clickhouse/manifests
vim /tmp/modules/clickhouse/manifests/test.pp +'norm Iclassheader	' # tabulation symbol
```

Try it with upstream and my branch

Also now parameter type defined in a class, not in docstrings, and will generate documentation automatically. See [source](https://github.com/innogames/puppet-clickhouse/blob/master/manifests/server.pp#L7) and [result](https://github.com/innogames/puppet-clickhouse/blob/master/REFERENCE.md#package_ensure-1)