### PR TITLE
feat(ultisnips): add conventional commit snippets

### DIFF
--- a/UltiSnips/gitcommit.snippets
+++ b/UltiSnips/gitcommit.snippets
@@ -1,0 +1,51 @@
+# https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification
+
+snippet fix "fix conventional commit"
+fix(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+
+snippet feat "feat conventional commit"
+feat(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+
+snippet chore "chore conventional commit"
+chore(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+
+snippet docs "docs conventional commit"
+docs(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+
+snippet refactor "refactor conventional commit"
+refactor(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+
+snippet test "test conventional commit"
+test(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+
+snippet ci "ci conventional commit"
+ci(${1:scope}): ${2:title}
+
+${0:body}
+
+endsnippet
+


### PR DESCRIPTION
Following [conventional commits](https://www.conventionalcommits.org) pattern, this commit adds initial support for conventional commits snippets.
