### PR TITLE
C++: a modern for loop

### DIFF
--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -30,6 +30,12 @@ endglobal
 ###########################################################################
 #                            TextMate Snippets                            #
 ###########################################################################
+snippet forc "general for loop (for)"
+for (${6:auto} ${1:i} = ${2:v.begin()}; `!p snip.rv = t[1].split(" ")[-1]` ${4:!=} ${3:`!p snip.rv = t[2].split(".")[0]`.end()}; ${5:++`!p snip.rv = t[1].split(" ")[-1]`}) {
+	${VISUAL}$0
+}
+endsnippet
+
 snippet beginend "$1.begin(), $1.end() (beginend)"
 ${1:v}${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}begin(), $1${1/^.*?(-)?(>)?$/(?2::(?1:>:.))/}end()
 endsnippet


### PR DESCRIPTION
In modern C++, the non-range `for` loop is usually used to loop on containers or sub-ranges, given a `begin` and `end` iterators.

My choice of the order of the tabstops and their defaults relies on the fact that imho we usually want to

  1. declare a local variable,
  2. that goes from one value, often the beginning of a container,
  3. to another value, often the end of the same container;

and on the fact that

  4. for reusability (e.g. with other containers), we most often rely on `!=` for the end condition of the loop, rather than `<`;
  5. most often pre-increment is the way to go;
  6. almost always `auto` is also the way to go.

I was unsure about two points:

  - maybe I should include the trailing space after `auto` in the tabstop, so it's easier to delete `auto` together with the space if the loop variable is declared before the for loop;
  - for reusability, maybe the defaults for the beginning and end should be `std::begin(v)` instead of `v.begin()` and similarly for `end`.

Any feedback is welcome. Oh, I've made a screencast:

[![asciicast](https://asciinema.org/a/1FDbcC9m723RvdWdutuyS3c54.svg)](https://asciinema.org/a/1FDbcC9m723RvdWdutuyS3c54)