### PR TITLE
Improve Markdown and R Markdown snippets

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -67,17 +67,21 @@ snippet <*
 	<`@*`>
 snippet <c
 	<`@+`>
-snippet **
-	**${1:bold}**
-snippet __
-	__${1:bold}__
-snippet ===
+snippet ** Bold
+	**$0**
+snippet __ Bold
+	__$0__
+snippet --- Front matter
+	---
+	$0
+	---
+snippet ====
 	`repeat('=', strlen(getline(line('.') - 3)))`
 
 	${0}
 snippet -
 	-   ${0}
-snippet ---
+snippet ----
 	`repeat('-', strlen(getline(line('.') - 3)))`
 
 	${0}
@@ -142,3 +146,11 @@ snippet pullquote
 	{% pullquote %}
 	${1:text} {" ${2:quote} "} ${0:text}
 	{% endpullquote %}
+
+# Definition lists
+snippet : Definition list
+	$1
+	: $0
+snippet :: Alternate definition list
+	$1
+	  - $0

--- a/snippets/pandoc.snippets
+++ b/snippets/pandoc.snippets
@@ -1,2 +1,1 @@
 extends markdown
-

--- a/snippets/rmd.snippets
+++ b/snippets/rmd.snippets
@@ -6,6 +6,8 @@
 # vim's `"*` register---i.e., the contents of the
 # system clipboard---to insert text.
 
+extends markdown
+
 # Insert Title Block
 snippet %%
 	% ${1:`Filename('', 'title')`}
@@ -19,64 +21,6 @@ snippet %%*
 	% ${3:`strftime("%d %b %Y")`}
 
 	${4}
-
-# Insert Definition List
-snippet ::
-	${1:term}
-	  ~  ${2:definition}
-
-# Underline with `=`s or `-`s
-snippet ===
-	`repeat('=', strlen(getline(line(".") - 1)))`
-	
-	${1}
-snippet ---
-	`repeat('-', strlen(getline(line(".") - 1)))`
-	
-	${1}
-
-# Links and their kin
-# -------------------
-#
-# (These don't play very well with delimitMate)
-#
-
-snippet [
-	[${1:link}](http://${2:url} "${3:title}")${4}
-snippet [*
-	[${1:link}](${2:`@*`} "${3:title}")${4}
-
-snippet [:
-	[${1:id}]: http://${2:url} "${3:title}"
-snippet [:*
-	[${1:id}]: ${2:`@*`} "${3:title}"
-
-snippet [@
-	[${1:link}](mailto:${2:email})${3}
-snippet [@*
-	[${1:link}](mailto:${2:`@*`})${3}
-
-snippet [:@
-	[${1:id}]: mailto:${2:email} "${3:title}"
-snippet [:@*
-	[${1:id}]: mailto:${2:`@*`} "${3:title}"
-
-snippet ![
-	![${1:alt}](${2:url} "${3:title}")${4}
-snippet ![*
-	![${1:alt}](${2:`@*`} "${3:title}")${4}
-
-snippet ![:
-	![${1:id}]: ${2:url} "${3:title}"
-snippet ![:*
-	![${1:id}]: ${2:`@*`} "${3:title}"
-
-snippet [^:
-	[^${1:id}]: ${2:note}
-snippet [^:*
-	[^${1:id}]: ${2:`@*`}
-
-#
 
 # library()
 snippet req


### PR DESCRIPTION
Here are the changes I made to improve Markdown and R Markdown snippets.

- use snippet descriptions instead of unneeded placeholder text
- add a font matter snippet which is very useful for Pandoc
- add another definition list snippet
- since R Markdown is just Markdown with extra things, add `extends markdown` to `rmd.snippets` and remove duplicate snippets
- delete the extra blank line in `pandoc.snippets`