### PR TITLE
Create snippets for puppet: type alias, lambda, lookup and trocla

### DIFF
--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -8,11 +8,13 @@ global !p
 import vim
 import os.path
 def get_module_namespace_and_basename():
-	"""This function will try to guess the current class or define name you are
-	trying to create. Note that for this to work you should be using the module
-	structure as per the style guide. Examples inputs and it's output
+	"""This function will try to guess the current class, define or type
+	name you are trying to create. Note that for this to work you should be
+	using the module structure as per the style guide. Examples inputs and
+	it's output
 	* /home/nikolavp/puppet/modules/collectd/manifests/init.pp -> collectd
-	* /home/nikolavp/puppet/modules/collectd/manfistes/mysql.pp -> collectd::mysql
+	* /home/nikolavp/puppet/modules/collectd/manifests/mysql.pp -> collectd::mysql
+	* /home/nikolavp/puppet/modules/collectd/types/dbname.pp -> Collectd::Dbname
 	"""
 	first_time = True
 	current_file_path_without_ext = vim.eval('expand("%:p:r")') or ""
@@ -25,8 +27,12 @@ def get_module_namespace_and_basename():
 			first_time = False
 			parts = os.path.split(parts[0])
 			continue
-		if parts[1] == 'manifests':
-			return os.path.split(parts[0])[1] + ('::' + namespace).rstrip(':')
+		if parts[1] in ['manifests', 'types']:
+			parsed_name = os.path.split(
+				parts[0])[1] + ('::' + namespace).rstrip(':')
+			if parts[1] == 'types':
+				parsed_name = parsed_name.title()
+			return parsed_name
 		else:
 			namespace = parts[1] + '::' + namespace
 		parts = os.path.split(parts[0])
@@ -49,6 +55,10 @@ snippet define "Definition" b
 define ${1:`!p snip.rv = get_module_namespace_and_basename()`} {
 	${0:# body}
 }
+endsnippet
+
+snippet type "Data type alias" b
+type ${1:`!p snip.rv = get_module_namespace_and_basename()`} = ${2:Type}
 endsnippet
 
 #################################################################

--- a/UltiSnips/puppet.snippets
+++ b/UltiSnips/puppet.snippets
@@ -61,6 +61,12 @@ snippet type "Data type alias" b
 type ${1:`!p snip.rv = get_module_namespace_and_basename()`} = ${2:Type}
 endsnippet
 
+snippet lambda "Lambda function chain-called on a variable"
+$${1:varname}.${2:each} |${3:Type} $${4:param}| {
+	$0
+}
+endsnippet
+
 #################################################################
 #  Puppet Types                                                 #
 #    See http://docs.puppetlabs.com/references/latest/type.html #
@@ -205,6 +211,14 @@ endsnippet
 
 snippet hiera_include "Hiera Include Function" b
 hiera_include("${1:Lookup}")$0
+endsnippet
+
+snippet lookup "Lookup data from hiera"
+$${1:varname} = lookup('${2:hiera::key}')$0
+endsnippet
+
+snippet trocla "Lookup or generate sensitive information"
+trocla('${1:lookup_key}', '${2:plain}', ${3:'length: 32'})$0
 endsnippet
 
 snippet include "Include Function" b


### PR DESCRIPTION
These are convenience methods for some of the puppet syntax that's been added since the snippets were created.

The lambda snippet defaults to `each` since it's the most commonly called lambda, but it can be used for any other like map, filter and reduce.

The trocla function is not built into puppet but it is a convenient tool for automating management of certain passwords and other types of sensitive material. It differs from the more commonly used hiera-eyaml in that sensitive data is generated during puppet runs if missing and can be refreshed after some time has elapsed, providing automatic password rotation.