### PR TITLE
fix the `$0` auto-jump issue

### DIFF
--- a/snippets/fortran.snippets
+++ b/snippets/fortran.snippets
@@ -1,13 +1,13 @@
 snippet impl
 	implicit none
-		$0
+		${0}
 snippet prog
 	program ${1:main}
-		$0
+		${0}
 	end program $1
 snippet mod
 	module ${1:modulename}
-		$0
+		${0}
 	end module $1
 snippet proc
 	procedure ${1:name}
@@ -25,7 +25,7 @@ snippet doc
 	! Github: `g:snips_github`
 	! Description: $1
 	! """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-	$0
+	${0}
 snippet dox
 	!> @brief ${1}
 	!!
@@ -37,45 +37,45 @@ snippet doxp
 # Variables definitions
 # Boolean
 snippet bool
-	logical :: $0
+	logical :: ${0}
 # Integer
 snippet int
-	integer :: $0
+	integer :: ${0}
 snippet real
-	real :: $0
+	real :: ${0}
 # Double Precision
 snippet double
-	double precision :: $0
+	double precision :: ${0}
 # Char
 snippet str
 	character(len=${1:*}) :: ${0:}
 # Types
 snippet type
 	type(${1:name})
-		$0
+		${0}
 	end type
 snippet const
-	${1:type}, parameter :: $2 = $0
+	${1:type}, parameter :: $2 = ${0}
 snippet arr
-	${1:type}, ${2:allocatable, }dimension(${3::}) :: $0
+	${1:type}, ${2:allocatable, }dimension(${3::}) :: ${0}
 snippet intent
-	${1:type}, intent(inout) :: $0
+	${1:type}, intent(inout) :: ${0}
 # Array
 snippet /
-	(/ $1 /) ${2:,&} $0
+	(/ $1 /) ${2:,&} ${0}
 snippet if
 	if (${1:condition}) then
-		$0
+		${0}
 	end if
 snippet case
 	select case (${1:expr})
 		case ($2)
 		case default
 			$3
-	end select $0
+	end select ${0}
 snippet do
 	do ${1:i} = ${2:start}, ${3:end}, ${4:incr}
-		$0
+		${0}
 	end do
 snippet dow
 	do while (${1:condition})
@@ -83,21 +83,21 @@ snippet dow
 	end do
 snippet sub
 	subroutine ${1:name}($2)
-		$0
+		${0}
 	end subroutine $1
 snippet func
 	function ${1:name}($2) result($3)
-		$0
+		${0}
 	end function $1
 snippet pr
-	write(*,*) $0
+	write(*,*) ${0}
 snippet dpr
 	write(*,*) '$1 = ', $1
 snippet read
-	read(unit = ${1:fp}, file = ${2:filename}, iostat = ${3:ierr}) $0
+	read(unit = ${1:fp}, file = ${2:filename}, iostat = ${3:ierr}) ${0}
 snippet write
-	write(unit = ${1:fp}, file = ${2:filename}, iostat = ${3:ierr}) $0
+	write(unit = ${1:fp}, file = ${2:filename}, iostat = ${3:ierr}) ${0}
 snippet open
-	open(unit = ${1:fp}, file = ${2:filename}, status = ${3:unknown}, iostat = ${4:ierr}) $0
+	open(unit = ${1:fp}, file = ${2:filename}, status = ${3:unknown}, iostat = ${4:ierr}) ${0}
 snippet close
-	close(unit = ${1:fp}) $0
+	close(unit = ${1:fp}) ${0}


### PR DESCRIPTION
all `$0` are changed into `${0}`. the old syntax does not allow auto-jump to the marker.