### PR TITLE
remove bracket of definition part of scheme.snippet `def`

### DIFF
--- a/snippets/scheme.snippets
+++ b/snippets/scheme.snippets
@@ -17,7 +17,7 @@ snippet *
 # Definition
 snippet def
 	(define (${1:name})
-			(${0:definition}))
+			${0:definition})
 
 # Definition with lambda
 snippet defl


### PR DESCRIPTION
Since `if` `cond` and other snippets all include brackets around them, including brackets in `def` is duplicate and will lead to an error if not deleted (e.g. if `if` returns a value), IMHO not including brackets is more intuitive.