### PR TITLE
Update Ocaml documentation and comment snippets

### DIFF
--- a/snippets/ocaml.snippets
+++ b/snippets/ocaml.snippets
@@ -1,7 +1,7 @@
 snippet doc
-	(*
-		${0}
-	 *)
+	(** ${0} *)
+snippet comment
+	(* ${0} *)
 snippet let
 	let ${1} = ${2} in
 	${0}


### PR DESCRIPTION
According to the official Ocaml documentation guideline, documentations should be wrapped in `(**` and `*)` whereas comments should be wrapped in `(*` and `*)`: https://ocamlverse.github.io/content/documentation_guidelines.html