### PR TITLE
Fix syntax error: unexpected end of file

### DIFF
--- a/UltiSnips/sh.snippets
+++ b/UltiSnips/sh.snippets
@@ -70,8 +70,7 @@ endsnippet
 
 snippet here "here document (here)"
 <<-${2:'${1:TOKEN}'}
-	$0
-${1/['"`](.+)['"`]/$1/}
+	$0`echo \\n`${1/['"`](.+)['"`]/$1/}
 endsnippet
 
 snippet /ift(est)?/ "if ... then (if)" rb


### PR DESCRIPTION
By placing the closing TOKEN at the begin of line, this fixes `syntax error: unexpected end of file`.

`echo \\n` creates a mere newline without indentation of the current line unlike a new line in a snippet.

See https://github.com/koalaman/shellcheck/wiki/SC1039