### PR TITLE
lua: Add assert

### DIFF
--- a/UltiSnips/lua.snippets
+++ b/UltiSnips/lua.snippets
@@ -8,6 +8,15 @@ snippet #! "#!/usr/bin/env lua" b
 $0
 endsnippet
 
+snippet assert "Assertion" b
+assert(${1:condition}`!p
+if t[2]:
+	snip.rv = ", "
+else:
+	snip.rv = ""
+`${2:msg})
+endsnippet
+
 snippet !fun(ction)?! "New function" br
 function ${1:new_function}(${2:args})
 	$0


### PR DESCRIPTION
Standard lua assert message. Same in [lua5.1](https://www.lua.org/manual/5.1/manual.html#pdf-assert)  as [lua5.4](https://www.lua.org/manual/5.4/manual.html#pdf-assert) 

msg is optional, so hide the ", " if it's omitted.