### PR TITLE
Update lua.snippets

### DIFF
--- a/UltiSnips/lua.snippets
+++ b/UltiSnips/lua.snippets
@@ -104,11 +104,11 @@ snippet local "local x = 1"
 local ${1:x} = ${0:1}
 endsnippet
 
-snippet use "Use" Ab
+snippet use "Use" b
 use { '$1' }
 endsnippet
 
-snippet req "Require"
+snippet req "Require" b
 require('$1')
 endsnippet
 


### PR DESCRIPTION
Remove the auto-trigger for the snippets `use` in the lua filetype. [This](https://github.com/honza/vim-snippets/pull/1390#issuecomment-1214369632) comment brought that to my attention.