### PR TITLE
Elixir - add piping pry

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -189,10 +189,8 @@ snippet pry
 	require IEx; IEx.pry
 	${0}
 snippet ppry
-	|> (fn x ->
-	  require IEx; IEx.pry
-		x
-	end).()${0}
+	|> (fn x -> require IEx; IEx.pry; x end).()
+	${0}
 snippet qu
 	quote do
 		${1}

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -188,6 +188,12 @@ snippet try try .. rescue .. end
 snippet pry
 	require IEx; IEx.pry
 	${0}
+snippet ppry
+	|> (fn x ->
+				require IEx
+				IEx.pry()
+				x
+			end).()${0}
 snippet qu
 	quote do
 		${1}

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -189,8 +189,7 @@ snippet pry
 	require IEx; IEx.pry
 	${0}
 snippet ppry
-	|> (fn x -> require IEx; IEx.pry; x end).()
-	${0}
+	|> (fn x -> require IEx; IEx.pry; x end).()${0}
 snippet qu
 	quote do
 		${1}

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -190,10 +190,9 @@ snippet pry
 	${0}
 snippet ppry
 	|> (fn x ->
-				require IEx
-				IEx.pry()
-				x
-			end).()${0}
+	  require IEx; IEx.pry
+		x
+	end).()${0}
 snippet qu
 	quote do
 		${1}


### PR DESCRIPTION
Often times I want to be able to conveniently place a `pry` in between pipes without having to assign new variables, add new lines, etc.

The code snippet I've added uses an anonymous function:
```elixir
|> (fn x -> require IEx; IEx.pry; x end).()
```

Example:
```elixir
defmodule Demo do
  def foo do
    1..10
    |> Enum.map(&(&1 * &1))
    |> Enum.filter(&rem(&1, 2) == 0)
    |> (fn x -> require IEx; IEx.pry; x end).()
    |> Enum.take(3)
  end
end
```
```
iex(1)> Demo.foo
Request to pry #PID<0.117.0> at lib/demo.ex:5

      |> (fn x -> require IEx; IEx.pry; x end).()

Allow? [Yn] Y

Interactive Elixir (1.3.2) - press Ctrl+C to exit (type h() ENTER for help)
pry(1)> e
[4, 16, 36, 64, 100]
pry(2)> respawn

Interactive Elixir (1.3.2) - press Ctrl+C to exit (type h() ENTER for help)
[4, 16, 36]
iex(1)>
```
Example taken from: https://riptutorial.com/elixir/example/22384/pry-in-pipe