### PR TITLE
c: Do not `return 0` in the `main` function

### DIFF
--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -4,14 +4,12 @@ snippet main
 	int main(int argc, char *argv[])
 	{
 		${0}
-		return 0;
 	}
 # main(void)
 snippet mainn
 	int main(void)
 	{
 		${0}
-		return 0;
 	}
 ##
 ## Preprocessor


### PR DESCRIPTION
In C, it is actually not necessary to `return 0` at the end of the program because it will automatically `return 0` anyways when the program is finished. Some people like to explicitly add `return 0` but that is not necessary so they can use the `ret` snippet for that.