### PR TITLE
correct $ as inline math delimiter fault in tex.snippets

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -217,8 +217,8 @@ snippet inmath "Inline Math" w
 \\(${1}\\) $0
 endsnippet
 
-snippet im "Inline Math $" A
-$$${1}$$ $0
+snippet im "Inline Math $" w
+$${1}$ $0
 endsnippet
 
 snippet dm "Display Math" w


### PR DESCRIPTION
I'm so sorry for my fault before.