### PR TITLE
fix the escape issue with python 3.12.0

### DIFF
--- a/pythonx/vimsnippets.py
+++ b/pythonx/vimsnippets.py
@@ -14,7 +14,7 @@ def complete(tab, opts):
     :return: a string that match with tab
     """
     el = [x for x in tab]
-    pat = "".join(list(map(lambda x: x + "\w*" if re.match("\w", x) else x,
+    pat = "".join(list(map(lambda x: x + r"\w*" if re.match(r"\w", x) else x,
                            el)))
     try:
         opts = [x for x in opts if re.search(pat, x, re.IGNORECASE)]


### PR DESCRIPTION
Here is the update with 3.12.0.

A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)


Therefore, we need use r"<string>".