### PR TITLE
feat(go): functional error handling

### DIFF
--- a/UltiSnips/go.snippets
+++ b/UltiSnips/go.snippets
@@ -113,3 +113,9 @@ if err != nil {
 	log.${1:Fatal}(err)
 }
 endsnippet
+
+snippet iferr "Functional error handling" b
+if err != nil {
+	return ${1}err
+}
+endsnippet


### PR DESCRIPTION
Very convenient snippet, familiar to all VS Code users.

NOTE: It puts cursor before err, so one can conveniently `D` to remove `err` or just insert more return parameters.