### PR TITLE
Snippet for #pragma once include guard

### DIFF
--- a/UltiSnips/cpp.snippets
+++ b/UltiSnips/cpp.snippets
@@ -30,6 +30,11 @@ endglobal
 ###########################################################################
 #                            TextMate Snippets                            #
 ###########################################################################
+snippet ponce "#pragma once include guard"
+#pragma once
+
+endsnippet
+
 snippet main
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
It is non-standard, but most (all?) compilers implement it.

See also https://en.wikipedia.org/wiki/Pragma_once#Portability