### PR TITLE
Add functional class snippet

### DIFF
--- a/snippets/javascript/javascript-react.snippets
+++ b/snippets/javascript/javascript-react.snippets
@@ -42,11 +42,24 @@ snippet pt
 	static propTypes = {
 		${1}: React.PropTypes.${2:type},
 	}
+snippet rfc
+	const ${1:ClassName} = (${2:props}) => {
+		return (
+			<div>
+				$1
+			</div>
+		);
+	}
 snippet rcc
 	class ${1:ClassName} extends React.Component {
+		state = {
+
+		}
 		render() {
 			return (
-				${0:<div />}
+				<div>
+					$1
+				</div>
 			);
 		}
 	}

--- a/snippets/javascript/javascript-react.snippets
+++ b/snippets/javascript/javascript-react.snippets
@@ -43,7 +43,7 @@ snippet pt
 		${1}: React.PropTypes.${2:type},
 	}
 snippet rfc
-	const ${1:ClassName} = (${2:props}) => {
+	const ${1:ComponentName} = (${2:props}) => {
 		return (
 			<div>
 				$1


### PR DESCRIPTION
There was a missing snippet that a lot of people use in Visual Studio code :
Creating a functional component using rfc
I added rfc and also changed 
</div> to be whatever you type on ClassName so that it the component is not just a useless empty div