### PR TITLE
Create `all.snippets`

### DIFF
--- a/snippets/all.snippets
+++ b/snippets/all.snippets
@@ -1,0 +1,1 @@
+extends _


### PR DESCRIPTION
LuaSnip uses `all` instead of `_` for global snippets. In order for global snippets to work in LuaSnip, you have to create a file called `all.snippets` which just `exends _`.