### PR TITLE
Replace old logging functions in julia by macros

### DIFF
--- a/snippets/julia.snippets
+++ b/snippets/julia.snippets
@@ -89,17 +89,17 @@ snippet thr throw
 	${0}
 
 # Messages
-snippet in
-	info("${1}")
-	${0}
+snippet @i
+	@info "${1}" ${0}
 
-snippet wa
-	warn("${1}")
-	${0}
+snippet @w
+	@warn "${1}" ${0}
 
-snippet err
-	error("${1}")
-	${0}
+snippet @e
+	@error "${1}" ${0}
+	
+snippet @d
+	@debug "${1}" ${0}
 
 snippet @t @testset with @test 
 	@testset "${1}" begin


### PR DESCRIPTION
move cursor at the end of line to enable to add variables in the log
ref https://docs.julialang.org/en/v1/stdlib/Logging/