### PR TITLE
Update ruby.snippets: add binding.irb debug

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -612,6 +612,8 @@ snippet debug18
 	require 'ruby-debug'; debugger
 snippet pry
 	require 'pry'; binding.pry
+snippet irb
+	binding.irb
 snippet strf
 	strftime('${1:%Y-%m-%d %H:%M:%S %z}')${0}
 #


### PR DESCRIPTION
["If you use Ruby 2.5 or later versions, you can also use binding.irb in your program as breakpoints."](https://github.com/ruby/irb?tab=readme-ov-file#the-bindingirb-breakpoint)
