### PR TITLE
Fixed spelling error

### DIFF
--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -101,7 +101,7 @@ snippet crate "Define create meta attributes"
 	// Crate name
 	#![crate_name = "${1:crate_name}"]
 	// Additional metadata attributes
-	#![desc = "${2:Descrption.}"]
+	#![desc = "${2:Description.}"]
 	#![license = "${3:BSD}"]
 	#![comment = "${4:Comment.}"]
 	// Specify the output type


### PR DESCRIPTION
Hi, Nothing major, Just a small spelling error I noticed while using the `crate` snippet