### PR TITLE
Auto set author's info get from git config

### DIFF
--- a/plugin/vimsnippets.vim
+++ b/plugin/vimsnippets.vim
@@ -4,15 +4,21 @@ endif
 let b:done_vimsnippets = 1
 
 " Some variables need default value
-if !exists("g:snips_author")
+if !exists("g:snips_author") && executable('git')
+    let g:snips_author = trim(system('git config --global user.name'))
+elseif
     let g:snips_author = "yourname"
 endif
 
-if !exists("g:snips_email")
+if !exists("g:snips_email") && executable('git')
+    let g:snips_email = trim(system('git config --global user.email'))
+elseif
     let g:snips_email = "yourname@email.com"
 endif
 
-if !exists("g:snips_github")
+if !exists("g:snips_github") && executable('git')
+    let g:snips_github = trim("https://github.com/" . system("git config --global user.name"))
+elseif
     let g:snips_github = "https://github.com/yourname"
 endif
 


### PR DESCRIPTION
Set author, email and GitHub address automatically from git config.
Resolves #1230.