### PR TITLE
Revert "Adding some generic parentheses snippets."

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -107,23 +107,4 @@ snippet uuid "Random UUID" w
 `!p if not snip.c: import uuid; snip.rv = uuid.uuid4()`
 endsnippet
 
-
-#################
-#  Parentheses  #
-#################
-snippet () "Parentheses surround" A
-$1(${2:${VISUAL}})$0
-endsnippet
-
-snippet [] "Bracket surround" A
-$1[${2:${VISUAL}}]$0
-endsnippet
-
-snippet {} "Brace surround" A
-$1{${2:${VISUAL}}}$0
-endsnippet
-
-snippet <> "Angle surround" A
-$1<${2:${VISUAL}}>$0
-endsnippet
 # vim:ft=snippets:


### PR DESCRIPTION
Reverts honza/vim-snippets#1154

Reverting this as it causes problems with typing expressions such as `[]int32{}`, it gets transformed into `int32{}[]`.