### PR TITLE
New snippets for Verilog and some reorganization 2

### DIFF
--- a/snippets/systemverilog.snippets
+++ b/snippets/systemverilog.snippets
@@ -1,32 +1,35 @@
 extends verilog
 
-# Foreach Loop
-snippet forea
+snippet tdsp "typedef struct packed"
+	typedef struct packed {
+		int ${2:data};
+	} ${1:`vim_snippets#Filename('$1_t', 'name')`};
+snippet tde "typedef enum"
+	typedef enum ${2:logic[15:0]}
+	{
+		${3:REG = 16'h0000}
+	} ${1:my_dest_t};
+snippet forea "Foreach Loop"
 	foreach (${1}) begin
 		${0}
 	end
-# Do-while statement
-snippet dowh
+snippet dowh "Do-while statement"
 	do begin
 		${0}
 	end while (${1});
-# Combinational always block
-snippet alc
+snippet alc "Combinational always block"
 	always_comb begin ${1:: statement_label}
 		${0}
 	end $1
-# Sequential logic
-snippet alff
+snippet alff "Sequential logic"
 	always_ff @(posedge ${1:clk}) begin ${2:: statement_label}
 		${0}
 	end $2
-# Latched logic
-snippet all
+snippet all "Latched logic"
 	always_latch begin ${1:: statement_label}
 		${0}
 	end $1
-# Class
-snippet cl
+snippet cl "Class"
 	class ${1:class_name};
 		// data or class properties
 		${0}
@@ -36,18 +39,15 @@ snippet cl
 		endfunction : new
 
 	endclass : $1
-# Typedef structure
-snippet types
+snippet types "Typedef structure"
 	typedef struct {
 		${0}
 	} ${1:name_t};
-# Program block
-snippet prog
+snippet prog "Program block"
 	program ${1:program_name} ();
 		${0}
 	endprogram : $1
-# Interface block
-snippet intf
+snippet intf "Interface block"
 	interface ${1:program_name} ();
 		// nets
 		${0}
@@ -56,18 +56,15 @@ snippet intf
 		// modports
 
 	endinterface : $1
-# Clocking Block
-snippet clock
+snippet clock "Clocking Block"
 	clocking ${1:clocking_name} @(${2:posedge} ${3:clk});
 		${0}
 	endclocking : $1
-# Covergroup construct
-snippet cg
+snippet cg "Covergroup construct"
 	covergroup ${1:group_name} @(${2:posedge} ${3:clk});
 		${0}
 	endgroup : $1
-# Package declaration
-snippet pkg
+snippet pkg "Package declaration"
 	package ${1:package_name};
 		${0}
 	endpackage : $1

--- a/snippets/verilog.snippets
+++ b/snippets/verilog.snippets
@@ -8,6 +8,32 @@ snippet be "Begin-end"
 	end
 snippet cond "Conditional operator"
 	(${1:if}) ? ${2:then} : ${3:else};
+snippet fsm "Finite state machine"
+	localparam ${1:IDLE} = 0;
+	${2:/*other states*/}
+
+	reg [${3:n}:${4:0}] ${5:state}_reg, $5_next;
+	always @(posedge clk) begin
+		if (rst) begin
+			$5_reg <= $1;
+		end
+		else begin
+			$5_reg <= $5_next;
+		end
+	end
+
+	always @* begin
+		// default values, regardless of state
+
+		case ($5_reg)
+			$1: begin
+				${6:/* $1 behavior */}
+			end
+			default: begin
+				$5_next = $1;
+			end
+		encase
+	end
 snippet gen "Generate block"
 	generate
 		${0:${VISUAL}}
@@ -128,8 +154,8 @@ snippet modp "Module with parameters"
 		${0:${VISUAL}}
 	endmodule
 snippet for "For"
-	for (int ${2:i} = 0; $2 < ${1:count}; $2${3:++}) begin
-		${4:${VISUAL}}
+	for (${1:i} = ${2:0}; ${3:i < count}; ${4:i = i + 1}) begin
+		${5:${VISUAL}}
 	end
 snippet forev "Forever"
 	forever begin

--- a/snippets/verilog.snippets
+++ b/snippets/verilog.snippets
@@ -7,7 +7,7 @@ snippet be "Begin-end"
 		${0:${VISUAL}}
 	end
 snippet cond "Conditional operator"
-	(${1:if}) ? ${2:then} : ${3:else};
+	(${1:if}) ? ${2:then} : ${3:else}
 snippet fsm "Finite state machine"
 	localparam ${1:IDLE} = 0;
 	${2:/*other states*/}

--- a/snippets/verilog.snippets
+++ b/snippets/verilog.snippets
@@ -1,73 +1,73 @@
 snippet if "if statement"
 	if (${1}) begin
-		${0}
+		${0:${VISUAL}}
 	end
 snippet ife "If/else statements"
 	if (${1}) begin
-		${2}
+		${2:${VISUAL}}
 	end
 	else begin
-		${3}
+		${3:${VISUAL}}
 	end
 snippet eif "Else if statement"
 	else if (${1}) begin
-		${0}
+		${0:${VISUAL}}
 	end
-snippet el "statement"
+snippet el "Else statement"
 	else begin
-		${0}
+		${0:${VISUAL}}
 	end
 snippet wh "While statement"
 	while (${1}) begin
-		${0}
+		${0:${VISUAL}}
 	end
 snippet rep "Repeat Loop"
 	repeat (${1}) begin
-		${0}
+		${0:${VISUAL}}
 	end
 snippet case "Case statement"
 	case (${1:/* variable */})
 		${2:/* value */}: begin
-			${3}
+			${3:${VISUAL}}
 		end
 		default: begin
-			${4}
+			${4:${VISUAL}}
 		end
 	endcase
 snippet casez "CaseZ statement"
 	casez (${1:/* variable */})
 		${2:/* value */}: begin
-			${3}
+			${3:${VISUAL}}
 		end
 		default: begin
-			${4}
+			${4:${VISUAL}}
 		end
 	endcase
 snippet al "Always block"
 	always @(${1:/* sensitive list */}) begin
-		${0}
+		${2:${VISUAL}}
 	end
 snippet mod "Module block"
 	module ${1:`vim_snippets#Filename('$1', 'name')`} (${2});
-		${0}
+		${0:${VISUAL}}
 	endmodule
 snippet for "For"
 	for (int ${2:i} = 0; $2 < ${1:count}; $2${3:++}) begin
-		${4}
+		${4:${VISUAL}}
 	end
 snippet forev "Forever"
 	forever begin
-		${0}
+		${0:${VISUAL}}
 	end
 snippet fun "Function"
 	function ${1:void} ${2:name}(${3});
-		${0}
+		${0:${VISUAL}}
 	endfunction: $2
 snippet task "Task"
 	task ${1:name}(${2});
-		${0}
+		${0:${VISUAL}}
 	endtask: $1
 snippet ini "Initial "
 	initial begin
-		${0}
+		${0:${VISUAL}}
 	end

--- a/snippets/verilog.snippets
+++ b/snippets/verilog.snippets
@@ -1,38 +1,31 @@
-# if statement
-snippet if
+snippet if "if statement"
 	if (${1}) begin
 		${0}
 	end
-# If/else statements
-snippet ife
+snippet ife "If/else statements"
 	if (${1}) begin
 		${2}
 	end
 	else begin
 		${3}
 	end
-# Else if statement
-snippet eif
+snippet eif "Else if statement"
 	else if (${1}) begin
 		${0}
 	end
-#Else statement
-snippet el
+snippet el "statement"
 	else begin
 		${0}
 	end
-# While statement
-snippet wh
+snippet wh "While statement"
 	while (${1}) begin
 		${0}
 	end
-# Repeat Loop
-snippet rep
+snippet rep "Repeat Loop"
 	repeat (${1}) begin
 		${0}
 	end
-# Case statement
-snippet case
+snippet case "Case statement"
 	case (${1:/* variable */})
 		${2:/* value */}: begin
 			${3}
@@ -41,8 +34,7 @@ snippet case
 			${4}
 		end
 	endcase
-# CaseZ statement
-snippet casez
+snippet casez "CaseZ statement"
 	casez (${1:/* variable */})
 		${2:/* value */}: begin
 			${3}
@@ -51,49 +43,31 @@ snippet casez
 			${4}
 		end
 	endcase
-# Always block
-snippet al
+snippet al "Always block"
 	always @(${1:/* sensitive list */}) begin
 		${0}
 	end
-# Module block
-snippet mod
+snippet mod "Module block"
 	module ${1:`vim_snippets#Filename('$1', 'name')`} (${2});
 		${0}
 	endmodule
-# For
-snippet for
+snippet for "For"
 	for (int ${2:i} = 0; $2 < ${1:count}; $2${3:++}) begin
 		${4}
 	end
-# Forever
-snippet forev
+snippet forev "Forever"
 	forever begin
 		${0}
 	end
-# Function
-snippet fun
+snippet fun "Function"
 	function ${1:void} ${2:name}(${3});
 		${0}
 	endfunction: $2
-# Task
-snippet task
+snippet task "Task"
 	task ${1:name}(${2});
 		${0}
 	endtask: $1
-# Initial 
-snippet ini
+snippet ini "Initial "
 	initial begin
 		${0}
 	end
-# typedef struct packed
-snippet tdsp
-	typedef struct packed {
-		int ${2:data};
-	} ${1:`vim_snippets#Filename('$1_t', 'name')`};
-# typedef eum
-snippet tde
-	typedef enum ${2:logic[15:0]}
-	{
-		${3:REG = 16'h0000}
-	} ${1:my_dest_t};

--- a/snippets/verilog.snippets
+++ b/snippets/verilog.snippets
@@ -164,11 +164,11 @@ snippet forev "Forever"
 snippet fun "Function"
 	function ${1:void} ${2:name}(${3});
 		${0:${VISUAL}}
-	endfunction: $2
+	endfunction
 snippet task "Task"
 	task ${1:name}(${2});
 		${0:${VISUAL}}
-	endtask: $1
+	endtask
 snippet ini "Initial "
 	initial begin
 		${0:${VISUAL}}

--- a/snippets/verilog.snippets
+++ b/snippets/verilog.snippets
@@ -1,3 +1,53 @@
+snippet . "IO when instantiating the module"
+	.${1:io_name}(${2:$1})
+snippet as "Assign"
+	assign ${1:name} = ${2:value};
+snippet be "Begin-end"
+	begin
+		${0:${VISUAL}}
+	end
+snippet cond "Conditional operator"
+	(${1:if}) ? ${2:then} : ${3:else};
+snippet gen "Generate block"
+	generate
+		${0:${VISUAL}}
+	endgenerate
+snippet in "Input"
+	input ${1:input_name}_i
+snippet inst "Instantiate module"
+	${1:module_name} ${2:$1}_inst (${3:.*});
+snippet instp "Instantiate module with parameters"
+	${1:module_name} #(${2:parameters}) ${3:$1}_inst (${4:.*});
+snippet inv "Input vector"
+	input [${1:n}:${2:0}] ${3:input_name}_i
+snippet lpar "Local parameter"
+	localparam ${1:name} = ${0:value}
+snippet neg "Negative edge"
+	negedge ${0:signal}
+snippet out "Output"
+	output ${1:output_name}_o
+snippet outr "Output register"
+	output reg ${1:output_name}_o
+snippet outv "Output vector"
+	output [${1:n}:${2:0}] ${3:output_name}_o
+snippet outrv "Output register vector"
+	output reg [${1:n}:${2:0}] ${3:output_name}_o
+snippet par "Parameter definition"
+	parameter ${1:name} = ${0:value}
+snippet pos "Positive edge"
+	posedge ${0:signal}
+snippet r "Register variable"
+	reg ${1:reg_name};
+snippet rv "Register vector"
+	reg [${1:n}:${2:0}] ${3:reg_name};
+snippet rva "Register vector array"
+	reg [${1:n}:${2:0}] ${3:reg_name} [${4:0}:${5:m}];
+snippet v "Vector/array range"
+	[${1:n}:${2:0}]
+snippet w "Simple wire"
+	wire ${1:signal_name};
+snippet wv "Wire vector"
+	wire [${1:n}:${2:0}] ${3:signal_name};
 snippet if "if statement"
 	if (${1}) begin
 		${0:${VISUAL}}
@@ -47,8 +97,34 @@ snippet al "Always block"
 	always @(${1:/* sensitive list */}) begin
 		${2:${VISUAL}}
 	end
+snippet alc "Combinational always block"
+	always @* begin
+		${1:${VISUAL}}
+	end
+snippet alss "Sync sequential block"
+	always @(${1:posedge} ${2:clk}) begin
+		if (${3:rst}) begin
+			$4
+		end
+		else begin
+			$5
+		end
+	end
+snippet alsa "Async sequential block"
+	always @(${1:posedge} ${2:clk}, ${3:posedge} ${4:rst}) begin
+		if ($4) begin
+			$5
+		end
+		else begin
+			$6
+		end
+	end
 snippet mod "Module block"
 	module ${1:`vim_snippets#Filename('$1', 'name')`} (${2});
+		${0:${VISUAL}}
+	endmodule
+snippet modp "Module with parameters"
+	module ${1:`vim_snippets#Filename('$1', 'name')`} #(${2}) (${3});
 		${0:${VISUAL}}
 	endmodule
 snippet for "For"

--- a/snippets/verilog_systemverilog.snippets
+++ b/snippets/verilog_systemverilog.snippets
@@ -1,0 +1,1 @@
+extends systemverilog


### PR DESCRIPTION
This is a partial revival of #1522.

Addressing some of the remarks from the previous PR.
- I have undone the reorganization of the existing snippets.
- No snippets have been moved to the UltiSnips directory.

A brief description of changes made this time:
- I have added some VISUAL markers, wherever the snippet operated on an `begin-end` like block, i.e. it is supposed to work with multiple lines of code.
- I have moved the comments above the snippets into their respective description fields; fixed a few typos.
- I have moved 2 snippets from Verilog to SystemVerilog, as they are not compatible with the Verilog-2005 standard, i.e. the `typedef enum` and `typedef struct packed`.
- I have added a `verilog_systemverilog.snippets`, which extends SystemVerilog, to be used with [vhda/verilog_systemverilog.vim](https://github.com/vhda/verilog_systemverilog.vim).
- I have added quite a few of my snippets to the `verilog.snippets` file.

TODO.
I still would want to rearrange the snippets into an alphabetical order in future commits, it really makes the navigation easier. Without any consistent ordering one needs to rely on search functionalities and jump around a file a lot chaotically. Maybe some thematic + alphabetic pattern could also be established.