### PR TITLE
Add the augroup with visual placeholder snippet

### DIFF
--- a/snippets/vim.snippets
+++ b/snippets/vim.snippets
@@ -45,6 +45,11 @@ snippet au augroup ... autocmd block
 	augroup ${1:AU_NAME}
 		autocmd ${2:BufRead,BufNewFile} ${3:*.ext,*.ext3|<buffer[=N]>} ${0}
 	augroup END
+snippet auv augroupvisual ... autocmd block with visual placeholder
+	augroup ${1:AU_NAME}
+		autocmd!
+		${0:${VISUAL}}
+	augroup END
 snippet bun Vundle.vim Plugin definition
 	Plugin '${0}'
 snippet plug vim-plug Plugin definition


### PR DESCRIPTION
This will place the visual selection in the correct place in the `augroup` for vim files.