### PR TITLE
Fix LaTeX snippet for inverse

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -400,7 +400,7 @@ snippet <! "normal" Aw
 \triangleleft 
 endsnippet
 
-snippet "(\d|\w)+invs" "inverse" Awr
+snippet "((\d|\w)+)invs" "inverse" Awr
 `!p snip.rv = match.group(1)`^{-1}
 endsnippet
 


### PR DESCRIPTION
If you type <kbd>1</kbd><kbd>2</kbd><kbd>3</kbd><kbd>i</kbd><kbd>n</kbd><kbd>v</kbd><kbd>s</kbd>, you'll see that it will be expanded to `3^{-1}`, throwing away anything but the last character before `invs`. This fixes it.