### PR TITLE
elixir.snippets extending html to allow html completions in elixir files

### DIFF
--- a/snippets/elixir.snippets
+++ b/snippets/elixir.snippets
@@ -1,3 +1,5 @@
+extends html
+
 snippet do
 	do
 		${0:${VISUAL}}


### PR DESCRIPTION
I was trying to write a HEEx template inside an elixir file inside the render function. I could not use the completions, doing this fixed it.