### PR TITLE
javascript: Add for and log snippets

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -109,6 +109,20 @@ for`!p snip.rv = keyword_spacing(snip)`(${1:prop} in ${2:obj}){
 }
 endsnippet
 
+snippet for "for loop with index" b
+for`!p snip.rv = keyword_spacing(snip)`(let ${1:i} = 0; $1 < ${2:10}; ++$1)
+{
+	${VISUAL}$0
+}
+endsnippet
+
+snippet fore "for loop over collection" b
+for`!p snip.rv = keyword_spacing(snip)`(${2:entry} in ${1:items})
+{
+	${VISUAL}$0
+}
+endsnippet
+
 snippet if "if (condition) { ... }"
 if`!p snip.rv = keyword_spacing(snip)`(${1:true}) {
 	${VISUAL}$0

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -168,4 +168,8 @@ snippet us
 'use strict'`!p snip.rv = semi(snip)`
 endsnippet
 
+snippet log "Debug print" b
+console.log(${1:"$2"}$3)
+endsnippet
+
 # vim:ft=snippets:


### PR DESCRIPTION
Add a common for loop like other languages.

Add a log snippet like several other languages have (coffeescript, golang, etc). Too bad there isn't a standardized one.

I'm not a js dev, so forgive my ignorance if these are uncommon. I used them for writing some code to paste into Chrome's console.