### PR TITLE
modify re in javascript.node.snippets

### DIFF
--- a/snippets/javascript/javascript.node.snippets
+++ b/snippets/javascript/javascript.node.snippets
@@ -5,7 +5,7 @@ snippet ex
 	module.exports = ${1};
 # require
 snippet re
-	${1:const} ${2} = require('${3:module_name}');
+	const ${1} = require('${2:module_name}');
 # EventEmitter
 snippet on
 	on('${1:event_name}', function(${2:stream}) {


### PR DESCRIPTION
I think when using the require snippets we practically never touch the const anyway, so I think the first placeholder should already be in the variable name instead of the const which we practically never modify