### PR TITLE
Include arg type in google-style docstrings

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -138,7 +138,7 @@ def format_arg(arg, style):
 	elif style == NORMAL:
 		return ":%s: TODO" % arg
 	elif style == GOOGLE:
-		return "%s (TODO): TODO" % arg
+		return "%s (%s): TODO" % (arg, arg.type or "TODO")
 	elif style == JEDI:
 		return ":type %s: TODO" % arg
 	elif style == NUMPY:


### PR DESCRIPTION
Results in something like this:

```python
def function(i: int, s: str, o: MyObject):
    """TODO: Docstring for function.

    Args:
        i (int): TODO
        s (str): TODO
        o (MyObject): TODO

    Returns: TODO

    """
    pass
```