### PR TITLE
Remove unnecessary placeholder text

### DIFF
--- a/snippets/actionscript.snippets
+++ b/snippets/actionscript.snippets
@@ -114,7 +114,7 @@ snippet forr
 	}
 # If Condition
 snippet if
-	if (${1:/* condition */}) {
+	if ($1) {
 		${0:${VISUAL}}
 	}
 snippet el
@@ -122,8 +122,8 @@ snippet el
 		${0:${VISUAL}}
 	}
 # Ternary conditional
-snippet t
-	${1:/* condition */} ? ${2:a} : ${0:b}
+snippet t Ternary: `condition ? true : false`
+	$1 ? $2 : $0
 snippet fun
 	function ${1:function_name}(${2})${3}
 	{
@@ -150,4 +150,3 @@ snippet FlxSprite
 			}
 		}
 	}
-

--- a/snippets/arduino.snippets
+++ b/snippets/arduino.snippets
@@ -19,7 +19,7 @@ snippet def
 
 # if
 snippet if
-	if (${1:/* condition */}) {
+	if ($1) {
 		${0:${VISUAL}}
 	}
 # else
@@ -29,12 +29,12 @@ snippet el
 	}
 # else if
 snippet elif
-	else if (${1:/* condition */}) {
+	else if ($1) {
 		${2}
 	}
 # ifi
 snippet ifi
-	if (${1:/* condition */}) ${2};
+	if ($1) ${2};
 
 # switch
 snippet switch
@@ -63,14 +63,14 @@ snippet forr
 	}
 # while
 snippet wh
-	while (${1:/* condition */}) {
+	while ($1) {
 		${2}
 	}
 # do... while
 snippet do
 	do {
 		${2}
-	} while (${1:/* condition */});
+	} while ($1);
 ##
 ## Functions
 # function definition

--- a/snippets/autoit.snippets
+++ b/snippets/autoit.snippets
@@ -1,16 +1,16 @@
 snippet if
-	If ${1:condition} Then
+	If $1 Then
 		${0:; True code}
 	EndIf
 snippet el
 	Else
 		${0}
 snippet eif
-	ElseIf ${1:condition} Then
+	ElseIf $1 Then
 		${0:; True code}
 # If/Else block
 snippet ife
-	If ${1:condition} Then
+	If $1 Then
 		${2:; True code}
 	Else
 		${0:; Else code}
@@ -26,7 +26,7 @@ snippet ifelif
 	EndIf
 # Switch block
 snippet switch
-	Switch (${1:condition})
+	Switch ($1)
 	Case ${2:case1}:
 		${3:; Case 1 code}
 	Case Else:
@@ -34,7 +34,7 @@ snippet switch
 	EndSwitch
 # Select block
 snippet select
-	Select (${1:condition})
+	Select ($1)
 	Case ${2:case1}:
 		${3:; Case 1 code}
 	Case Else:
@@ -42,7 +42,7 @@ snippet select
 	EndSelect
 # While loop
 snippet wh
-	While (${1:condition})
+	While ($1)
 		${0:; code...}
 	WEnd
 # For loop

--- a/snippets/bash.snippets
+++ b/snippets/bash.snippets
@@ -9,17 +9,17 @@ snippet s#!
 	set -eu
 
 snippet if
-	if [[ ${1:condition} ]]; then
+	if [[ $1 ]]; then
 		${0:${VISUAL}}
 	fi
 snippet elif
-	elif [[ ${1:condition} ]]; then
+	elif [[ $1 ]]; then
 		${0:${VISUAL}}
 snippet wh
-	while [[ ${1:condition} ]]; do
+	while [[ $1 ]]; do
 		${0:${VISUAL}}
 	done
 snippet until
-	until [[ ${1:condition} ]]; do
+	until [[ $1 ]]; do
 		${0:${VISUAL}}
 	done

--- a/snippets/c.snippets
+++ b/snippets/c.snippets
@@ -86,8 +86,8 @@ snippet elif
 snippet ifi
 	if (${1:true}) ${0};
 # ternary
-snippet t
-	${1:/* condition */} ? ${2:a} : ${3:b}
+snippet t Ternary: `condition ? true : false`
+	$1 ? $2 : $0
 # switch
 snippet switch
 	switch (${1:/* variable */}) {
@@ -138,7 +138,7 @@ snippet wht
 snippet do
 	do {
 		${0:${VISUAL}}
-	} while (${1:/* condition */});
+	} while ($1);
 ##
 ## Functions
 # function definition
@@ -351,7 +351,7 @@ snippet getopt
 
 ## Assertions
 snippet asr
-	assert(${1:condition});
+	assert($1);
 
 snippet anl
 	assert(${1:ptr} != NULL);

--- a/snippets/codeigniter.snippets
+++ b/snippets/codeigniter.snippets
@@ -99,7 +99,7 @@ snippet ci_db-select
 snippet ci_db-from
 	$this->db->from("${1:table}");${2}
 snippet ci_db-join
-	$this->db->join("${1:table}", "${2:condition}", "${3:type}");${4}
+	$this->db->join("${1:table}", "$2", "${3:type}");${4}
 snippet ci_db-where
 	$this->db->where("${1:key}", "${2:value}");${3}
 snippet ci_db-or_where

--- a/snippets/coffee/coffee.snippets
+++ b/snippets/coffee/coffee.snippets
@@ -54,24 +54,24 @@ snippet cla class .. extends .. constructor: ..
 		${0}
 # If
 snippet if
-	if ${1:condition}
+	if $1
 		${0:${VISUAL}}
 # If __ Else
 snippet ife
-	if ${1:condition}
+	if $1
 		${2:${VISUAL}}
 	else
-		${0:# body...}
+		${0}
 # Else if
 snippet eif
-	else if ${1:condition}
+	else if $1
 		${0:${VISUAL}}
 # Ternary If
-snippet ifte
-	if ${1:condition} then ${2:value} else ${0:other}
+snippet ifte Ternary
+	if $1 then $2 else $0
 # Unless
-snippet unl
-	${1:action} unless ${0:condition}
+snippet unl Unless
+	$1 unless $0
 # Switch
 snippet swi
 	switch ${1:object}

--- a/snippets/crystal.snippets
+++ b/snippets/crystal.snippets
@@ -1,12 +1,12 @@
 snippet req require
 	require "${1}"
 snippet case
-	case ${1:object}
-	when ${2:condition}
+	case $1
+	when $2
 		${0}
 	end
 snippet when
-	when ${1:condition}
+	when $1
 		${0}
 snippet def
 	def ${1:method_name}
@@ -17,17 +17,17 @@ snippet pdef
 		${0}
 	end
 snippet if
-	if ${1:condition}
+	if $1
 		${0:${VISUAL}}
 	end
 snippet ife
-	if ${1:condition}
+	if $1
 		${2:${VISUAL}}
 	else
 		${0}
 	end
 snippet wh
-	while ${1:condition}
+	while $1
 		${0:${VISUAL}}
 	end
 snippet cla class .. end

--- a/snippets/dart.snippets
+++ b/snippets/dart.snippets
@@ -61,15 +61,15 @@ snippet fore
 	  ${0}
 	}
 snippet wh
-	while (${1:/* condition */}) {
+	while ($1) {
 	  ${0}
 	}
 snippet dowh
 	do {
 	  ${0}
-	} while (${0:/* condition */});
+	} while ($0);
 snippet as
-	assert(${0:/* condition */});
+	assert($0);
 snippet try
 	try {
 	  ${0:${VISUAL}}

--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -13,29 +13,29 @@ snippet if if .. do .. end
 		${0:${VISUAL}}
 	end
 snippet if: if .. do: ..
-	if ${1:condition}, do: ${0}
+	if $1, do: ${0}
 snippet ife if .. do .. else .. end
-	if ${1:condition} do
+	if $1 do
 		${2:${VISUAL}}
 	else
 		${0}
 	end
 snippet ife: if .. do: .. else:
-	if ${1:condition}, do: ${2}, else: ${0}
+	if $1, do: ${2}, else: ${0}
 snippet unless unless .. do .. end
 	unless ${1} do
 		${0:${VISUAL}}
 	end
 snippet unless: unless .. do: ..
-	unless ${1:condition}, do: ${0}
+	unless $1, do: ${0}
 snippet unlesse unless .. do .. else .. end
-	unless ${1:condition} do
+	unless $1 do
 		${2:${VISUAL}}
 	else
 		${0}
 	end
 snippet unlesse: unless .. do: .. else:
-	unless ${1:condition}, do: ${2}, else: ${0}
+	unless $1, do: ${2}, else: ${0}
 snippet cond
 	cond do
 		${1} ->

--- a/snippets/falcon.snippets
+++ b/snippets/falcon.snippets
@@ -19,13 +19,13 @@ snippet class
 
 # If
 snippet if
-	if ${1:condition}
+	if $1
 		${0}
 	end
 
 # If else
 snippet ife
-	if ${1:condition}
+	if $1
 		${0}
 	else
 	    ${1}
@@ -33,7 +33,7 @@ snippet ife
 
 # If else if
 snippet eif
-	elif ${1:condition}
+	elif $1
 		${0}
 
 # Switch case

--- a/snippets/fortran.snippets
+++ b/snippets/fortran.snippets
@@ -64,7 +64,7 @@ snippet intent
 snippet /
 	(/ $1 /) ${2:,&} ${0}
 snippet if
-	if (${1:condition}) then
+	if ($1) then
 		${0}
 	end if
 snippet case
@@ -78,7 +78,7 @@ snippet do
 		${0}
 	end do
 snippet dow
-	do while (${1:condition})
+	do while ($1)
 		$2
 	end do
 snippet sub

--- a/snippets/go.snippets
+++ b/snippets/go.snippets
@@ -64,13 +64,13 @@ snippet inf "full interface "
 	}
 
 snippet if "if condition"
-	if ${1:/* condition */} {
+	if $1 {
 		${2:${VISUAL}}
 	}
 
 
 snippet ife "if else condition"
-	if ${1:/* condition */} {
+	if $1 {
 		${2:${VISUAL}}
 	} else {
 		${0}

--- a/snippets/haml.snippets
+++ b/snippets/haml.snippets
@@ -26,12 +26,12 @@ snippet mt
 snippet mts
 	= mail_to ${1:email_address}, ${2:name}, :subject => ${3}, :body => ${4}
 snippet ife
-	- if ${1:condition}
+	- if $1
 		${2:${VISUAL}}
 	- else
 		${0}
 snippet ifp
-	- if ${1:condition}.presence?
+	- if $1.presence?
 		${0:${VISUAL}}
 snippet ntc
 	= number_to_currency(${1})

--- a/snippets/htmltornado.snippets
+++ b/snippets/htmltornado.snippets
@@ -24,11 +24,11 @@ snippet for
 snippet from
 	{% from ${1:x} import ${0:y} %}
 snippet if
-	{% if ${1:condition} %}
+	{% if $1 %}
 	  ${0}
 	{% end %}
 snippet eif
-	{% elif ${0:condition} %}
+	{% elif $0 %}
 snippet el
 	{% else %}
 snippet import
@@ -50,6 +50,6 @@ snippet try
 	  ${0}
 	{% end %}
 snippet wh
-	{% while ${1:condition} %}
+	{% while $1 %}
 	  ${0}
 	{% end %}

--- a/snippets/java.snippets
+++ b/snippets/java.snippets
@@ -142,9 +142,9 @@ snippet ae
 snippet aae
 	assertArrayEquals("${1:Failure message}", ${2:expecteds}, ${3:actuals});
 snippet af
-	assertFalse("${1:Failure message}", ${2:condition});
+	assertFalse("${1:Failure message}", $2);
 snippet at
-	assertTrue("${1:Failure message}", ${2:condition});
+	assertTrue("${1:Failure message}", $2);
 snippet an
 	assertNull("${1:Failure message}", ${2:object});
 snippet ann

--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -62,8 +62,8 @@ snippet ife "if (condition) { ... } else { ... }"
 		${2}
 	}
 # tertiary conditional
-snippet ter
-	${1:/* condition */} ? ${2:/* if true */} : ${0:/* if false */}
+snippet ter Ternary: `condition ? true : false`
+	$1 ? $2: $0
 # switch
 snippet switch
 	switch (${1:expression}) {
@@ -117,7 +117,7 @@ snippet wht "(true) { ... }"
 snippet do "do { ... } while (condition)"
 	do {
 		${0:${VISUAL}}
-	} while (${1:/* condition */});
+	} while ($1);
 # For in loop
 snippet fori
 	for (let ${1:prop} in ${2:object}) {

--- a/snippets/liquid.snippets
+++ b/snippets/liquid.snippets
@@ -2,32 +2,32 @@
 # https://marketplace.visualstudio.com/items?itemName=killalau.vscode-liquid-snippets
 
 snippet if
-	{% if ${1:condition} %}
+	{% if $1 %}
 		${0:${VISUAL}}
 	{% endif %}
 snippet else
 	{% else %}
 snippet elsif
-	{% elsif ${1:condition} %}
+	{% elsif $1 %}
 snippet ifelse
-	{% if ${1:condition} %}
+	{% if $1 %}
 		${2}
 	{% else %}
 		${0}
 	{% endif %}
 snippet unless
-	{% unless ${1:condition} %}
+	{% unless $1 %}
 		${0:${VISUAL}}
 	{% endunless %}
 snippet case
 	{% case ${1:variable} %}
-		{% when ${2:condition} %}
+		{% when $2 %}
 			${3}
 		{% else %}
 			${0}
 	{% endcase %}
 snippet when
-	{% when ${1:condition} %}
+	{% when $1 %}
 		${0:${VISUAL}}
 snippet cycle
 	{% cycle '${1:odd}', '${2:even}' %}
@@ -102,32 +102,32 @@ snippet javascript
 snippet comment-
 	{%- comment -%}${0:${VISUAL}}{%- endcomment -%}
 snippet if-
-	{%- if ${1:condition} -%}
+	{%- if $1 -%}
 		${0:${VISUAL}}
 	{%- endif -%}
 snippet else-
 	{%- else -%}
 snippet elsif-
-	{%- elsif ${1:condition} -%}
+	{%- elsif $1 -%}
 snippet ifelse-
-	{%- if ${1:condition} -%}
+	{%- if $1 -%}
 		${2}
 	{%- else -%}
 		${0}
 	{%- endif -%}
 snippet unless-
-	{%- unless ${1:condition} -%}
+	{%- unless $1 -%}
 		${0:${VISUAL}}
 	{%- endunless -%}
 snippet case-
 	{%- case ${1:variable} -%}
-		{%- when ${2:condition} -%}
+		{%- when $2 -%}
 			${3}
 		{%- else -%}
 			${0}
 	{%- endcase -%}
 snippet when-
-	{%- when ${1:condition} -%}
+	{%- when $1 -%}
 		${0:${VISUAL}}
 snippet cycle-
 	{%- cycle '${1:odd}', '${2:even}' -%}

--- a/snippets/lpc.snippets
+++ b/snippets/lpc.snippets
@@ -66,8 +66,8 @@ snippet elif
 snippet ifi
 	if(${1:true}) ${0};
 # ternary
-snippet t
-	${1:/* condition */} ? ${2:a} : ${3:b}
+snippet t Ternary: `condition ? true : false`
+	$1 ? $2 : $0
 # switch
 snippet switch
 	switch(${1:/* variable */})
@@ -115,7 +115,7 @@ snippet forr
 	}
 # while
 snippet wh
-	while(${1:/* condition */})
+	while($1)
 	{
 		${0:${VISUAL}}
 	}
@@ -123,7 +123,7 @@ snippet wh
 snippet do
 	do{
 		${0:${VISUAL}}
-	}while (${1:/* condition */});
+	}while ($1);
 ##
 ## Functions
 # function definition

--- a/snippets/ls.snippets
+++ b/snippets/ls.snippets
@@ -54,24 +54,24 @@ snippet cla class .. extends .. constructor: ..
 		${5}
 # If
 snippet if
-	if ${1:condition}
+	if $1
 		${2}
 # If __ Else
 snippet ife
-	if ${1:condition}
+	if $1
 		${2}
 	else
 		${3}
 # Else if
 snippet elif
-	else if ${1:condition}
+	else if $1
 		${2}
 # Ternary If
 snippet ifte
-	if ${1:condition} then ${2:value} else ${3:other}
+	if $1 then $2 else $0
 # Unless
 snippet unl
-	${1:action} unless ${2:condition}
+	$1 unless $0
 # Switch
 snippet swi
 	switch ${1:object}

--- a/snippets/lua.snippets
+++ b/snippets/lua.snippets
@@ -20,24 +20,24 @@ snippet fori
 		${0:-- body}
 	end
 snippet if
-	if ${1:condition} then
+	if $1 then
 		${2:-- body}
 	end
 snippet ife
-	if ${1:condition} then
+	if $1 then
 		${2:-- if condition}
 	else
 		${0:-- else}
 	end
 snippet elif
-	elseif ${1:condition} then
+	elseif $1 then
 		${0:--body}
 snippet repeat
 	repeat
 		${1:--body}
-	until ${0:condition}
+	until $0
 snippet while
-	while ${1:condition} do
+	while $1 do
 		${0:--body}
 	end
 snippet wh

--- a/snippets/mako.snippets
+++ b/snippets/mako.snippets
@@ -19,11 +19,11 @@ snippet for
 		${0:}
 	% endfor
 snippet if if
-	% if ${1:condition}:
+	% if $1:
 		${0:}
 	% endif
 snippet ife if/else
-	% if ${1:condition}:
+	% if $1:
 		${2:}
 	% else:
 		${0:}

--- a/snippets/perl.snippets
+++ b/snippets/perl.snippets
@@ -40,7 +40,7 @@ snippet eif
 	}
 # Conditional One-line
 snippet xif
-	${1:expression} if ${2:condition};
+	$1 if $0;
 # Unless conditional
 snippet unless
 	unless (${1}) {
@@ -48,7 +48,7 @@ snippet unless
 	}
 # Unless conditional One-line
 snippet xunless
-	${1:expression} unless ${2:condition};
+	$1 unless $0;
 # Try/Except
 snippet eval
 	local $@;
@@ -65,7 +65,7 @@ snippet wh
 	}
 # While Loop One-line
 snippet xwh
-	${1:expression} while ${2:condition};
+	$1 while $0;
 # C-style For Loop
 snippet cfor
 	for (my $${2:var} = 0; $$2 < ${1:count}; $$2${3:++}) {
@@ -73,7 +73,7 @@ snippet cfor
 	}
 # For loop one-line
 snippet xfor
-	${1:expression} for @${2:array};
+	$1 for @$0;
 # Foreach Loop
 snippet for
 	foreach my $${1:x} (@${2:array}) {
@@ -81,7 +81,7 @@ snippet for
 	}
 # Foreach Loop One-line
 snippet fore
-	${1:expression} foreach @${2:array};
+	$1 foreach @$0;
 # Package
 snippet package
 	package ${1:`expand('%:p:s?.*lib/??:r:gs?/?::?')`};

--- a/snippets/perl6.snippets
+++ b/snippets/perl6.snippets
@@ -33,7 +33,7 @@ snippet eif
 	}
 # Conditional One-line
 snippet xif
-	${1:expression} if ${2:condition};
+	${1} if $2;
 # Unless conditional
 snippet unless
 	unless ${1} {
@@ -41,14 +41,14 @@ snippet unless
 	}
 # Unless conditional One-line
 snippet xunless
-	${1:expression} unless ${2:condition};
+	${1} unless $2;
 # Ternary conditional
 snippet tc
-	${1:condition} ?? ${2:value-if-true} !! ${3:value-if-false};
+	$1 ?? ${2:value-if-true} !! ${3:value-if-false};
 # given - when (perl6 switch)
 snippet switch
 	given ${1:$var} {
-	  when ${2:condition} {
+	  when $2 {
 		  ${3:# code block ...}
 	  }
 	  ${4}

--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -86,7 +86,7 @@ snippet =?:
 snippet ?:
 	${1:true} ? ${2:a} : ${0}
 snippet t "$retVal = (condition) ? a : b"
-	$${1:retVal} = (${2:condition}) ? ${3:a} : ${4:b};
+	$${1:retVal} = ($2) ? ${3:a} : ${4:b};
 # Predefined variables
 snippet C
 	$_COOKIE['${1:variable}']
@@ -283,7 +283,7 @@ snippet def "define('VARIABLE_NAME', 'definition')"
 snippet def?
 	${1}defined('${2}')
 snippet wh "while (condition) { ... }"
-	while (${1:/* condition */}) {
+	while ($1) {
 		${0:${VISUAL}}
 	}
 snippet do "do { ... } while (condition)"

--- a/snippets/processing.snippets
+++ b/snippets/processing.snippets
@@ -64,7 +64,7 @@ snippet for
 	};
 #loop while
 snippet wh
-	while (${1:/* condition */}) {
+	while ($1) {
 		${0}
 	}
 #break

--- a/snippets/ps1.snippets
+++ b/snippets/ps1.snippets
@@ -43,13 +43,13 @@ snippet enum
 
 # PowerShell if..then
 snippet if
-	if (${1:condition}) {
-		${2:statement}
+	if ($1) {
+		$0
 	}
 
 # PowerShell if..else
 snippet ife
-	if ( ${1:condition} ) {
+	if ( $1 ) {
 		${2}
 	}
 	else {
@@ -58,8 +58,8 @@ snippet ife
 
 # PowerShell While Loop
 snippet while
-	while (${1:condition}) {
-		${2:statement}
+	while ($1) {
+		$0
 	}
 
 # PowerShell Filter..Sort
@@ -69,7 +69,7 @@ snippet filtersort
 # PowerShell foreach
 snippet foreach
 	foreach ( $${1:iterator} in $${2:collection} ) {
-		${3:statement}
+		$0
 	}
 
 # PowerShell export-csv

--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -28,14 +28,14 @@ snippet sk "skip unittests" b
 	@unittest.skip(${1:skip_reason})
 
 snippet wh
-	while ${1:condition}:
+	while $1:
 		${0:${VISUAL}}
 
 # dowh - does the same as do...while in other languages
 snippet dowh
 	while True:
 		${1}
-		if ${0:condition}:
+		if $0:
 			break
 
 snippet with
@@ -115,13 +115,13 @@ snippet property
 
 # Ifs
 snippet if
-	if ${1:condition}:
+	if $1:
 		${0:${VISUAL}}
 snippet el
 	else:
 		${0:${VISUAL}}
 snippet ei
-	elif ${1:condition}:
+	elif $1:
 		${0:${VISUAL}}
 
 # Match

--- a/snippets/r.snippets
+++ b/snippets/r.snippets
@@ -11,7 +11,7 @@ snippet source
 
 # conditionals
 snippet if
-	if (${1:condition}) {
+	if ($1) {
 		${0}
 	}
 snippet el
@@ -19,7 +19,7 @@ snippet el
 		${0}
 	}
 snippet ei
-	else if (${1:condition}) {
+	else if ($1) {
 		${0}
 	}
 

--- a/snippets/rmd.snippets
+++ b/snippets/rmd.snippets
@@ -27,7 +27,7 @@ snippet req
 	require(${1:}, quietly = TRUE)
 # If Condition
 snippet if
-	if ( ${1:condition} )
+	if ( $1 )
 	{
 		${2:}
 	}
@@ -51,7 +51,7 @@ snippet fun
 snippet re
 	repeat{
 	  ${2:}
-	  if(${1:condition}) break
+	  if($1) break
 	}
 
 # matrix

--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -34,11 +34,11 @@ snippet #
 	# =>
 snippet case
 	case ${1:object}
-	when ${2:condition}
+	when $2
 		${0}
 	end
 snippet when
-	when ${1:condition}
+	when $1
 		${0:${VISUAL}}
 snippet def
 	def ${1:method_name}
@@ -55,46 +55,46 @@ snippet descendants
 		end
 	end
 snippet if
-	if ${1:condition}
+	if $1
 		${0:${VISUAL}}
 	end
 snippet ife
-	if ${1:condition}
+	if $1
 		${2:${VISUAL}}
 	else
 		${0}
 	end
 snippet eif
-	elsif ${1:condition}
+	elsif $1
 		${0:${VISUAL}}
 snippet ifee
-	if ${1:condition}
+	if $1
 		$2
-	elsif ${3:condition}
+	elsif $3
 		$4
 	else
 		$0
 	end
 snippet unless
-	unless ${1:condition}
+	unless $1
 		${0:${VISUAL}}
 	end
 snippet unlesse
-	unless ${1:condition}
+	unless $1
 		$2
 	else
 		$0
 	end
 snippet unlesee
-	unless ${1:condition}
+	unless $1
 		$2
-	elsif ${3:condition}
+	elsif $3
 		$4
 	else
 		$0
 	end
 snippet wh
-	while ${1:condition}
+	while $1
 		${0:${VISUAL}}
 	end
 snippet for
@@ -102,7 +102,7 @@ snippet for
 		${0}
 	end
 snippet until
-	until ${1:condition}
+	until $1
 		${0:${VISUAL}}
 	end
 snippet cla class .. end

--- a/snippets/rust.snippets
+++ b/snippets/rust.snippets
@@ -147,7 +147,7 @@ snippet loop "loop {}" b
 		${0:${VISUAL}}
 	}
 snippet wh "while loop"
-	while ${1:condition} {
+	while $1 {
 		${0:${VISUAL}}
 	}
 snippet whl "while let (...)"

--- a/snippets/sass.snippets
+++ b/snippets/sass.snippets
@@ -13,15 +13,15 @@ snippet fun
 	@function ${1:name}(${2:args})
 		${0}
 snippet if
-	@if ${1:condition}
+	@if $1
 		${0:${VISUAL}}
 snippet ife
-	@if ${1:condition}
+	@if $1
 		${2:${VISUAL}}
 	@else
 		${0}
 snippet eif
-	@else if ${1:condition}
+	@else if $1
 		${0:${VISUAL}}
 snippet for
 	@for ${1:$i} from ${2:1} through ${3:3}

--- a/snippets/scss.snippets
+++ b/snippets/scss.snippets
@@ -17,17 +17,17 @@ snippet fun
 		${0}
 	}
 snippet if
-	@if ${1:condition} {
+	@if $1 {
 		${0}
 	}
 snippet ife
-	@if ${1:condition} {
+	@if $1 {
 		${2}
 	} @else {
 		${0}
 	}
 snippet eif
-	@else if ${1:condition} {
+	@else if $1 {
 		${0}
 	}
 snippet for

--- a/snippets/sh.snippets
+++ b/snippets/sh.snippets
@@ -18,11 +18,11 @@ snippet sbash
 	IFS=$'\n\t'
 
 snippet if
-	if [ ${1:condition} ]; then
+	if [ $1 ]; then
 		${0:${VISUAL}}
 	fi
 snippet elif
-	elif [ ${1:condition} ]; then
+	elif [ $1 ]; then
 		${0:${VISUAL}}
 snippet for
 	for (( ${2:i} = 0; $2 < ${1:count}; $2++ )); do
@@ -33,7 +33,7 @@ snippet fori
 		${0:${VISUAL}}
 	done
 snippet wh
-	while [ ${1:condition} ]; do
+	while [ $1 ]; do
 		${0:${VISUAL}}
 	done
 snippet wht
@@ -41,7 +41,7 @@ snippet wht
 		${0:${VISUAL}}
 	done
 snippet until
-	until [ ${1:condition} ]; do
+	until [ $1 ]; do
 		${0:${VISUAL}}
 	done
 snippet case

--- a/snippets/yii.snippets
+++ b/snippets/yii.snippets
@@ -144,7 +144,7 @@ snippet yrp
 #----------------Yii Model-----------------------------
 #Yii Model count
 snippet ycountm
-	${1:ModelName}::model()->count(${2:condition}, array('${3:key}'=>${0:value}));
+	${1:ModelName}::model()->count($2, array('${3:key}'=>${0:value}));
 
 #Yii Model countBySql
 snippet ycountbs
@@ -152,35 +152,35 @@ snippet ycountbs
 
 #Yii Model updateAll
 snippet yupdatea
-	${1:ModelName}::model()->updateAll(${2:array('attributes')}, ${3:condition},array('${4:key}'=>${0:value}));
+	${1:ModelName}::model()->updateAll(${2:array('attributes')}, $3,array('${4:key}'=>${0:value}));
 
 #Yii Model updateByPk
 snippet yupdatebp
-	${1:ModelName}::model()->updateByPk(${2:pk}, ${3:array('attributes')}, ${4:condition},array('${5:key}'=>${0:value}));
+	${1:ModelName}::model()->updateByPk(${2:pk}, ${3:array('attributes')}, $4,array('${5:key}'=>${0:value}));
 
 #Yii Model deleteAll
 snippet ydela
-	${1:ModelName}::model()->deleteAll(${2:condition},array('${3:key}'=>${0:value}));
+	${1:ModelName}::model()->deleteAll($2,array('${3:key}'=>${0:value}));
 
 #Yii Model deleteByPk
 snippet ydelbp
-	${1:ModelName}::model()->deleteByPk(${2:pk}, ${3:condition}, array('${4:key}'=>${0:value}));
+	${1:ModelName}::model()->deleteByPk(${2:pk}, $3, array('${4:key}'=>${0:value}));
 
 #Yii Model find
 snippet yfind
-	${1:ModelName}::model()->find(${2:condition},array('${3:key}'=>${0:value}));
+	${1:ModelName}::model()->find($2,array('${3:key}'=>${0:value}));
 
 #Yii Model findAll
 snippet yfinda
-	${1:ModelName}::model()->findAll(${2:condition},array('${3:key}'=>${0:value}));
+	${1:ModelName}::model()->findAll($2,array('${3:key}'=>${0:value}));
 
 #Yii Model findByPk
 snippet yfindbp
-	${1:ModelName}::model()->findByPk(${2:pk}, ${3:condition}, array('${4:key}'=>${0:value}));
+	${1:ModelName}::model()->findByPk(${2:pk}, $3, array('${4:key}'=>${0:value}));
 
 #Yii Model findAllByPk
 snippet yfindabp
-	${1:ModelName}::model()->findAllByPk(${2:pk}, ${3:condition},array('${4:key}'=>${0:value}));
+	${1:ModelName}::model()->findAllByPk(${2:pk}, $3,array('${4:key}'=>${0:value}));
 
 #Yii Model findBySql
 snippet yfindbs
@@ -188,11 +188,11 @@ snippet yfindbs
 
 #Yii Model findAllByAttributes
 snippet yfindaba
-	${1:ModelName}::model()->findAllByAttributes(array('${2:attributeName}'=>${3:attributeValue}), ${4:condition}, array('${5:key}'=>${0:value}));
+	${1:ModelName}::model()->findAllByAttributes(array('${2:attributeName}'=>${3:attributeValue}), $4, array('${5:key}'=>${0:value}));
 
 #Yii Model exists
 snippet yexists
-	${1:ModelName}::model()->exists(${2:condition}, array('${3:key}'=>${0:value}));
+	${1:ModelName}::model()->exists($2, array('${3:key}'=>${0:value}));
 
 #Yii Create model class
 snippet ymodel

--- a/snippets/zsh.snippets
+++ b/snippets/zsh.snippets
@@ -5,17 +5,17 @@ snippet #!
 	#!/usr/bin/env zsh
 
 snippet if
-	if ${1:condition}; then
+	if $1; then
 		${0:${VISUAL}}
 	fi
 snippet ife
-	if ${1:condition}; then
+	if $1; then
 		${2:${VISUAL}}
 	else
 		${0:# statements}
 	fi
 snippet eif
-	elif ${1:condition}; then
+	elif $1; then
 		${0:${VISUAL}}
 snippet for
 	for (( ${2:i} = 0; $2 < ${1:count}; $2++ )); do
@@ -30,11 +30,11 @@ snippet fore
 		${0:${VISUAL}}
 	done
 snippet wh
-	while ${1:condition}; do
+	while $1; do
 		${0:${VISUAL}}
 	done
 snippet until
-	until ${1:condition}; do
+	until $1; do
 		${0:${VISUAL}}
 	done
 snippet repeat


### PR DESCRIPTION
This [section](https://github.com/honza/vim-snippets#things-to-consider-when-contributing) of the README states:

> Don't add useless placeholder default texts

A lot of snippets still do this though, so I used a regular expression and some manual editing to fix it.