### PR TITLE
Remove redundant whitespaces from Python todo

### DIFF
--- a/pythonx/vimsnippets.py
+++ b/pythonx/vimsnippets.py
@@ -69,7 +69,7 @@ def get_comment_format():
     commentstring = vim.eval("&commentstring")
     if commentstring.endswith("%s"):
         c = commentstring[:-2]
-        return (c, c, c, "")
+        return (c.rstrip(), c.rstrip(), c.rstrip(), "")
     comments = _parse_comments(vim.eval("&comments"))
     for c in comments:
         if c[0] == "SINGLE_CHAR":


### PR DESCRIPTION
This fixes #1145 .
I chose to remove leading whitespaces in `all.snippets` todo-snippet, since whitespaces should IMO be managed by the language's comment format. There might be languages that discourage leading spaces in comments. In Python, this lead to two leading whitespaces.
In pythonx's `get_comment_format()`, I removed trailing whitespaces from the `end_line` comment format, avoiding trailing whitespaces to be inserted into the code.