### PR TITLE
Redefine `mainn` snippet for C++ without `void`

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -1,5 +1,14 @@
+priority 2
 extends c
 
+## Main
+# main()
+snippet mainn
+	int main()
+	{
+		${0}
+		return 0;
+	}
 ##
 ## Preprocessor
 # #include <...>


### PR DESCRIPTION
In C++ (not C), `int main(void)` and `int main()` do the exact same thing but it is conventional to write `int main()` instead because it is shorter.