### PR TITLE
Add spaces between braces

### DIFF
--- a/snippets/javascript/javascript-react.snippets
+++ b/snippets/javascript/javascript-react.snippets
@@ -1,7 +1,7 @@
 snippet ir
 	import React from 'react';
 snippet irc
-	import React, {Component} from 'react';
+	import React, { Component } from 'react';
 snippet ird
 	import ReactDOM from 'react-dom';
 snippet cdm


### PR DESCRIPTION
Add spaces between braces in javascript-react.snippets, like [javascript-redux.snippets](https://github.com/honza/vim-snippets/blob/91ef2dcf1e75d06fd04ceafc144c8cf5d1b4f46a/snippets/javascript/javascript-redux.snippets#L2).

I think that this is better.