### PR TITLE
Fix error when using box snippet in HTML

### DIFF
--- a/pythonx/vimsnippets.py
+++ b/pythonx/vimsnippets.py
@@ -84,12 +84,13 @@ def get_comment_format():
 
 def make_box(twidth, bwidth=None):
     b, m, e, i = (s.strip() for s in get_comment_format())
+    m0 = m[0] if m else ''
     bwidth_inner = bwidth - 3 - max(len(b), len(i + e)) if bwidth else twidth + 2
-    sline = b + m + bwidth_inner * m[0] + 2 * m[0]
+    sline = b + m + bwidth_inner * m0 + 2 * m0
     nspaces = (bwidth_inner - twidth) // 2
     mlines = i + m + " " + " " * nspaces
     mlinee = " " + " "*(bwidth_inner - twidth - nspaces) + m
-    eline = i + m + bwidth_inner * m[0] + 2 * m[0] + e
+    eline = i + m + bwidth_inner * m0 + 2 * m0 + e
     return sline, mlines, mlinee, eline
 
 def foldmarker():


### PR DESCRIPTION
Previously expanding the `box` snippet in an HTML file raised the following error:
```python
Following is the full stack trace:
Traceback (most recent call last):
    ... 
    sline = b + m + bwidth_inner * m[0] + 2 * m[0]
IndexError: string index out of range
```

This is because `comments` is `s:<!--,m:    ,e:-->`, and `make_box` strips whitespace so `m` is an empty string. The proposed fix now makes a box like:
```html
<!--
  content
-->
```
which is pretty ugly, but I'm not sure how to do better without making a special case for HTML.