### PR TITLE
Do not call external processes during plugin initialization (revert PR #1252)

### DIFF
--- a/plugin/vimsnippets.vim
+++ b/plugin/vimsnippets.vim
@@ -4,38 +4,17 @@ endif
 let b:done_vimsnippets = 1
 
 " Some variables need default value
-let s:has_git = executable('git')
-
 if !exists("g:snips_author")
-    if s:has_git
-        let s:author = substitute(system('git config --global user.name'), '\n', '', 'g')
-        if s:author == ''
-            let g:snips_author = "yourname"
-        else
-            let g:snips_author = s:author
-        endif
-    else
-        let g:snips_author = "yourname"
-    endif
+    let g:snips_author = "yourname"
 endif
 
 if !exists("g:snips_email")
-    if s:has_git
-        let s:email = substitute(system('git config --global user.email'), '\n', '', 'g')
-        if s:email == ''
-            let g:snips_email = "yourname@email.com"
-        else
-            let g:snips_email = s:email
-        endif
-    else
-        let g:snips_email = "yourname@email.com"
-    endif
+    let g:snips_email = "yourname@email.com"
 endif
 
 if !exists("g:snips_github")
-    let g:snips_github = "https://github.com/" . g:snips_author
+    let g:snips_github = "https://github.com/yourname"
 endif
-
 
 " Expanding the path is not needed on Vim 7.4
 if &cp || version >= 704


### PR DESCRIPTION
This reverts the status of `vimsnippets.vim` to what it was before PR #1252 tried to do something smart for a limited use-case and just ended up increasing the startup time of the plugin by orders of magnitude. Fixes #1267.

Please do not force everybody to have two `system()` calls every time Vim starts, having us to opt-out of it instead of been opt-in variables as before.

The plugin was just ridiculously fast:

    000.046  000.046: sourcing .../vim-snippets/plugin/vimsnippets.vim

And now I have almost extra 40 ms of startup time:

    039.083  039.083: sourcing .../vim-snippets/plugin/vimsnippets.vim

More than **800x** increase, takes a fifth of the startup time now (having almost 50 plugins) and it takes more than 2.5 longer than any other plugin. And some people are having it much worse as reported by #1267 or 06fbadd9b3c8e4be1e1343addb51cd0582c047f7.

A lot of us care about our Vim startup time, and having `system()` calls in a `<rtp>/plugin/*.vim` file has a really bad effect in the startup time. And this plugin is a collection of snippets, it should try to do the least possible when loading.

Regarding those variables, and guessing that most users want the UltiSnips snippets from this repo, they are far from being widely used:

```
$ rg 'g:snips_' UltiSnips
UltiSnips/javascript-jsdoc.snippets
12:@author ${1:`!v g:snips_author`} [${2:`!v g:snips_author_email`}]

UltiSnips/php-laravel.snippets
6: * \author      ${3:`!v g:snips_author`}
45: * \author      ${3:`!v g:snips_author`}
73: * \author      ${4:`!v g:snips_author`}
113: * \author      ${3:`!v g:snips_author`}
139: * \author      ${4:`!v g:snips_author`}
207: * \author      ${5:`!v g:snips_author`}
226: * \author      ${6:`!v g:snips_author`}
254: * \author      ${5:`!v g:snips_author`}

UltiSnips/php-symfony2.snippets
17: * ${1:@author `!v g:snips_author`}
47: * ${1:@author `!v g:snips_author`}
111: * ${3:@author `!v g:snips_author`}
146: * ${1:@author `!v g:snips_author`}
180: * ${3:@author `!v g:snips_author`}
215: * ${3:@author `!v g:snips_author`}
256: * ${2:@author `!v g:snips_author`}
300: * ${2:@author `!v g:snips_author`}

UltiSnips/pandoc.snippets
8:% ${2:`!v g:snips_author`}

UltiSnips/php.snippets
179: * @author ${2:`!v g:snips_author`}
198: * @author ${2:`!v g:snips_author`}
218: * @author ${2:`!v g:snips_author`}
247: * @author `!v g:snips_author`
273: * @author `!v g:snips_author`

UltiSnips/all.snippets
103:`!p snip.rv=get_comment_format()[0]` ${2:TODO}: $0${3: <${4:`!v strftime('%d-%m-%y')`}${5:, `!v g:snips_author`}>} `!p snip.rv=get_comment_format()[2]`

UltiSnips/php-phpspec.snippets
20: * @author `!v g:snips_author`
```

And then mostly used in snipMate global snippets for licenses. Which again doesn't justify increasing the startup time for everyone. I would say they are barely used or even noticed by most people.

And I am sorry, but PR #1252 should have never been merged in the first place, based on the merit of the patch itself. It has required 5 extra commits just to try to make it right: 5b5cc3650a062c180f0c3861c5f1c8030c27dfd3, 06fbadd9b3c8e4be1e1343addb51cd0582c047f7, db91ad48017e51e6b323fe1a7fac36626689b2fd, a0441888b7a1e7ef8ab8b309d6c5c314d53096df, 730443a98e9bfa8709ed51a355f17a9ce86a9fb4, but there is no making it right if those `system()` calls are still executed on startup.

If somebody really cares about having these variables automatically set from Git then they should create a PR moving those variables into autoload functions, and editing all snippets that depend on them, or some other better solution. But these variables have been just fine since the initial commit, for almost 10 years now (probably more), and then it took around 4 years for somebody to notice that they needed a default value. I am pretty sure that this repo can live without PR #1252 a bit longer, and our startup times will not need to be affected.
