### PR TITLE
Improve print and write functions for Lua

### DIFF
--- a/snippets/lua.snippets
+++ b/snippets/lua.snippets
@@ -42,5 +42,23 @@ snippet while
 	end
 snippet print
 	print("${1:string}")
+snippet pr
+	print($0)
+snippet prs
+	print("$0")
+snippet prf
+	print(string.format("${1:%s}"$0))
+snippet wr
+	io.write($0)
+snippet wrs
+	io.write("$0")
+snippet wrf
+	io.write(string.format("${1:%s}"$0))
+snippet fwr
+	io.${1:stderr}:write($0)
+snippet fwrs
+	io.${1:stderr}:write("$0")
+snippet fwrf
+	io.${1:stderr}:write(string.format("${2:%s}"$0))
 snippet im
 	import "${1:import file}"


### PR DESCRIPTION
So far `lua.snippets` just has the `print` snippet. I decided to add a couple more snippets for printing, including one with `string.format` to format the string. I also added snippets for printing with `io.write` (to omit the trailing newline) and also added snippets with writing to `stderr`.