### PR TITLE
fix the escape issue with python 3.12.0

### DIFF
--- a/UltiSnips/java.snippets
+++ b/UltiSnips/java.snippets
@@ -21,7 +21,7 @@ def nl(snip):
 		snip.rv += " "
 def getArgs(group):
 	import re
-	word = re.compile('[a-zA-Z0-9><.]+ \w+')
+	word = re.compile(r'[a-zA-Z0-9><.]+ \w+')
 	return [i.split(" ") for i in word.findall(group) ]
 
 def camel(word):


### PR DESCRIPTION
Here is the update with 3.12.0.

A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in https://github.com/python/cpython/issues/98401.)

Therefore, we need use r"".