### PR TITLE
Remove autotrigger of frac

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -219,7 +219,7 @@ snippet dm "Display Math" w
 .\]$0
 endsnippet
 
-snippet frac "Fraction" Aw
+snippet frac "Fraction" w
 \frac{$1}{$2}$0
 endsnippet
 


### PR DESCRIPTION
The recent PR #1397 has changed ``//`` trigger to ``frac``, but it remains to be autotriggered. Each time I wrote ``\frac`` it would be automatically expanded to ``\\frac{}{}``. This behavior would be better if it could be triggered manually.
