### PR TITLE
Add Gleam snippets

### DIFF
--- a/snippets/gleam.snippets
+++ b/snippets/gleam.snippets
@@ -1,0 +1,98 @@
+snippet fn "fn"
+  fn ${1:function_name}(${2}) -> ${3:Nil} {
+    ${0:${VISUAL:todo}}
+  }
+
+snippet pfn "pub fn"
+  pub fn ${1:function_name}(${2}) -> ${3:Nil} {
+    ${0:${VISUAL:todo}}
+  }
+
+snippet test "test fn"
+  pub fn ${1:name}_test() {
+    ${0}
+  }
+
+snippet af "anonymous fn"
+  fn(${1}) { ${0:${VISUAL}} }
+
+snippet let "let binding"
+  let ${1} = ${0}
+
+snippet l "let binding"
+  let ${1} = ${0}
+
+snippet as "assert binding"
+  assert ${1} = ${0}
+
+snippet tr "try binding"
+  try ${1} = ${0}
+
+snippet - "->"
+  -> ${0}
+
+snippet case "case expression"
+  case ${1} {
+    ${2} -> ${0}
+  }
+
+snippet ty "type"
+  type ${1:Name} {
+    ${0:$1}
+  }
+
+snippet pty "pub type"
+  pub type ${1:Name} {
+    ${0:$1}
+  }
+
+snippet tya "type alias"
+  type ${1:Name} =
+    ${0:$1}
+
+snippet ptya "pub type alias"
+  pub type ${1:Name} =
+    ${0:$1}
+
+snippet ext "external type"
+  external type ${0}
+
+snippet pext "pub external type"
+  pub external type ${0}
+
+snippet exfn "external fn"
+  external fn ${1:function_name}(${2}) -> ${3}
+    = "${4}" "${0}"
+
+snippet pexfn "pub external fn"
+  pub external fn ${1:function_name}(${2}) -> ${3}
+    = "${4}" "${0}"
+
+snippet im "import"
+  import ${0:gleam/result}
+
+snippet im. "import exposing"
+  import ${1:gleam/result}.{${0}}
+
+snippet p "|>"
+  |> ${0}
+
+snippet tup "tuple()"
+  tuple(${0:${VISUAL}})
+
+snippet bl "block"
+  {
+    ${0:${VISUAL}}
+  }
+
+snippet tf "fn(Type) -> Type"
+  fn(${1}) -> ${0}
+
+snippet seq "should.equal"
+  should.equal(${0:${VISUAL}})
+
+snippet strue "should.be_true"
+  should.be_true(${0:${VISUAL}})
+
+snippet sfalse "should.be_false"
+  should.be_true(${0:${VISUAL}})


### PR DESCRIPTION
This pull request adds snippets for [Gleam](https://gleam.run). It is more or less just a copy-paste of the snippets from the [`gleam.vim`](https://github.com/gleam-lang/gleam.vim) repository with minor formatting.