### PR TITLE
feat(go): update error wrap snippet

### DIFF
--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -274,7 +274,7 @@ snippet ja "Marshalable json alias"
 	}
 
 
-snippet errwr "Error handling with errors.Wrap"
+snippet errwr "Error handling with fmt.Errorf"
 	if ${1}err != nil {
-		return errors.Wrap(err, "${2}")
+		return fmt.Errorf("${2} %w", err)
 	}


### PR DESCRIPTION
Since go1.13 it's [now possible](https://go.dev/blog/go1.13-errors) to use `%w` verb to wrap an error natively. I think it makes more sense to have a native snippet than one that requires [an external library](https://pkg.go.dev/github.com/pkg/errors) to works