### PR TITLE
C++: improved modern for loop

### DIFF
--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -31,7 +31,7 @@ endglobal
 #                            TextMate Snippets                            #
 ###########################################################################
 snippet forc "general for loop (for)"
-for (${6:auto} ${1:i} = ${2:v.begin()}; `!p snip.rv = t[1].split(" ")[-1]` ${4:!=} ${3:`!p snip.rv = t[2].split(".")[0]`.end()}; ${5:++`!p snip.rv = t[1].split(" ")[-1]`}) {
+for (${6:auto} ${1:i} = ${2:v.begin()}; `!p import re; snip.rv = re.split("[^\w]",t[1])[-1]` ${4:!=} ${3:`!p m = re.search(r'^(?:(.*)(\.|->)begin\(\)|((?:std|boost)::)?begin\((.*)\))$', t[2]); snip.rv = (((m.group(3) if m.group(3) else "") + "end(" + m.group(4) + ")") if m.group(4) else (m.group(1) + m.group(2) + "end()")) if m else ""`}; ${5:++`!p snip.rv = t[1].split(" ")[-1]`}) {
 	${VISUAL}$0
 }
 endsnippet


### PR DESCRIPTION
As a follow up to #1275, I've improved the snippet in such a way that it automatically generates the _condition_ for _init-statement_ matching these forms (see the demo below)

  - `begin(whatever)`,
  - `std::begin(whatever)`,
  - `boost::begin(whatever)`,
  - `whatever.begin()`,
  - `whatever->begin()`.

If this PR is merged, in the future I plan to make another (possibly last) improvement to handle a backward loop (as in, if you enter an `end`-like thing in the _init-statement_, then the condition adapts to the corresponding `begin`).

[![asciicast](https://asciinema.org/a/EQ6kENjat6yp3vlsypFPJNAGt.svg)](https://asciinema.org/a/EQ6kENjat6yp3vlsypFPJNAGt)