### PR TITLE
haskell: removed repeated whitespaces

### DIFF
--- a/snippets/haskell.snippets
+++ b/snippets/haskell.snippets
@@ -21,9 +21,9 @@ snippet info
 snippet imp
 	import ${0:Data.Text}
 snippet import
-	import           ${0:Data.Text}
+	import ${0:Data.Text}
 snippet import2
-	import           ${1:Data.Text} (${0:head})
+	import ${1:Data.Text} (${0:head})
 snippet impq
 	import qualified ${1:Data.Text} as ${0:T}
 snippet importq


### PR DESCRIPTION
Whitespaces were used to make the snippet code look prettier and aligned, but this introduces actual whitespace when the snippets are expanded.