### PR TITLE
Adjust: use python3 default, same as snippets/python.snippets

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -5,8 +5,8 @@ priority -50
 ###########################################################################
 
 #! header
-snippet #! "#!/usr/bin/env python3" b
-#!/usr/bin/env python3
+snippet #! "#!/usr/bin/env python" b
+#!/usr/bin/env python
 $0
 endsnippet
 

--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -5,8 +5,19 @@ priority -50
 ###########################################################################
 
 #! header
-snippet #! "#!/usr/bin/env python" b
-#!/usr/bin/env python
+snippet #! "#!/usr/bin/env python3" b
+#!/usr/bin/env python3
+$0
+endsnippet
+
+snippet #!2 "#!/usr/bin/env python2" b
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+$0
+endsnippet
+
+snippet #!3 "#!/usr/bin/env python3" b
+#!/usr/bin/env python3
 $0
 endsnippet
 


### PR DESCRIPTION
python2 is end of life, so make python3 as default, same as snippets/python.snippets does.