### PR TITLE
Shell: conform to guidelines (visual, standard triggers)

### DIFF
--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -47,24 +47,24 @@ endsnippet
 snippet case "case .. esac (case)"
 case ${1:word} in
 	${2:pattern} )
-		$0;;
+		${0:${VISUAL}};;
 esac
 endsnippet
 
 snippet elif "elif .. (elif)"
 elif ${2:[[ ${1:condition} ]]}; then
-	${0:#statements}
+	${0:${VISUAL}}
 endsnippet
 
 snippet for "for ... done (for)"
 for (( i = 0; i < ${1:10}; i++ )); do
-	${0:#statements}
+	${0:${VISUAL}}
 done
 endsnippet
 
 snippet forin "for ... in ... done (forin)"
 for ${1:i}${2/.+/ in /}${2:words}; do
-	${0:#statements}
+	${0:${VISUAL}}
 done
 endsnippet
 
@@ -76,19 +76,19 @@ endsnippet
 
 snippet if "if ... then (if)"
 if ${2:[[ ${1:condition} ]]}; then
-	${0:#statements}
+	${0:${VISUAL}}
 fi
 endsnippet
 
 snippet until "until ... (done)"
 until ${2:[[ ${1:condition} ]]}; do
-	${0:#statements}
+	${0:${VISUAL}}
 done
 endsnippet
 
 snippet while "while ... (done)"
 while ${2:[[ ${1:condition} ]]}; do
-	${0:#statements}
+	${0:${VISUAL}}
 done
 endsnippet
 

--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -29,14 +29,14 @@ snippet #! "#!/usr/bin/env (!env)" b
 `!p snip.rv = '#!/usr/bin/env ' + getShell() + "\n" `
 endsnippet
 
-snippet sbash "safe bash options"
+snippet sbash "safe bash options" b
 #!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 `!p snip.rv ='\n\n' `
 endsnippet
 
-snippet temp "Tempfile"
+snippet temp "Tempfile" b
 ${1:TMPFILE}="$(mktemp -t ${3:--suffix=${4:.SUFFIX}} ${2:`!p
 snip.rv = re.sub(r'[^a-zA-Z]', '_', snip.fn) or "untitled"
 `}.XXXXXX)"
@@ -44,25 +44,25 @@ ${5:${6/(.+)/trap "/}${6:rm -f '$${1/.*\s//}'}${6/(.+)/" 0               # EXIT\
 
 endsnippet
 
-snippet /case|sw(itch)?/ "case .. esac (case)" r
+snippet /case|sw(itch)?/ "case .. esac (case)" rb
 case ${1:word} in
 	${2:pattern} )
 		${0:${VISUAL}};;
 esac
 endsnippet
 
-snippet elif "elif .. (elif)"
+snippet elif "elif .. (elif)" b
 elif ${2:[[ ${1:condition} ]]}; then
 	${0:${VISUAL}}
 endsnippet
 
-snippet for "for ... done (for)"
+snippet for "for ... done (for)" b
 for (( i = 0; i < ${1:10}; i++ )); do
 	${0:${VISUAL}}
 done
 endsnippet
 
-snippet forin "for ... in ... done (forin)"
+snippet forin "for ... in ... done (forin)" b
 for ${1:i}${2/.+/ in /}${2:words}; do
 	${0:${VISUAL}}
 done
@@ -74,19 +74,19 @@ snippet here "here document (here)"
 ${1/['"`](.+)['"`]/$1/}
 endsnippet
 
-snippet if "if ... then (if)"
+snippet if "if ... then (if)" b
 if ${2:[[ ${1:condition} ]]}; then
 	${0:${VISUAL}}
 fi
 endsnippet
 
-snippet until "until ... (done)"
+snippet until "until ... (done)" b
 until ${2:[[ ${1:condition} ]]}; do
 	${0:${VISUAL}}
 done
 endsnippet
 
-snippet /wh(ile)?/ "while ... (done)" r
+snippet /wh(ile)?/ "while ... (done)" rb
 while ${2:[[ ${1:condition} ]]}; do
 	${0:${VISUAL}}
 done

--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -86,7 +86,7 @@ until ${2:[[ ${1:condition} ]]}; do
 done
 endsnippet
 
-snippet while "while ... (done)"
+snippet /wh(ile)?/ "while ... (done)" r
 while ${2:[[ ${1:condition} ]]}; do
 	${0:${VISUAL}}
 done

--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -44,7 +44,7 @@ ${5:${6/(.+)/trap "/}${6:rm -f '$${1/.*\s//}'}${6/(.+)/" 0               # EXIT\
 
 endsnippet
 
-snippet case "case .. esac (case)"
+snippet /case|sw(itch)?/ "case .. esac (case)" r
 case ${1:word} in
 	${2:pattern} )
 		${0:${VISUAL}};;


### PR DESCRIPTION
I can move these to separate PRs if desired, but since I was doing everything in one I grouped them together.

Mostly cleanup on shell snippets to conform to the guidelines in README, but also adding 'switch' as a trigger for shell's 'case' (it's equivalent to a switch statement) and making snippets start on one line.

I assume the first two are easy merges. The second two might have objections. If you just want the first half, let me know.