### PR TITLE
Update django snippet

### DIFF
--- a/UltiSnips/django.snippets
+++ b/UltiSnips/django.snippets
@@ -148,7 +148,6 @@ class ${1:MODELNAME}(models.Model):
 	def save(self):
 		return super($1, self).save()
 
-	@models.permalink
 	def get_absolute_url(self):
 		return ('')
 


### PR DESCRIPTION
removed reference to models.permalink decorator as it removed from Django 2.1 as per https://docs.djangoproject.com/en/2.2/releases/2.1/

While using running the code generated from the snippet, I encountered the below error. 
```
AttributeError: module 'django.db.models' has no attribute 'permalink'
```

