### PR TITLE
tex: Remove unnumbered equation

### DIFF
--- a/snippets/tex.snippets
+++ b/snippets/tex.snippets
@@ -91,11 +91,6 @@ snippet eq* unnumbered equation environment
 	\\begin{equation*}
 		${0:${VISUAL}}
 	\\end{equation*}
-# Unnumbered Equation
-snippet \ unnumbered equation: \[ ... \]
-	\\[
-		${0:${VISUAL}}
-	\\]
 # Equation array
 snippet eqnarray eqnarray environment
 	\\begin{eqnarray}


### PR DESCRIPTION
This PR removes the unnumbered equation snippet `snippet \`.

This snippet leads to a lot unwanted use, especially when using `\\` used very commonly for linebreaks in itemize.
I also interferes with verbatim envs where the target language uses `\` at the end of the line (Dockerfile, shell scripts, C/C++ Macros).

```tex
\begin{itemize}
  \item First line\\|
   second line
  \item etc
\end{itemize}
```
