### PR TITLE
Replace f-string with format

### DIFF
--- a/UltiSnips/c.snippets
+++ b/UltiSnips/c.snippets
@@ -18,7 +18,7 @@ def printf_expand_args(snip):
 
 	# Add the amount of tabstops
 	for placeholder_index in range(3, amount_placeholders + 3):
-		output += f", ${placeholder_index}"
+		output += ", ${}".format(placeholder_index)
 	
 	# convert them into tabstops
 	snip.expand_anon(output)


### PR DESCRIPTION
f-string only works for python3.6 or above. The snippet fails to work when the vim specified python version is below 3.6.

[Related issue](https://github.com/neoclide/coc-snippets/issues/214)