### PR TITLE
Remove nested snippets from snipMate snippets

### DIFF
--- a/UltiSnips/rust.snippets
+++ b/UltiSnips/rust.snippets
@@ -45,8 +45,8 @@ snippet .it ".iter()" i
 endsnippet
 
 snippet impl "Struct/Trait implementation" b
-impl ${1:Type/Trait}${2: for ${3:Type}} {
-	$0
+impl$4 ${1:Type/Trait}${2: for ${3:Type}}${4:<${5:T}>} {
+	${0}
 }
 endsnippet
 

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -123,7 +123,7 @@ snippet ife "if / else"
 		${0}
 	}
 snippet ifl "if let (...)"
-	if let ${1:Some(${2})} = $3 {
+	if let ${1:Some($2)} = $3 {
 		${0:${VISUAL}}
 	}
 snippet el "else"
@@ -151,7 +151,7 @@ snippet wh "while loop"
 		${0:${VISUAL}}
 	}
 snippet whl "while let (...)"
-	while let ${1:Some(${2})} = $3 {
+	while let ${1:Some($2)} = $3 {
 		${0:${VISUAL}}
 	}
 snippet for "for ... in ... loop"
@@ -165,15 +165,15 @@ snippet fixme "FIXME comment"
 	// FIXME: $0
 # Struct
 snippet st "Struct definition"
-	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`}${2:<${3:T}>} {
+	struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
 		${0}
 	}
 snippet impl "Struct/Trait implementation"
-	impl$4 ${1:Type/Trait}${2: for ${3:Type}}${4:<${5:T}>} {
+	impl ${1:Type/Trait}${2: for $3} {
 		${0}
 	}
 snippet stn "Struct with new constructor"
-	pub struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`}${2:<${3:T}>} {
+	pub struct ${1:`substitute(vim_snippets#Filename(), '\(_\|^\)\(.\)', '\u\2', 'g')`} {
 		${0}
 	}
 
@@ -198,7 +198,7 @@ snippet trait "Trait definition"
 		${0}
 	}
 snippet drop "Drop trait implementation (destructor)"
-	impl$2 Drop for ${1:Name}${2:<${3:T}>} {
+	impl Drop for $1 {
 		fn drop(&mut self) {
 			${0}
 		}
@@ -253,4 +253,4 @@ snippet rc "Rc::new()"
 snippet unim "unimplemented!()"
 	unimplemented!()
 snippet use "use ...;" b
-	use ${1:std::${2:io}};
+	use ${1:std::$2};


### PR DESCRIPTION
snipMate doesn't seem to support them so they're incorrectly expanded. Attaching some screenshots below:

![if_let](https://user-images.githubusercontent.com/28014843/89095967-c5012180-d3d2-11ea-8a82-4ea1d4b386e9.png)

![drop](https://user-images.githubusercontent.com/28014843/89095966-c4688b00-d3d2-11ea-9d19-62ecd17fc26e.png)