### PR TITLE
Support `while true` loops

### DIFF
--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -127,7 +127,11 @@ snippet forr
 	}
 # while
 snippet wh
-	while (${1:/* condition */}) {
+	while (${1:1}) {
+		${0:${VISUAL}}
+	}
+snippet wht
+	while (true) {
 		${0:${VISUAL}}
 	}
 # do... while

--- a/snippets/java.snippets
+++ b/snippets/java.snippets
@@ -211,7 +211,9 @@ snippet enfor
 snippet for
 	for (${1}; ${2}; ${3}) ${0}
 snippet wh
-	while (${1}) ${0}
+	while (${1:true}) ${0}
+snippet wht
+	while (true) ${0}
 ##
 ## Main method
 snippet psvm

--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -107,7 +107,11 @@ snippet forr "reversed for (...) {...}"
 		${0:${VISUAL}}
 	}
 snippet wh "(condition) { ... }"
-	while (${1:/* condition */}) {
+	while (${1:true}) {
+		${0:${VISUAL}}
+	}
+snippet wht "(true) { ... }"
+	while (true) {
 		${0:${VISUAL}}
 	}
 snippet do "do { ... } while (condition)"

--- a/snippets/lua.snippets
+++ b/snippets/lua.snippets
@@ -40,6 +40,14 @@ snippet while
 	while ${1:condition} do
 		${0:--body}
 	end
+snippet wh
+	while ${1:true} do
+		${0}
+	end
+snippet wht
+	while true do
+		${0}
+	end
 snippet print
 	print("${1:string}")
 snippet pr

--- a/snippets/r.snippets
+++ b/snippets/r.snippets
@@ -25,8 +25,12 @@ snippet ei
 
 # loops
 snippet wh
-	while(${1}) {
-		${2}
+	while(${1:true}) {
+		${0}
+	}
+snippet wht
+	while(true) {
+		${0}
 	}
 snippet for
 	for (${1:item} in ${2:list}) {

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -147,7 +147,11 @@ snippet loop "loop {}" b
 		${0:${VISUAL}}
 	}
 snippet wh "while loop"
-	while ${1:condition} {
+	while ${1:true} {
+		${0:${VISUAL}}
+	}
+snippet wht "forever loop"
+	while true {
 		${0:${VISUAL}}
 	}
 snippet whl "while let (...)"

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -147,11 +147,7 @@ snippet loop "loop {}" b
 		${0:${VISUAL}}
 	}
 snippet wh "while loop"
-	while ${1:true} {
-		${0:${VISUAL}}
-	}
-snippet wht "forever loop"
-	while true {
+	while ${1:condition} {
 		${0:${VISUAL}}
 	}
 snippet whl "while let (...)"

--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -36,6 +36,10 @@ snippet wh
 	while [ ${1:condition} ]; do
 		${0:${VISUAL}}
 	done
+snippet wht
+	while true; do
+		${0:${VISUAL}}
+	done
 snippet until
 	until [ ${1:condition} ]; do
 		${0:${VISUAL}}


### PR DESCRIPTION
For `while` loops in several languages, the default condition is true. Snippets called `wht` are also added in which the condition is true. I did this because having the default condition as true is more useful than having a comment there. `while true` is used commonly for making a forever loop.