### PR TITLE
tex.snippets: generalize \begin snippet

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -44,7 +44,7 @@ def add_row(snip):
 
 endglobal
 
-snippet "b(egin)?" "begin{} / end{}" br
+snippet "\\?b(egin)?" "begin{} / end{}" br
 \begin{${1:something}}
 	${0:${VISUAL}}
 \end{$1}


### PR DESCRIPTION
I tend to type a true prefix `\b` or `\begin` before I think to hit the autocomplete button, and this change supports that while still allowing the old behavior.

I've been using this minor modification for a while now and haven't run into any issues.

Let me know if this works, or if I should modify the PR in any way. Thanks!