### PR TITLE
Snippets for Range-v3 and C++20's <ranges> entities

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -230,3 +230,24 @@ snippet af auto function
 	{
 		${0}
 	};
+# Range-v3 transform
+snippet transform "ranges::views::transform"
+	${1:${2:std::}${3:ranges::}views::}transform($4)
+# Range-v3 transform
+snippet filter "ranges::views::filter"
+	${1:${2:std::}${3:ranges::}views::}filter($4)
+# Range-v3 ranges::
+snippet r "ranges::"
+	ranges::
+# Range-v3 ranges::views::
+snippet rv "ranges::views::"
+	ranges::views::
+# Range-v3 ranges::actions::
+snippet ra "ranges::actions::"
+	ranges::actions::
+# STL std::ranges::
+snippet sr "std::ranges::"
+	std::ranges::
+# STL std::views::
+snippet sv "std::views::"
+	std::views::


### PR DESCRIPTION
I find myself very frequently writing `ranges::views::`, and I'd be doing the same with `std::views::` if I was using C++20, so I think this snippets can be useful.

`transform` and `filter` are two of the most used adapters, so haveing a snippet for them is good (for both `std::` and `ranges::`, at the price of a backspace).