### PR TITLE
Add cpp auto alternatives to msp and mup

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -62,9 +62,13 @@ snippet pqueue
 # std::shared_ptr
 snippet msp
 	std::shared_ptr<${1:T}> ${2} = std::make_shared<$1>(${3});
+snippet amsp
+	auto ${1} = std::make_shared<${2:T}>(${3});
 # std::unique_ptr
 snippet mup
 	std::unique_ptr<${1:T}> ${2} = std::make_unique<$1>(${3});
+snippet amup
+	auto ${1} = std::make_unique<${2:T}>(${3});
 ##
 ## Access Modifiers
 # private


### PR DESCRIPTION
This syntax follows (A)lways (A)lways (A)uto, a popular C++11
syntax guideline coined by Scott Meyers.

A small addition to jprof's commit at 2af1ffe88d3de3fbe40a6e74fb626b18a6548cbd

Signed-off-by: Kevin Morris <kevr.gtalk@gmail.com>