### PR TITLE
New JavaScript snippet: `for..of`

### DIFF
--- a/snippets/javascript/javascript.snippets
+++ b/snippets/javascript/javascript.snippets
@@ -123,6 +123,11 @@ snippet fori
 	for (let ${1:prop} in ${2:object}) {
 		${0:$2[$1]}
 	}
+# For of loop
+snippet foro
+	for (let ${1:element} of ${2:iterable}) {
+		${0:$2[$1]}
+	}
 # Objects
 # Object Method
 snippet :f


### PR DESCRIPTION
Similar to the `for..in` for objects, the `for..of` can be used with Iterable Objects such as `Array`, `Map`, and `Set`.
- [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)