### PR TITLE
Autotrigger behavior of bra and ket

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -429,11 +429,11 @@ snippet bar "bar" wi
 \bar{${1:${VISUAL}}}$0
 endsnippet
 
-snippet "\<(.*?)\|" "bra" Awri
+snippet "\<(.*?)\|" "bra" wri
 \bra{`!p snip.rv = match.group(1).replace('q', f'\psi').replace('f', f'\phi')`}
 endsnippet
 
-snippet "\|(.*?)\>" "ket" Awri
+snippet "\|(.*?)\>" "ket" wri
 \ket{`!p snip.rv = match.group(1).replace('q', f'\psi').replace('f', f'\phi')`}
 endsnippet
 


### PR DESCRIPTION
When writing comparisons with absolute values, like

![formula](https://render.githubusercontent.com/render/math?math=|a|>2)

Typing `|a|>` the snippet would autotrigger and convert it into `\ket{a|}`. There were also similar behavior with `\ker`.

Seems like these snippets are related to physics, but are disturbing when typing math formulas.