### PR TITLE
added commentstring(s)? to the modeline all.snippets

### DIFF
--- a/UltiSnips/all.snippets
+++ b/UltiSnips/all.snippets
@@ -73,7 +73,7 @@ endsnippet
 # modeline form ('set') to work in languages with comment terminators
 # (/* like C */).
 snippet modeline "Vim modeline"
-vim`!v ':set '. (&expandtab ? printf('et sw=%i ts=%i', &sw, &ts) : printf('noet sts=%i sw=%i ts=%i', &sts, &sw, &ts)) . (&tw ? ' tw='. &tw : '') . ':'`
+`!v (split(&cms, "%s")[0]) . (&expandtab ? printf(' vim:et:sw=%i:ts=%i', &sw, &ts) : printf(' vim:noet:sts=%i:sw=%i:ts=%i', &sts, &sw, &ts)) . (&tw ? ' tw='. &tw : '') . ':' . (len(split(&cms,"%s")) > 1 ? split(&cms, "%s")[1] : '')`
 endsnippet
 
 #########


### PR DESCRIPTION
I noticed that modelines did not include commentstrings and based on this question:
https://vi.stackexchange.com/questions/13028/

I have tried my best to improve this snippet

1 - added indentation to "vim" as needed for modelines 
2 - added start commentstring --> (split(&cms, "%s")[0]) .   concatenating
3 - If len( commetstring) is bigger than 1 add -> . (len(split(&cms,"%s")) > 1 ? split(&cms, "%s")[1] : '')

I hope this can help! 