### PR TITLE
Move cursor to the next line after include in C

### DIFF
--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -18,9 +18,11 @@ snippet mainn
 # #include <...>
 snippet inc
 	#include <${1:stdio}.h>
+	$0
 # #include "..."
 snippet Inc
 	#include "${1:`vim_snippets#Filename("$1.h")`}"
+	$0
 # ifndef...define...endif
 snippet ndef
 	#ifndef $1

--- a/snippets/html.snippets
+++ b/snippets/html.snippets
@@ -441,10 +441,9 @@ snippet html5
 			<meta charset="utf-8">
 			<meta name="viewport" content="width=device-width">
 			<title>${1:`substitute(vim_snippets#Filename('', 'Page Title'), '^.', '\u&', '')`}</title>
-			${2:link}
 		</head>
 		<body>
-			${0:body}
+			$0
 		</body>
 	</html>
 snippet html5l


### PR DESCRIPTION
With the snippet `inc` in `c.snippets`, I think it is better to have the caret at the next line after pressing `Tab` rather than at the end of the line.

```vim
inc<Tab><Tab>
```

```c
#include <stdio.h>
|
```