### PR TITLE
cleanup(tex): improvements and cleanup for tex snippets

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -138,12 +138,6 @@ snippet int "Intuition" bi
 \end{intuition}
 endsnippet
 
-snippet obs "Observation" bi
-\begin{observation}[$1]
-	$0${VISUAL}
-\end{observation}
-endsnippet
-
 snippet conc "Conclusion" bi
 \begin{conclusion}[$1]
 	$0${VISUAL}

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -128,7 +128,7 @@ endsnippet
 
 snippet fig "Figure environment" bi
 \begin{figure}[${1:htpb}]
-	\centering:${VISUAL}
+	\centering
 	${2:\includegraphics[width=0.8\textwidth]{$3}}
 	\caption{${4:$3}}
 	\label{fig:${5:${3/\W+/-/g}}}

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -285,22 +285,6 @@ snippet nnn "bigcap" w
 \bigcap_{${1:i \in ${2: I}}} $0
 endsnippet
 
-snippet OO "emptyset" w
-\O
-endsnippet
-
-snippet RR "real" w
-\R
-endsnippet
-
-snippet QQ "Q" w
-\Q
-endsnippet
-
-snippet ZZ "Z" w
-\Z
-endsnippet
-
 snippet HH "H" w
 \mathbb{H}
 endsnippet

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -108,7 +108,7 @@ snippet corl "Corollary" bi
 \end{corollary}
 endsnippet
 
-snippet example "Example" bAi
+snippet example "Example" bi
 \begin{example}[$1]
 	$0${VISUAL}
 \end{example}
@@ -118,12 +118,6 @@ snippet notion "Notation" bi
 \begin{notation}[$1]
 	$0${VISUAL}
 \end{notation}
-endsnippet
-
-snippet int "Intuition" bi
-\begin{intuition}[$1]
-	$0${VISUAL}
-\end{intuition}
 endsnippet
 
 snippet conc "Conclusion" bi

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -309,8 +309,8 @@ snippet DD "D" w
 \mathbb{D}
 endsnippet
 
-snippet im "Inline Math" w
-$${1}$
+snippet $$ "Inline Math" iA
+\\(${1}\\) $0
 endsnippet
 
 snippet dm "Display Math" w

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -177,18 +177,6 @@ snippet case "cases" bi
 \end{cases}
 endsnippet
 
-snippet ali "Align" bi
-\begin{align}
-	${1:${VISUAL}}
-.\end{align}
-endsnippet
-
-snippet ali* "Align*" bi
-\begin{align*}
-	${1:${VISUAL}}
-.\end{align*}
-endsnippet
-
 snippet abs "abstract environment" b
 \begin{abstract}
 	$0${VISUAL}

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -543,10 +543,6 @@ snippet <! "normal" Aw
 \triangleleft 
 endsnippet
 
-snippet SI "SI" Aw
-\SI{$1}{$2}
-endsnippet
-
 snippet ~~ "~" Aw
 \sim 
 endsnippet

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -120,12 +120,6 @@ snippet notion "Notation" bi
 \end{notation}
 endsnippet
 
-snippet prop "Property" bi
-\begin{property}[$1]
-	$0${VISUAL}
-\end{property}
-endsnippet
-
 snippet int "Intuition" bi
 \begin{intuition}[$1]
 	$0${VISUAL}

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -217,46 +217,6 @@ endsnippet
 # MATH #
 ########
 
-snippet "([a-zA-Z])MM"  "^m" wr
-`!p snip.rv = match.group(1)`^{m}
-endsnippet
-
-snippet "([a-zA-Z])NN"  "^n" wr
-`!p snip.rv = match.group(1)`^{n}
-endsnippet
-
-snippet "([a-zA-Z])II"  "^i" wr
-`!p snip.rv = match.group(1)`^{i}
-endsnippet
-
-snippet "([a-zA-Z])KK"  "^k" wr
-`!p snip.rv = match.group(1)`^{k}
-endsnippet
-
-snippet "([a-zA-Z])JJ"  "^j" wr
-`!p snip.rv = match.group(1)`^{j}
-endsnippet
-
-snippet "([a-zA-Z])mm"  "_m" wr
-`!p snip.rv = match.group(1)`_{m}
-endsnippet
-
-snippet "([a-zA-Z])nn"  "_n" wr
-`!p snip.rv = match.group(1)`_{n}
-endsnippet
-
-snippet "([a-zA-Z])ii"  "_i" wr
-`!p snip.rv = match.group(1)`_{i}
-endsnippet
-
-snippet "([a-zA-Z])kk"  "_k" wr
-`!p snip.rv = match.group(1)`_{k}
-endsnippet
-
-snippet "([a-zA-Z])jj"  "_j" wr
-`!p snip.rv = match.group(1)`_{j}
-endsnippet
-
 snippet cc "subset" w
 \subset 
 endsnippet

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -341,14 +341,6 @@ snip.rv = stripped[0:i] + "\\frac{" + stripped[i+1:-1] + "}"
 `{$1}$0
 endsnippet
 
-snippet '([A-Za-z])_\{(\d+)\}(\d)' "Auto subscript 3+" wrA
-`!p snip.rv = match.group(1)`_{`!p snip.rv = match.group(2) + match.group(3)`}
-endsnippet
-
-snippet '([A-Za-z])\^\{(\d+)\}(\d)' "Auto superscript" wrA
-`!p snip.rv = match.group(1)`^{`!p snip.rv = match.group(2) + match.group(3)`}
-endsnippet
-
 snippet compl "Complement" i
 ^{c}
 endsnippet

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -323,24 +323,6 @@ snippet // "Fraction" Aw
 \frac{$1}{$2}$0
 endsnippet
 
-snippet '((\d+)|(\d*)(\\)?([A-Za-z]+)((\^|_)(\{\d+\}|\d))*)/' "Fraction" wrA
-\\frac{`!p snip.rv = match.group(1)`}{$1}$0
-endsnippet
-
-snippet '^.*\)/' "() Fraction" wrA
-`!p
-stripped = match.string[:-1]
-depth = 0
-i = len(stripped) - 1
-while True:
-	if stripped[i] == ')': depth += 1
-	if stripped[i] == '(': depth -= 1
-	if depth == 0: break;
-	i -= 1
-snip.rv = stripped[0:i] + "\\frac{" + stripped[i+1:-1] + "}"
-`{$1}$0
-endsnippet
-
 snippet compl "Complement" i
 ^{c}
 endsnippet

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -501,23 +501,6 @@ snippet >= "geq" Aw
 \ge 
 endsnippet
 
-snippet plot "Plot" w
-\begin{figure}[$1]
-	\centering
-	\begin{tikzpicture}
-		\begin{axis}[
-			xmin= ${2:-10}, xmax= ${3:10},
-			ymin= ${4:-10}, ymax = ${5:10},
-			axis lines = middle,
-		]
-			\addplot[domain=$2:$3, samples=${6:100}]{$7};
-		\end{axis}
-	\end{tikzpicture}
-	\caption{$8}
-	\label{${9:$8}}
-\end{figure}
-endsnippet
-
 snippet nn "Tikz node" w
 \node[$5] (${1/[^0-9a-zA-Z]//g}${2}) ${3:at (${4:0,0}) }{$${1}$};
 $0

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -38,13 +38,13 @@ endglobal
 
 snippet beg "begin{} / end{}" bi
 \begin{$1}
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{$1}
 endsnippet
 
 snippet cnt "Center" bi
 \begin{center}
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{center}
 endsnippet
 
@@ -56,61 +56,61 @@ endsnippet
 
 snippet lemma "Lemma" bi
 \begin{lemma}
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{lemma}
 endsnippet
 
 snippet prop "Proposition" bi
 \begin{prop}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{prop}
 endsnippet
 
 snippet thrm "Theorem" bi
 \begin{theorem}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{theorem}
 endsnippet
 
 snippet post "postulate" bi
 \begin{postulate}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{postulate}
 endsnippet
 
 snippet prf "Proof" bi
 \begin{myproof}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{myproof}
 endsnippet
 
 snippet def "Definition" bi
 \begin{definition}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{definition}
 endsnippet
 
 snippet nte "Note" bi
 \begin{note}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{note}
 endsnippet
 
 snippet prob "Problem" bi
 \begin{problem}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{problem}
 endsnippet
 
 snippet corl "Corollary" bi
 \begin{corollary}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{corollary}
 endsnippet
 
 snippet example "Example" bi
 \begin{example}[$1]
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{example}
 endsnippet
 
@@ -137,25 +137,25 @@ endsnippet
 
 snippet enum "Enumerate" bi
 \begin{enumerate}
-	\item $0${VISUAL}
+	\item ${0:${VISUAL}}
 \end{enumerate}
 endsnippet
 
 snippet item "Itemize" bi
 \begin{itemize}
-	\item $0${VISUAL}
+	\item ${0:${VISUAL}}
 \end{itemize}
 endsnippet
 
 snippet case "cases" bi
 \begin{cases}
-	$0${VISUAL}
+	${0:${VISUAL}}
 \end{cases}
 endsnippet
 
 snippet abs "abstract environment" b
 \begin{abstract}
-	$0${VISUAL}
+	${0:${VISUAL}}
 .\end{abstract}
 endsnippet
 

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -120,12 +120,6 @@ snippet notion "Notation" bi
 \end{notation}
 endsnippet
 
-snippet rep "Repetition" bi
-\begin{repetition}[$1]
-	$0${VISUAL}
-\end{repetition}
-endsnippet
-
 snippet prop "Property" bi
 \begin{property}[$1]
 	$0${VISUAL}

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -50,7 +50,7 @@ endsnippet
 
 snippet desc "Description" bi
 \begin{description}
-	$0${VISUAL}
+	\item[${1:${VISUAL}}] $0
 \end{description}
 endsnippet
 

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -265,10 +265,6 @@ snippet inn "in " w
 \in 
 endsnippet
 
-snippet NN "n" w
-\N
-endsnippet
-
 snippet Nn "cap" w
 \cap 
 endsnippet


### PR DESCRIPTION
Hi, its me again with some TeX improvements/corrections. :)

Summary of all commits:

f720db1 fix(tex): unclear use of `${VISUAL}` here
1563422 fix(tex): correct use of `${VISUAL}` placeholder
3c10e8a cleanup(tex): a more sensible snippet for `description`
3390ab4 cleanup(tex): the environment `intuition` is not standard
df5e78c cleanup(tex): the environment `property` is not standard
598cc6b cleanup(tex): the environment `repetition` is not standard
8b37206 cleanup(tex): the environment observation is not standard
8fba2b6 cleanup(tex): align is already defined in texmath
0a53561 cleanup(tex): these are all also rather specific snippets
a4bac70 cleanup(tex): `\N` is not a standard latex command
3a2f74f cleanup(tex): these snippets were too specific
fdcbb70 fix(tex): inline math should use `\(...\)` instead of `$...$`.
156f9d8 cleanup(tex): more `\frac{}{}` that autotrigger when not needed
b68af00 cleanup(tex): subscript and superscript would trigger outside math
5c9c355 cleanup(tex): plot snippet is too specific.
2441209 fix(tex): SI snippet is already in texmath
