### PR TITLE
Fix useS snippet in UltiSnips/javascript_react

### DIFF
--- a/UltiSnips/javascript_react.snippets
+++ b/UltiSnips/javascript_react.snippets
@@ -1,3 +1,11 @@
+global !p
+# Capitalize the first letter without affecting the rest of the letters
+def capitalize_first(word):
+	if(word):
+		word = word[0].upper() + word[1:]
+	return word
+endglobal
+
 # Functional components
 snippet rfc "react functional component" b
 import React, {useState} from "react"
@@ -14,7 +22,7 @@ export default $4`!p snip.rv = snip.basename`
 endsnippet
 # React Hooks
 snippet useS "useState Hook" b
-const [${1}, set`!p snip.rv=t[1].title()`] = useState(${3:"${4}"})
+const [${1}, set`!p snip.rv=capitalize_first(t[1])`] = useState(${3:"${4}"})
 endsnippet
 snippet useE "useEffect Hook" b
 useEffect(() => {


### PR DESCRIPTION
Previously, the .title() function was used to capitalize the first item.
However, this function doesn't maintain the capitalization of letters in
the middle. Therefore, a custom function was created to effectively
convert camelCase to PascalCase.