### PR TITLE
Fix snipmate/java-snippets "find" snippets

### DIFF
--- a/snippets/java.snippets
+++ b/snippets/java.snippets
@@ -175,9 +175,9 @@ snippet tryf
 ##
 ## Find Methods
 snippet findall
-	List<${1:listName}> ${2:items} = ${1}.findAll();
+	List<${1:listName}> ${2:items} = $1.findAll();
 snippet findbyid
-	${1:var} ${2:item} = ${1}.findById(${3});
+	${1:var} ${2:item} = $1.findById(${3});
 ##
 ## Javadocs
 snippet /**


### PR DESCRIPTION
Fix an issue where some snippets would not work as intended due to erroneous braces, i.e.: ${1} instead of $1.

This pull request fixes issue #1282.