### PR TITLE
Inline Math and Display Math Ultisnippet fixed

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -322,16 +322,11 @@ snippet DD "D" w
 \mathbb{D}
 endsnippet
 
-snippet im "Inline Math" Aw
-$${1}$`!p
-if t[2] and t[2][0] not in [',', '.', '?', '-', ' ']:
-	snip.rv = ' '
-else:
-	snip.rv = ''
-`$0
+snippet im "Inline Math" w
+$${1}$
 endsnippet
 
-snippet dm "Display Math" Aw
+snippet dm "Display Math" w
 \[
 	${1:${VISUAL}}
 .\]$0


### PR DESCRIPTION
The previous implementation would cause a python exception because of wrong array indexing.
The proposed implementation gets rid of the python stuff, which I don't really understand is the purpose of in the first place, which fixes the error.

Additionally, the snippets 'im' and 'dm' now don't get triggered automatically anymore, which can be annoying if you want to write text with prefix 'im' or 'dm', for example 'image' and 'dmesg'.