### PR TITLE
datetime snippet with utc offset

### DIFF
--- a/snippets/_.snippets
+++ b/snippets/_.snippets
@@ -13,6 +13,8 @@ snippet time
 	`strftime("%H:%M")`
 snippet datetime
 	`strftime("%Y-%m-%d %H:%M")`
+snippet utcoffset
+	`strftime("%Y-%m-%d %H:%M:%S %z")`
 snippet lorem
 	Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 snippet GPL2


### PR DESCRIPTION
For convenience, here's a datetime snippet that conforms with what Jekyll expects in its front matter. 
https://jekyllrb.com/docs/front-matter/