### PR TITLE
Elixir: Fix mirror of `defsd`, add `defs`

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -92,12 +92,17 @@ snippet defd
 	def ${2:name} do
 		${0}
 	end
+snippet defs
+	@spec ${1:name}(${2:arg types}) :: ${3:no_return}
+	def $1(${4:args}) do
+		${0}
+	end
 snippet defsd
 	@doc """
 	${1:doc string}
 	"""
-	@spec ${2:name} :: ${3:no_return}
-	def ${2} do
+	@spec ${2:name}(${3:arg types}) :: ${4:no_return}
+	def $2(${5:args}) do
 		${0}
 	end
 snippet defim


### PR DESCRIPTION
Mirror is not using braces, so it's `$1` not `${1}` (at least for UltiSnips, but SnipMate supports this syntax too https://github.com/garbas/vim-snipmate/blob/master/doc/SnipMate.txt#L379).

Seems like this is a feature and not a bug of UltiSnips (https://github.com/SirVer/ultisnips/issues/875, https://github.com/SirVer/ultisnips/issues/875).

Also, arguments and argument types aren't the same, so are not shared, unlike `name`.

I have also added a `defs` which hasn't got the docstring, but is otherwise the same as `defsd`. Perhaps I should always use a docstring, but sometimes I feel the name of the function is descriptive enough.