### PR TITLE
Fix wrong snippet commands

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -380,11 +380,11 @@ snippet lim limit
 
 # Partial derivative
 snippet pdv partial derivation
-	\\frac{\\partial {$1}}{\partial {$2}} {$0}
+	\\frac{\\partial {$1}}{\\partial {$2}} {$0}
 
 # Second order partial derivative
 snippet ppdv second partial derivation
-	\\frac{\partial^2 {$1}}{\partial {$2} \partial {$3}} {$0}
+	\\frac{\\partial^2 {$1}}{\\partial {$2} \\partial {$3}} {$0}
 
 # Ordinary derivative
 snippet dv derivative
@@ -416,7 +416,7 @@ snippet . dot product
 
 # Integral
 snippet int integral
-	\\int_{{$1}}^{{$2}} {$3} \: d{$4} {$5}
+	\\int_{{$1}}^{{$2}} {$3} \\: d{$4} {$0}
 
 # Right arrow
 snippet ra rightarrow


### PR DESCRIPTION
I modify snippets for Integral and Partial derivatives for some typos.
E.g., lack of \ and the argument number.

Thanks for contributing snippets!