### PR TITLE
Vim: remove useless comment from `au` snippet

### DIFF
--- a/snippets/vim.snippets
+++ b/snippets/vim.snippets
@@ -43,7 +43,6 @@ snippet ife if ... else statement
 	endif
 snippet au augroup ... autocmd block
 	augroup ${1:AU_NAME}
-		" this one is which you're most likely to use?
 		autocmd ${2:BufRead,BufNewFile} ${3:*.ext,*.ext3|<buffer[=N]>} ${0}
 	augroup end
 snippet bun Vundle.vim Plugin definition


### PR DESCRIPTION
I don't know where this comment comes from, nor what it is for, but I bet it's completely useless.