### PR TITLE
haskell: pre- and post- dot tabstops on import directives

### DIFF
--- a/UltiSnips/haskell.snippets
+++ b/UltiSnips/haskell.snippets
@@ -1,5 +1,13 @@
 priority -50
 
+snippet imp "Simple import"
+import ${1:${2:Data}.${0:Text}}
+endsnippet
+
+snippet imp2 "Selective import" b
+import ${1:${2:Data}.${3:Text}} (${4})${0}
+endsnippet
+
 snippet impq "Qualified import"
-import qualified ${1:Data.Text} as ${0:`!p snip.rv = t[1].split(".")[-1]`}
+import qualified ${1:${2:Data}.${3:Text}} as ${0:`!p snip.rv = t[1].split(".")[-1]`}
 endsnippet


### PR DESCRIPTION
`Data.Text` is only one of the several modules which we want to import/import from/import with a different name, therefore this PR 
  - modifies the `imp` UltiSnips snippet to that two other placeolders are added for the text before and after the dot
  - adds the `imp` with similar logic for the simple import
  - add `imp2` as well, but since the last argument/tabstop is between parenthesis, the final tabstop is placed after the parenthesis.

Let me know if you like it.