### PR TITLE
added a missing 'auto function' comment to the cpp.snippet file

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -216,6 +216,7 @@ snippet try
 	}catch(${1}) {
 
 	}
+# auto function
 snippet af auto function
 	auto ${1:name}(${2}) -> ${3:void}
 	{


### PR DESCRIPTION
I added a missing comment to the cpp.snippet file, which was missing before.
It should describe the `af` auto function snippet.