### PR TITLE
CSS: reorder `text-shadow`'s arguments and add `inset` to `box-shadow`

### DIFF
--- a/UltiSnips/css.snippets
+++ b/UltiSnips/css.snippets
@@ -45,11 +45,11 @@ snippet ! "!important CSS (!)"
 endsnippet
 
 snippet tsh "text-shadow: color-hex x y blur (text)"
-text-shadow: ${1:${2:color} ${3:offset-x} ${4:offset-y} ${5:blur}};$0
+text-shadow: ${1:${2:offset-x} ${3:offset-y} ${4:blur} ${5:color}};$0
 endsnippet
 
 snippet bxsh "box-shadow: color-hex x y blur (text)"
-box-shadow: ${1:${2:offset-x} ${3:offset-y} ${4:blur} ${5:spread} ${6:color}};$0
+box-shadow: ${1:${2:offset-x} ${3:offset-y} ${4:blur} ${5:spread} ${6:color} ${7:inset}};$0
 endsnippet
 
 #


### PR DESCRIPTION
[`box-shadow`](https://www.w3schools.com/CSSref/css3_pr_box-shadow.asp) and [`text-shadow`](https://www.w3schools.com/cssref/css3_pr_text-shadow.asp) have a very similar syntax, so it makes sense to have the order of the arguments common to the two properties be the same, so I moved `color` to the end for `text-shadow` to match the order of `box-shadow`.

I've also added `inset` to `box-shadow`, because why not.

As regards the opening of the snippets, should I reorder also that one? I'm asking because the order of the arguments on lines 51 and 52 wasn't the same even before my change. By the way, what does the `(text)` thing mean?