### PR TITLE
Disable auto trigger for leq and geq

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -371,11 +371,11 @@ snippet != "Not Equal" w
 \neq 
 endsnippet
 
-snippet <= "leq" Aw
+snippet <= "leq" w
 \le 
 endsnippet
 
-snippet >= "geq" Aw
+snippet >= "geq" w
 \ge 
 endsnippet
 


### PR DESCRIPTION
Disabled auto expansions of the following snippets
- `>=` -> `\ge`
- `<=` -> `\le`

When writing inline code using `\verb` or `minted`, the manual behavior would be more suitable.