### PR TITLE
Improve POSIX-compliant shell snippets

### DIFF
--- a/snippets/bash.snippets
+++ b/snippets/bash.snippets
@@ -1,0 +1,25 @@
+extends sh
+
+# Shebang
+snippet #!
+	#!/usr/bin/env bash
+
+snippet s#!
+	#!/usr/bin/env bash
+	set -eu
+
+snippet if
+	if [[ ${1:condition} ]]; then
+		${0:${VISUAL}}
+	fi
+snippet elif
+	elif [[ ${1:condition} ]]; then
+		${0:${VISUAL}}
+snippet wh
+	while [[ ${1:condition} ]]; do
+		${0:${VISUAL}}
+	done
+snippet until
+	until [[ ${1:condition} ]]; do
+		${0:${VISUAL}}
+	done

--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -1,4 +1,3 @@
-priority 2
 extends c
 
 ## Main

--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -18,11 +18,11 @@ snippet sbash
 	IFS=$'\n\t'
 
 snippet if
-	if [[ ${1:condition} ]]; then
+	if [ ${1:condition} ]; then
 		${0:${VISUAL}}
 	fi
 snippet elif
-	elif [[ ${1:condition} ]]; then
+	elif [ ${1:condition} ]; then
 		${0:${VISUAL}}
 snippet for
 	for (( ${2:i} = 0; $2 < ${1:count}; $2++ )); do
@@ -33,11 +33,11 @@ snippet fori
 		${0:${VISUAL}}
 	done
 snippet wh
-	while [[ ${1:condition} ]]; do
+	while [ ${1:condition} ]; do
 		${0:${VISUAL}}
 	done
 snippet until
-	until [[ ${1:condition} ]]; do
+	until [ ${1:condition} ]; do
 		${0:${VISUAL}}
 	done
 snippet case

--- a/snippets/zsh.snippets
+++ b/snippets/zsh.snippets
@@ -1,5 +1,4 @@
 # #!/bin/zsh
-priority 1
 extends bash
 
 snippet #!

--- a/snippets/zsh.snippets
+++ b/snippets/zsh.snippets
@@ -1,6 +1,9 @@
 # #!/bin/zsh
+priority 1
+extends bash
+
 snippet #!
-	#!/bin/zsh
+	#!/usr/bin/env zsh
 
 snippet if
 	if ${1:condition}; then


### PR DESCRIPTION
Here are the changes I made to `sh.snippets`, `zsh.snippets` and `bash.snippets` (the latter I created the file).

- remove Bashisms from `sh.snippets`
  - Bashisms are things that can't be run in shells other than Bash, so we should use pure POSIX-compliant code in `sh.snippets` and put Bashims in `bash.snippets` instead
- create the file `bash.snippets` which extends `sh` but uses the Bashims
- change the `#!` snippet to `#!/usr/bin/env bash` instead of `#!/usr/bin/env sh` in `bash.snippets`
- do the same above for `zsh.snippets`
- make `zsh.snippets` extend `bash`