### PR TITLE
[Python] Improve snippet tryef

### DIFF
--- a/UltiSnips/python.snippets
+++ b/UltiSnips/python.snippets
@@ -648,7 +648,7 @@ endsnippet
 snippet tryef "Try / Except / Else / Finally" b
 try:
 	${1:${VISUAL:pass}}
-except${2: ${3:Exception} as ${4:e}}:
+except ${2:${3:Exception} as ${4:e}}:
 	${5:raise}
 else:
 	${6:pass}


### PR DESCRIPTION
Append space directly to except instead of using placeholder. For
providing space from placeholder, user need type space again when
modifying Exception class.