### PR TITLE
Remove undefined "pipefail" from shell snippet

### DIFF
--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -4,10 +4,10 @@ snippet #!
 
 snippet s#!
 	#!/usr/bin/env sh
-	set -euo pipefail
+	set -eu
 
 snippet safe
-	set -euo pipefail
+	set -eu
 
 snippet bash
 	#!/usr/bin/env bash


### PR DESCRIPTION
For POSIX shells pipefail is undefined.
bash on the other hand has defined pipefail

Reference:

https://github.com/koalaman/shellcheck/wiki/SC2039