### PR TITLE
Add documentclass snippet with and without options

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -1,5 +1,11 @@
 #version 1
 #PREAMBLE
+#documentclass without options
+snippet dcl \documentclass{}
+	\\documentclass{${1:class}} ${0}
+#documentclass with options
+snippet dclo \documentclass[]{}
+	\\documentclass[${1:options}]{${2:class}} ${0}
 #newcommand
 snippet nc \newcommand
 	\\newcommand{\\${1:cmd}}[${2:opt}]{${3:realcmd}} ${0}


### PR DESCRIPTION
Whit options: dclo -> \documentclass[options]{class}
Whitout options: dcl -> \documentclass{class}