### PR TITLE
`sh`: `#!/usr/bin/env sh` -> `#!/bin/sh`

### DIFF
--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -1,9 +1,9 @@
-# Shebang. Executing bash via /usr/bin/env makes scripts more portable.
+# Shebang
 snippet #!
-	#!/usr/bin/env sh
+	#!/bin/sh
 
 snippet s#!
-	#!/usr/bin/env sh
+	#!/bin/sh
 	set -eu
 
 snippet safe


### PR DESCRIPTION
`#!/bin/sh` is actually more portable than `#!/usr/bin/env sh`. This is because `sh` is always located in `/bin` while not every system has `env` in `/usr/bin`. The same is **not** true for Bash and Zsh.