### PR TITLE
Python: add br -> breakpoint()

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -159,6 +159,10 @@ snippet ifmain
 # __magic__
 snippet _
 	__${1:init}__
+
+# debugger breakpoint
+snippet br
+    breakpoint()
 # python debugger (pdb)
 snippet pdb
 	__import__('pdb').set_trace()


### PR DESCRIPTION
Other languages are using br -> break(), if that's a problem, another option could be to use `bp` or `b`