### PR TITLE
Rust: Fix description of function snippet

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -4,7 +4,7 @@
 
 priority -50
 
-snippet fn "pub fn name(?) -> ? {}"
+snippet fn "fn name(?) -> ? {}"
 fn ${1:function_name}($2)${3/..*/ -> /}$3 {
 	${VISUAL}$0
 }


### PR DESCRIPTION
pfn is the snippet for the public version. Copy paste error.