### PR TITLE
Add the 'autocmd!' command to clean the autocmd in the group

### DIFF
--- a/snippets/vim.snippets
+++ b/snippets/vim.snippets
@@ -43,6 +43,7 @@ snippet ife if ... else statement
 	endif
 snippet au augroup ... autocmd block
 	augroup ${1:AU_NAME}
+		autocmd!
 		autocmd ${2:BufRead,BufNewFile} ${3:*.ext,*.ext3|<buffer[=N]>} ${0}
 	augroup END
 snippet bun Vundle.vim Plugin definition


### PR DESCRIPTION
This will prevent to add the already loaded autocmd when reloading the
vim configuration. The 'autocmd!' command remove the content of the
augroup at load.

https://learnvimscriptthehardway.stevelosh.com/chapters/14.html