### PR TITLE
Remove the default protocol for markdown link creation

### DIFF
--- a/snippets/markdown.snippets
+++ b/snippets/markdown.snippets
@@ -5,7 +5,7 @@
 # The suffix `c` stands for "Clipboard".
 
 snippet [
-	[${1:text}](https://${2:address})
+	[${1:text}](${2:address})
 snippet [*
 	[${1:link}](${2:`@*`})
 snippet [c


### PR DESCRIPTION
I think it makes sense for the default behavior to be not adding a protocol to a link. 99% of the time when I'm adding a link into markdown I don't just copy the domain and path but the entire protocol. And sometimes my links are anchor tags or to other files. So removing the default `https:` protocol I believe makes the most sense.