### PR TITLE
Eliminate Python encoding error on every startup

### DIFF
--- a/pythonx/vimsnippets.py
+++ b/pythonx/vimsnippets.py
@@ -1,3 +1,5 @@
+# vim:set et fileencoding=utf8 sts=0 sw=4 ts=4:
+
 """Helper methods used in UltiSnips snippets."""
 
 import string, vim, re
@@ -114,5 +116,3 @@ def has_cjk(s):
     cjk_re = re.compile(u'[⺀-⺙⺛-⻳⼀-⿕々〇〡-〩〸-〺〻㐀-䶵一-鿃豈-鶴侮-頻並-龎]', re.UNICODE)
 
     return cjk_re.search(s) is not None
-
-# vim:set et sts=0 sw=4 ts=4:


### PR DESCRIPTION
Because `pythonx/vimsnippets.py` lacks a magic comment declaring the file encoding compliant with [PEP 263](https://www.python.org/dev/peps/pep-0263/), I've been seeing the following `SyntaxError` interrupt my flow every single time I open the editor.

```
[coc.nvim] Error on execute python script: request error nvim_command - Vim(return):Error invoking 'python_execute_file' on channel 4 (python2-script-host):
Traceback (most recent call last):
  File "/var/folders/dg/cqpqw4cd2vx68kl1rw6cgs8h0000gn/T/coc.nvim-49796/coc-ultisnips-NFLbThHae1.py", line 286, in <module>
    from vimsnippets import foldmarker, make_box, get_comment_format
  File "/usr/local/lib/python2.7/site-packages/pynvim/plugin/script_host.py", line 235,
in load_module
    return imp.load_module(fullname, *self.module)
  File "/Users/eyalkalderon/.config/nvim/plugged/vim-snippets/pythonx/vimsnippets.py", line 114
SyntaxError: Non-ASCII character '\xe2' in file /Users/eyalkalderon/.config/nvim/plugged/vim-snippets/pythonx/vimsnippets.py on line 114, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

Adding the necessary magic comment to the file and putting it at the top instead of the bottom thankfully silences the error.

Also, the problematic lines of Python which trigger this error seem to be [copied verbatim from StackOverflow](https://stackoverflow.com/a/2718268). In the posted solution, they include the magic comment, but this file does not.