### PR TITLE
Update javascript-mocha.snippets

### DIFF
--- a/snippets/javascript-mocha.snippets
+++ b/snippets/javascript-mocha.snippets
@@ -1,29 +1,29 @@
-snippet des "describe('thing', () => { ... })" b
-	describe('${1:}', () => {
+be('thing', function() { ... })" b
+	describe('${1:}', function() {
 		${0:${VISUAL}}
 	});
-snippet it "it('should do', () => { ... })" b
-	it('${1:}', () => {
+snippet it "it('should do', function() { ... })" b
+	it('${1:}', function() {
 		${0:${VISUAL}}
 	});
-snippet xit "xit('should do', () => { ... })" b
-	xit('${1:}', () => {
+snippet xit "xit('should do', function() { ... })" b
+	xit('${1:}', function() {
 		${0:${VISUAL}}
 	});
-snippet bef "before(() => { ... })" b
-	before(() => {
+snippet bef "before(function() { ... })" b
+	before(function() {
 		${0:${VISUAL}}
 	});
-snippet befe "beforeEach(() => { ... })" b
-	beforeEach(() => {
+snippet befe "beforeEach(function() { ... })" b
+	beforeEach(function() {
 		${0:${VISUAL}}
 	});
-snippet aft "after(() => { ... })" b
-	after(() => {
+snippet aft "after(function() { ... })" b
+	after(function() {
 		${0:${VISUAL}}
 	});
-snippet afte "afterEach(() => { ... })" b
-	afterEach(() => {
+snippet afte "afterEach(function() { ... })" b
+	afterEach(function() {
 		${0:${VISUAL}}
 	});
 snippet exp "expect(...)" b


### PR DESCRIPTION
[mocha recommends using the `function` syntax](https://mochajs.org/#arrow-functions) in test files

When mocha tests use the arrow function syntax, they cannot access the mocha context