### PR TITLE
Unify shabang in ultisnips

### DIFF
--- a/UltiSnips/javascript-node.snippets
+++ b/UltiSnips/javascript-node.snippets
@@ -1,6 +1,6 @@
 priority -50
 
-snippet #! "shebang"
+snippet #! "#!/usr/bin/env node" b
 #!/usr/bin/env node
 endsnippet
 

--- a/UltiSnips/lua.snippets
+++ b/UltiSnips/lua.snippets
@@ -3,7 +3,7 @@ priority -50
 #################################
 # Snippets for the Lua language #
 #################################
-snippet #! "Shebang header" b
+snippet #! "#!/usr/bin/env lua" b
 #!/usr/bin/env lua
 $0
 endsnippet

--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -5,8 +5,12 @@ priority -50
 ###########################################################################
 
 #! header
-snippet #! "Shebang header for python scripts" b
+snippet #! "#!/usr/bin/env python" b
 #!/usr/bin/env python
+$0
+endsnippet
+
+snippet "^# ?[uU][tT][fF]-?8" "# encoding: UTF-8" r
 # -*- coding: utf-8 -*-
 $0
 endsnippet

--- a/UltiSnips/r.snippets
+++ b/UltiSnips/r.snippets
@@ -15,8 +15,9 @@ FIELD_TYPES = [
 'vector']
 endglobal
 
-snippet #! "Hashbang for Rscript (#!)" b
+snippet #! "#!/usr/bin/env Rscript" b
 #!/usr/bin/env Rscript
+$0
 endsnippet
 
 snippet setwd "Set workingdir" b

--- a/UltiSnips/ruby.snippets
+++ b/UltiSnips/ruby.snippets
@@ -21,7 +21,7 @@ endglobal
 # Snippets
 #
 
-snippet "^#!" "#!/usr/bin/env ruby" r
+snippet #! "#!/usr/bin/env ruby" b
 #!/usr/bin/env ruby
 $0
 endsnippet

--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -25,12 +25,8 @@ endglobal
 ###########################################################################
 #                            TextMate Snippets                            #
 ###########################################################################
-snippet #!
-`!p snip.rv = '#!/bin/' + getShell() + "\n\n" `
-endsnippet
-
-snippet !env "#!/usr/bin/env (!env)"
-`!p snip.rv = '#!/usr/bin/env ' + getShell() + "\n\n" `
+snippet #! "#!/usr/bin/env (!env)" b
+`!p snip.rv = '#!/usr/bin/env ' + getShell() + "\n" `
 endsnippet
 
 snippet sbash "safe bash options"

--- a/UltiSnips/zsh.snippets
+++ b/UltiSnips/zsh.snippets
@@ -4,14 +4,9 @@ extends sh
 
 priority -49
 
-snippet #! "shebang" b
-#!/bin/zsh
-
-endsnippet
-
-snippet !env "#!/usr/bin/env (!env)" b
+snippet #! "#!/usr/bin/env zsh" b
 #!/usr/bin/env zsh
-
+$0
 endsnippet
 
 # vim:ft=snippets:


### PR DESCRIPTION
Unify shabang in ultisnips, and python3 no longer need to append `code: utf-8`