### PR TITLE
Remove the charset="utf-8" attribute of <script>

### DIFF
--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -709,7 +709,7 @@ snippet samp
 		${0}
 	</samp>
 snippet script
-	<script charset="utf-8">
+	<script>
 		${0}
 	</script>
 snippet scripts


### PR DESCRIPTION
According to <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-charset> using `charset` is deprecated and useless.