### PR TITLE
Add GTest support

### DIFF
--- a/snippets/cpp.snippets
+++ b/snippets/cpp.snippets
@@ -251,3 +251,29 @@ snippet sr "std::ranges::"
 # STL std::views::
 snippet sv "std::views::"
 	std::views::
+##
+## Tests
+# GTest:add main
+snippet gtemain "GTest:add main"
+	int main(int argc, char **argv) {
+		testing::InitGoogleTest(&argc, argv);
+		return RUN_ALL_TESTS();
+	}
+# GTest:add test
+snippet gtetest "GTest:add test"
+	TEST(${1:SuiteName}, ${2:TestName}) {
+		${0}
+	}
+# GTest:add fixture
+snippet gtefix "GTest:add fixture"
+	TEST_F(${1:SuiteName}, ${2:TestName}) {
+		${0}
+	}
+# GTest:add parameterized test
+snippet gtepar "GTest:add parameterized test"
+	TEST_P(${1:SuiteName}, ${2:TestName}) {
+		${0}
+	}
+# GTest:instantiate parameterized test
+snippet gteparins "GTest:instantiate parameterized test"
+	INSTANTIATE_TEST_SUITE_P(${1:InstantiationName}, ${2:SuiteName}, ${0});


### PR DESCRIPTION
I found some GTest macros are frequently used in day-to-day activities. On the one hand, it makes them good candidates for adding to snippets. On the other hand, they are not a part of the language, and I have some doubts about adding them to CPP snippets.

So, I created MR for reviewing and discussing. 

Thanks