### PR TITLE
created public/private/protected field snippet for typescript

### DIFF
--- a/snippets/typescript.snippets
+++ b/snippets/typescript.snippets
@@ -31,6 +31,10 @@ snippet tpmet "ts public method"
 	public ${1}(${2}): ${3:any} {
 		${0}
 	}
+snippet tpsmet "ts public static method"
+	public static ${1}(${2}): ${3:any} {
+		${0}
+	}
 snippet tprmet "ts private method"
 	private ${1}(${2}): ${3:any} {
 		${0}

--- a/snippets/typescript.snippets
+++ b/snippets/typescript.snippets
@@ -13,6 +13,12 @@ snippet + "ts create field"
 	${1}: ${0:any}
 snippet #+ "ts create private field using #"
 	#${1}: ${0:any}
+snippet tpfi "ts create public field"
+	public ${1}: ${0:any}
+snippet tprfi "ts create private field"
+	private ${1}: ${0:any}
+snippet tprofi "ts create protected field"
+	protected ${1}: ${0:any}
 snippet int "interface"
 	interface ${1} {
 		${2}: ${3:any};


### PR DESCRIPTION
I used the "fi" suffix for the word field. It does not conflict with existing snippets either.