### PR TITLE
`END` to close an `augroup` should be capitalized

### DIFF
--- a/snippets/vim.snippets
+++ b/snippets/vim.snippets
@@ -44,7 +44,7 @@ snippet ife if ... else statement
 snippet au augroup ... autocmd block
 	augroup ${1:AU_NAME}
 		autocmd ${2:BufRead,BufNewFile} ${3:*.ext,*.ext3|<buffer[=N]>} ${0}
-	augroup end
+	augroup END
 snippet bun Vundle.vim Plugin definition
 	Plugin '${0}'
 snippet plug vim-plug Plugin definition


### PR DESCRIPTION
`:h :aug` for reference.

I discovered this because I was not able to jump between beginning and end of an auto group.