### PR TITLE
Add snippets for async functions in Rust

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -16,6 +16,18 @@ pub fn ${1:function_name}($2)${3/..*/ -> /}$3 {
 }
 endsnippet
 
+snippet afn "async fn name(?) -> ? {}"
+fn ${1:function_name}($2)${3/..*/ -> /}$3 {
+	${VISUAL}$0
+}
+endsnippet
+
+snippet pafn "pub async fn name(?) -> ? {}"
+pub fn ${1:function_name}($2)${3/..*/ -> /}$3 {
+	${VISUAL}$0
+}
+endsnippet
+
 snippet pri "print!(..)" b
 print!("$1"${2/..*/, /}$2);
 endsnippet

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -11,6 +11,14 @@ snippet pfn "Function definition"
 	pub fn ${1:function_name}(${2})${3} {
 		${0}
 	}
+snippet afn "Async function definition"
+	async fn ${1:function_name}(${2})${3} {
+		${0}
+	}
+snippet pafn "Async function definition"
+	pub async fn ${1:function_name}(${2})${3} {
+		${0}
+	}
 snippet bench "Bench function" b
 	#[bench]
 	fn ${1:bench_function_name}(b: &mut test::Bencher) {


### PR DESCRIPTION
Most methods of function declaration are already in the snippets. This adds the now-stabilized `async fn` syntax, for both `pub fn` and `fn`.