### PR TITLE
Remove outdated Rails `sweeper` snippet

### DIFF
--- a/UltiSnips/rails.snippets
+++ b/UltiSnips/rails.snippets
@@ -799,28 +799,6 @@ snippet xput "xhr put"
 xhr :put, :${1:update}, id: ${2:1}, ${3:object}: { $4 }$0
 endsnippet
 
-snippet sweeper "Create sweeper class"
-class ${1:Model}Sweeper < ActionController::Caching::Sweeper
-	observe ${1:Model}
-
-	def after_save(${1/./\l$0/})
-		expire_cache(${1/./\l$0/})
-	end
-
-	def after_destroy(${1/./\l$0/})
-		expire_cache(${1/./\l$0/})
-	end
-
-	private
-
-		def expire_cache(${1/./\l$0/})
-			${0:expire_page ${1/./\l$0/}s_path
-			expire_page ${1/./\l$0/}_path(${1/./\l$0/})}
-		end
-
-end
-endsnippet
-
 snippet col "collection routes"
 collection do
 	${1:get :${2:action}}

--- a/snippets/rails.snippets
+++ b/snippets/rails.snippets
@@ -274,22 +274,6 @@ snippet sl
 	end
 snippet sha1
 	Digest::SHA1.hexdigest(${0:string})
-snippet sweeper
-	class ${1:ModelClassName}Sweeper < ActionController::Caching::Sweeper
-		observe $1
-
-		def after_save(${0:model_class_name})
-			expire_cache($2)
-		end
-
-		def after_destroy($2)
-			expire_cache($2)
-		end
-
-		def expire_cache($2)
-			expire_page
-		end
-	end
 snippet va validates_associated
 	validates_associated :${0:attribute}
 snippet va validates .., acceptance: true


### PR DESCRIPTION
When browsing the Rails snippets, I noticed this snippet for a feature that was removed in Rails 3.2.13, over nine years ago:

https://apidock.com/rails/ActionController/Caching/Sweeper
