### PR TITLE
Latex figure snippets

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -85,7 +85,7 @@ snippet fig "Figure environment" b
 \begin{figure}[${2:htpb}]
 	\centering
 	\includegraphics[width=${3:0.8}\linewidth]{${4:name.ext}}
-	\caption{${4/(\w+)\.\w+/\u$1/}$0}
+	\caption{${4/(\w+)\.\w+/\u$1/}$0}%
 	\label{fig:${4/(\w+)\.\w+/$1/}}
 \end{figure}
 endsnippet

--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -248,7 +248,7 @@ snippet tikz figure environment (tikzpicture)
 		${2}
 	\\end{tikzpicture}
 	\\end{center}
-	\\caption{${3}}
+	\\caption{${3}}%
 	\\label{fig:${4}}
 	\\end{figure}
 	${0}


### PR DESCRIPTION
A space between the caption and the label is not recommended as it can create error in page references. I suggest adding a comment sign after the caption to fix this problem.