### PR TITLE
[FIX] Tex conflicting snippets for `it`

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -246,7 +246,7 @@ snippet bf "Bold"
 endsnippet
 
 # Italic text
-snippet it "Italics"
+snippet ita "Italics"
 \textit{$1} $0
 endsnippet
 


### PR DESCRIPTION
The `it` snippet was already used for `/item`. PR #1243 reused it for italics, leading to a conflict.
This PR uses `ita` for italics, as it is already the case in  [/snippets/tex.snippets](https://github.com/honza/vim-snippets/blob/master/snippets/tex.snippets).