### PR TITLE
Improve/add some Rust snippets

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -122,6 +122,10 @@ snippet ife "if / else"
 	} else {
 		${0}
 	}
+snippet ifl "if let (...)"
+	if let ${1:Some(${2})} = $3 {
+		${0:${VISUAL}}
+	}
 snippet el "else"
 	else {
 		${0:${VISUAL}}
@@ -144,6 +148,10 @@ snippet loop "loop {}" b
 	}
 snippet wh "while loop"
 	while ${1:condition} {
+		${0:${VISUAL}}
+	}
+snippet whl "while let (...)"
+	while let ${1:Some(${2})} = $3 {
 		${0:${VISUAL}}
 	}
 snippet for "for ... in ... loop"

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -165,21 +165,21 @@ snippet fixme "FIXME comment"
 	// FIXME: $0
 # Struct
 snippet st "Struct definition"
-	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
+	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`}${2:<${3:T}>} {
 		${0}
 	}
 snippet impl "Struct/Trait implementation"
-	impl ${1:Type/Trait}${2: for ${3:Type}} {
+	impl$4 ${1:Type/Trait}${2: for ${3:Type}}${4:<${5:T}>} {
 		${0}
 	}
 snippet stn "Struct with new constructor"
-	pub struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
+	pub struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`}${2:<${3:T}>} {
 		${0}
 	}
 
-	impl $1 {
-		pub fn new(${2}) -> Self {
-			$1 { ${3} }
+	impl$2 $1$2 {
+		pub fn new(${4}) -> Self {
+			$1 { ${5} }
 		}
 	}
 snippet ty "Type alias"
@@ -198,7 +198,7 @@ snippet trait "Trait definition"
 		${0}
 	}
 snippet drop "Drop trait implementation (destructor)"
-	impl Drop for ${1:Name} {
+	impl$2 Drop for ${1:Name}${2:<${3:T}>} {
 		fn drop(&mut self) {
 			${0}
 		}

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -238,7 +238,7 @@ snippet macro "macro_rules!" b
 			$3
 		)
 	}
-snippet box "Box::new()"
+snippet boxp "Box::new()"
 	Box::new(${0:${VISUAL}})
 snippet rc "Rc::new()"
 	Rc::new(${0:${VISUAL}})

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -252,3 +252,5 @@ snippet rc "Rc::new()"
 	Rc::new(${0:${VISUAL}})
 snippet unim "unimplemented!()"
 	unimplemented!()
+snippet use "use ...;" b
+	use ${1:std::${2:io}};


### PR DESCRIPTION
- I added a final `p` to the `box` snippet which was overshadowed by the global `box` snippet, as I reported in issue #1227.
- `if let (...)`,  `while let (...)` and `use` are fairly common constructs in Rust, so I added snippets for those.
- Snippets that expand to `struct` and `trait` definitions I found are a bit inconvenient to use when there are generic types involved, because you'd need to go back and add them where needed, which in a way takes away those time savings you want when using a snippet, imo. This is especially a problem in Rust where you need to specify the generic type in more than one spot. For that reason, I added an additional tab stop that the user can quickly delete and move on if a generic type is not needed at all and, if inserted, it will be duplicated everywhere.

I've been testing those snippets for a few days and they seem to work for me. I copy-pasted them to make this PR but haven't tested them. They should work but let me if there's a copy-paste error somewhere.