### PR TITLE
Rust: Remove "thread::scoped" snippet

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -209,10 +209,6 @@ snippet ss "static string declaration"
 snippet stat "static item declaration"
 	static ${1}: ${2:usize} = ${0};
 # Concurrency
-snippet scoped "spawn a scoped thread"
-	thread::scoped(${1:move }|| {
-		${0}
-	});
 snippet spawn "spawn a thread"
 	thread::spawn(${1:move }|| {
 		${0}


### PR DESCRIPTION
`thread::scoped` no longer exists.