### PR TITLE
fix: remove snippet that autotriggers \frac with /

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -349,10 +349,6 @@ snippet // "Fraction" Aw
 \frac{$1}{$2}$0
 endsnippet
 
-snippet / "Fraction" i
-\\frac{${VISUAL}}{$1}$0
-endsnippet
-
 snippet '((\d+)|(\d*)(\\)?([A-Za-z]+)((\^|_)(\{\d+\}|\d))*)/' "Fraction" wrA
 \\frac{`!p snip.rv = match.group(1)`}{$1}$0
 endsnippet


### PR DESCRIPTION
This snippet was removed since it autotriggers regardless of whether the
cursor is in a math environment or not.