### PR TITLE
add snippet for gitcommit co-author directive

### DIFF
--- a/snippets/gitcommit.snippets
+++ b/snippets/gitcommit.snippets
@@ -1,0 +1,2 @@
+snippet co
+	Co-authored-by: ${1} <${2}>


### PR DESCRIPTION
This directive will make the commit display as having multiple authors in github.

https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors