### PR TITLE
Fix EEx if/else error

### DIFF
--- a/snippets/eelixir.snippets
+++ b/snippets/eelixir.snippets
@@ -17,7 +17,7 @@ snippet if
 snippet ife
 	<%= if ${1} do %>
 		${2:${VISUAL}}
-	<%= else %>
+	<% else %>
 		${0}
 	<% end %>
 snippet ft


### PR DESCRIPTION
There was a '=' in the else clause, which should not be there.